### PR TITLE
refactor: streamline challenge ID handling in ChallengePage component

### DIFF
--- a/apps/web/src/app/(game)/challenge/[id]/page.tsx
+++ b/apps/web/src/app/(game)/challenge/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, use } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { WarmupPhase } from "@/components/game/warmup-phase";
@@ -16,10 +16,10 @@ interface PageProps {
 }
 
 export default function ChallengePage({ params }: PageProps) {
+  const { id: challengeId } = use(params);
   const { data: session } = useSession();
   const router = useRouter();
 
-  const [challengeId, setChallengeId] = useState<string>("");
   const [challenge, setChallenge] = useState<Challenge | null>(null);
   const [questions, setQuestions] = useState<ChallengeQuestion[]>([]);
   const [phase, setPhase] = useState<GamePhase>("loading");
@@ -27,12 +27,6 @@ export default function ChallengePage({ params }: PageProps) {
   const [challengeToken, setChallengeToken] = useState("");
   const [sessionId, setSessionId] = useState("");
   const [scores, setScores] = useState<number[]>([]);
-
-  useEffect(() => {
-    params.then(({ id }) => {
-      setChallengeId(id);
-    });
-  }, [params]);
 
   useEffect(() => {
     if (!challengeId) return;


### PR DESCRIPTION
Closes #3 

I have replaced the params.then() promise resolution in `apps/web/src/app/(game)/challenge/[id]/page.tsx` with React.use(params). This change ensures that the route parameters are resolved synchronously during the component's render phase (suspending if necessary), which eliminates the race condition previously caused by setting state within an effect.

  ## Summary of changes:
   - Added use to the React imports.
   - Replaced the challengeId state and its corresponding useEffect with const { id: challengeId } = use(params);.
   - Verified that challengeId is correctly inferred as a string and that all dependent logic (data fetching and navigation) remains correct and more deterministic.
   - Confirmed that Next.js will handle the suspension via the existing loading.tsx in the same directory.
   - Ran type-check to confirm that the modified file passes TypeScript validation.


   ```
1 // apps/web/src/app/(game)/challenge/[id]/page.tsx
   2
   3 export default function ChallengePage({ params }: PageProps) {
   4   const { id: challengeId } = use(params);
   5   // ... rest of the component
   6 }

```