### PR TITLE
test(phone): add unit tests for Twilio verification service with mock…

### DIFF
--- a/apps/api/src/services/phone.test.ts
+++ b/apps/api/src/services/phone.test.ts
@@ -1,0 +1,126 @@
+import twilio from "twilio";
+import {
+  sendVerificationCode,
+  checkVerificationCode,
+  requirePhoneVerified,
+} from "./phone";
+
+jest.mock("twilio", () => {
+  return jest.fn();
+});
+
+describe("Phone Service (Twilio Verification)", () => {
+  const mockCreateVerification = jest.fn();
+  const mockCreateCheck = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock Twilio client structure
+    (twilio as unknown as jest.Mock).mockImplementation(() => ({
+      verify: {
+        v2: {
+          services: () => ({
+            verifications: {
+              create: mockCreateVerification,
+            },
+            verificationChecks: {
+              create: mockCreateCheck,
+            },
+          }),
+        },
+      },
+    }));
+  });
+
+  // -------------------------
+  // sendVerificationCode
+  // -------------------------
+  describe("sendVerificationCode", () => {
+    it("calls Twilio verify API with correct params", async () => {
+      mockCreateVerification.mockResolvedValue({ sid: "123" });
+
+      await sendVerificationCode("+15551234567");
+
+      expect(mockCreateVerification).toHaveBeenCalledWith({
+        to: "+15551234567",
+        channel: "sms",
+      });
+    });
+
+    it("surfaces Twilio errors", async () => {
+      mockCreateVerification.mockRejectedValue(
+        new Error("Twilio error")
+      );
+
+      await expect(
+        sendVerificationCode("+15551234567")
+      ).rejects.toThrow("Twilio error");
+    });
+  });
+
+  // -------------------------
+  // checkVerificationCode
+  // -------------------------
+  describe("checkVerificationCode", () => {
+    it("returns true when status is approved", async () => {
+      mockCreateCheck.mockResolvedValue({ status: "approved" });
+
+      const result = await checkVerificationCode(
+        "+15551234567",
+        "123456"
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when status is pending", async () => {
+      mockCreateCheck.mockResolvedValue({ status: "pending" });
+
+      const result = await checkVerificationCode(
+        "+15551234567",
+        "123456"
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when status is invalid/canceled", async () => {
+      mockCreateCheck.mockResolvedValue({ status: "canceled" });
+
+      const result = await checkVerificationCode(
+        "+15551234567",
+        "123456"
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("surfaces Twilio errors", async () => {
+      mockCreateCheck.mockRejectedValue(
+        new Error("Verification failed")
+      );
+
+      await expect(
+        checkVerificationCode("+15551234567", "123456")
+      ).rejects.toThrow("Verification failed");
+    });
+  });
+
+  // -------------------------
+  // requirePhoneVerified
+  // -------------------------
+  describe("requirePhoneVerified", () => {
+    it("does nothing if phone is verified", async () => {
+      await expect(
+        requirePhoneVerified("user1", true)
+      ).resolves.toBeUndefined();
+    });
+
+    it("throws error if phone is not verified", async () => {
+      await expect(
+        requirePhoneVerified("user1", false)
+      ).rejects.toThrow("Phone verification required");
+    });
+  });
+});


### PR DESCRIPTION
Closes #20
## Summary

Adds comprehensive unit tests for the Twilio phone verification service. Mocks the Twilio client to test send and verification flows, ensuring correct behavior for approved, pending, invalid, and error scenarios without making external API calls.

---

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Smart contract change
* [ ] Documentation
* [ ] Breaking change
* [ ] Other (please describe)

---

## Checklist

* [x] Tests added or updated
* [x] No hardcoded secrets or private keys
* [ ] If contract change: `cargo test` passes
* [ ] If frontend change: `npm run typecheck` passes
* [x] If backend change: `npm test` passes
* [x] Related issues linked (Closes #20)
* [x] Self-review completed
* [x] Code follows project style guidelines

---

## Screenshots (if applicable)

N/A

---

## Testing

* Mocked Twilio client to avoid real API calls
* Verified `sendVerificationCode` calls Twilio with correct parameters
* Confirmed errors from Twilio are properly surfaced
* Tested `checkVerificationCode` for:

  * approved → returns true
  * pending → returns false
  * invalid/canceled → returns false
  * error → throws
* Tested `requirePhoneVerified`:

  * allows verified users
  * throws for unverified users

---

## Additional Notes

* Ensures deterministic and isolated unit tests using Jest mocks
* Improves confidence in phone verification flow which gates payouts
* Current implementation does not yet include rate limiting, phone normalization, or hashing — can be added in follow-up PR if required by broader spec

---
