### PR TITLE
fix: solved round timeout issue

### DIFF
--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -139,6 +139,33 @@ describe("Sessions API", () => {
       expect(sessionQueries.recordRoundScore).toHaveBeenCalledWith("s1", 1, 100);
     });
 
+    it("should accept timeout answer and score 0", async () => {
+      (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
+      (sessionQueries.getSession as any).mockResolvedValue({
+        id: "s1",
+        user_id: "user123",
+        challenge_started_at: new Date(),
+      });
+      (challengeQueries.getChallengeQuestions as any).mockResolvedValue([
+        { round: 1, correct_option: "A" },
+      ]);
+      (scoringService.calculateRoundScore as any).mockReturnValue(0);
+      (scoringService.validateAnswer as any).mockReturnValue(false);
+
+      const res = await request(app)
+        .post("/sessions/c1/answer/1")
+        .send({ selectedOption: null, reactionTimeMs: 15000 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.score).toBe(0);
+      expect(sessionQueries.recordRoundScore).toHaveBeenCalledWith("s1", 1, 0);
+      expect(scoringService.calculateRoundScore).toHaveBeenCalledWith({
+        selectedOption: null,
+        correctOption: "A",
+        reactionTimeMs: 15000,
+      });
+    });
+
     it("should finalize session on round 3", async () => {
       (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
       (sessionQueries.getSession as any).mockResolvedValue({

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -25,7 +25,7 @@ import { WARMUP_MIN_SECONDS } from "@brandblitz/stellar";
 const router = Router();
 
 const AnswerSchema = z.object({
-  selectedOption: z.enum(["A", "B", "C", "D"]),
+  selectedOption: z.enum(["A", "B", "C", "D"]).nullable(),
   reactionTimeMs: z.number().int().min(0),
 });
 

--- a/apps/api/src/services/scoring.test.ts
+++ b/apps/api/src/services/scoring.test.ts
@@ -52,6 +52,16 @@ describe("scoring service", () => {
         })
       ).toBe(0);
     });
+
+    it("returns 0 for timeout answer", () => {
+      expect(
+        calculateRoundScore({
+          selectedOption: null,
+          correctOption: "A",
+          reactionTimeMs: 15000,
+        })
+      ).toBe(0);
+    });
   });
 
   /**
@@ -70,6 +80,10 @@ describe("scoring service", () => {
 
     it("returns false for wrong answer", () => {
       expect(validateAnswer(question, "A")).toBe(false);
+    });
+
+    it("returns false for timeout answer", () => {
+      expect(validateAnswer(question, null)).toBe(false);
     });
 
     it("is case-sensitive", () => {

--- a/apps/api/src/services/scoring.ts
+++ b/apps/api/src/services/scoring.ts
@@ -13,7 +13,7 @@ const ROUND_DURATION_MS = 15_000;
  * Max per round: 150. Max total: 450.
  */
 export function calculateRoundScore(params: {
-  selectedOption: "A" | "B" | "C" | "D";
+  selectedOption: "A" | "B" | "C" | "D" | null;
   correctOption: "A" | "B" | "C" | "D";
   reactionTimeMs: number;
 }): number {
@@ -33,7 +33,7 @@ export function calculateRoundScore(params: {
  */
 export function validateAnswer(
   question: ChallengeQuestion,
-  selectedOption: "A" | "B" | "C" | "D"
+  selectedOption: "A" | "B" | "C" | "D" | null
 ): boolean {
   return question.correct_option === selectedOption;
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "CommonJS",
     "moduleResolution": "Node",
     "lib": ["ES2022"],
-    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "composite": true,

--- a/apps/web/src/app/(game)/challenge/[id]/page.tsx
+++ b/apps/web/src/app/(game)/challenge/[id]/page.tsx
@@ -60,7 +60,7 @@ export default function ChallengePage({ params }: PageProps) {
     setCurrentRound(1);
   };
 
-  const handleAnswer = async (option: "A" | "B" | "C" | "D", reactionTimeMs: number) => {
+  const handleAnswer = async (option: "A" | "B" | "C" | "D" | null, reactionTimeMs: number) => {
     const apiToken = (session as any)?.apiToken as string;
     const api = createApiClient(apiToken);
 

--- a/apps/web/src/components/game/challenge-round.test.tsx
+++ b/apps/web/src/components/game/challenge-round.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { ChallengeRound } from "./challenge-round";
+
+describe("ChallengeRound", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("submits null on timer expiry", () => {
+    const onAnswer = vi.fn();
+
+    render(
+      <ChallengeRound
+        question={{
+          id: "q1",
+          challenge_id: "c1",
+          round: 1,
+          question_type: "mcq",
+          prompt_type: "logo",
+          question_text: "Pick the correct brand",
+          option_a: "A option",
+          option_b: "B option",
+          option_c: "C option",
+          option_d: "D option",
+        }}
+        round={1}
+        onAnswer={onAnswer}
+      />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(15_100);
+    });
+
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+    expect(onAnswer).toHaveBeenCalledWith(null, 15_000);
+    expect(onAnswer).not.toHaveBeenCalledWith("A", expect.any(Number));
+  });
+});

--- a/apps/web/src/components/game/challenge-round.tsx
+++ b/apps/web/src/components/game/challenge-round.tsx
@@ -10,7 +10,7 @@ import type { ChallengeQuestion } from "@/lib/api";
 interface ChallengeRoundProps {
   question: ChallengeQuestion;
   round: 1 | 2 | 3;
-  onAnswer: (option: "A" | "B" | "C" | "D", reactionTimeMs: number) => void;
+  onAnswer: (option: "A" | "B" | "C" | "D" | null, reactionTimeMs: number) => void;
   brandLogoUrl?: string;
   brandProductImageUrl?: string;
 }
@@ -44,9 +44,9 @@ export function ChallengeRound({
 
   const handleTimeExpire = () => {
     if (!answered) {
-      // Submit null answer — server records 0 score
       const reactionTimeMs = ROUND_SECONDS * 1000;
-      onAnswer("A", reactionTimeMs); // forced answer on expire
+      setAnswered(true);
+      onAnswer(null, reactionTimeMs);
     }
   };
 

--- a/docs/03-stellar-architecture.md
+++ b/docs/03-stellar-architecture.md
@@ -1,0 +1,17 @@
+# 03 Stellar Architecture
+
+## Scoring
+
+Each challenge has 3 rounds, and each round is scored independently.
+
+- Correct answer score: base 100 points + speed bonus up to 50 points
+- Wrong answer score: 0 points
+- Timeout (no answer): submitted as selectedOption = null and scored as 0 points
+
+Timeout behavior is explicit in both frontend and backend contracts:
+
+- The client submits null when the round timer expires without a click.
+- The API accepts selectedOption as one of A/B/C/D or null.
+- Null is treated as no-answer and never as an implicit letter choice.
+
+This prevents accidental scoring from silent defaults and preserves fair outcomes across players.

--- a/tests/e2e/round-timeout.spec.ts
+++ b/tests/e2e/round-timeout.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+test("round 1 timeout submits no-answer and yields 0 points", async ({ page }) => {
+  await page.goto("/challenge/test-challenge-id");
+
+  const roundOneAnswerResponse = page.waitForResponse((response) => {
+    return response.url().includes("/sessions/test-challenge-id/answer/1") && response.request().method() === "POST";
+  });
+
+  // Let round 1 expire naturally without clicking any option.
+  await page.waitForTimeout(16_000);
+
+  const response = await roundOneAnswerResponse;
+  const requestBody = response.request().postDataJSON() as {
+    selectedOption: "A" | "B" | "C" | "D" | null;
+    reactionTimeMs: number;
+  };
+  const payload = (await response.json()) as { score: number; round: number };
+
+  expect(requestBody.selectedOption).toBeNull();
+  expect(payload.round).toBe(1);
+  expect(payload.score).toBe(0);
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleDetection": "force",
-    "verbatimModuleSyntax": false,
-    "ignoreDeprecations": "6.0"
+    "verbatimModuleSyntax": false
   }
 }


### PR DESCRIPTION
closes #153

This pull request implements explicit support for round timeouts in the challenge game flow, ensuring that when a player does not answer within the allotted time, a `null` answer is submitted and scored as zero. The changes span both frontend and backend to handle this scenario clearly and consistently, with new and updated tests to verify the behavior. 