### PR TITLE
fixes

### DIFF
--- a/apps/api/src/db/queries/sessions.ts
+++ b/apps/api/src/db/queries/sessions.ts
@@ -173,3 +173,42 @@ export async function getLeaderboard(
   );
   return result.rows;
 }
+
+export async function getTopSessionsPerChallenge(
+  challengeIds: string[],
+  limitPerChallenge = 10
+): Promise<LeaderboardSession[]> {
+  if (challengeIds.length === 0) return [];
+
+  const result = await query<LeaderboardSession>(
+    `SELECT sub.id, sub.user_id, sub.challenge_id, sub.device_id,
+            sub.warmup_started_at, sub.warmup_completed_at,
+            sub.challenge_started_at, sub.challenge_ended_at,
+            sub.round_1_score, sub.round_2_score, sub.round_3_score,
+            sub.total_score, sub.flagged, sub.flag_reasons,
+            sub.is_practice, sub.created_at,
+            sub.username, sub.avatar_url, sub.stellar_address
+     FROM (
+       SELECT gs.*,
+              u.email        AS username,
+              u.avatar_url,
+              COALESCE(
+                NULLIF(to_jsonb(u) ->> 'embedded_wallet_address', ''),
+                NULLIF(to_jsonb(u) ->> 'stellar_address', '')
+              ) AS stellar_address,
+              ROW_NUMBER() OVER (
+                PARTITION BY gs.challenge_id
+                ORDER BY gs.total_score DESC, gs.challenge_ended_at ASC
+              ) AS rn
+       FROM game_sessions gs
+       JOIN users u ON gs.user_id = u.id
+       WHERE gs.challenge_id = ANY($1::uuid[])
+         AND gs.flagged = FALSE
+         AND gs.is_practice = FALSE
+     ) sub
+     WHERE sub.rn <= $2
+     ORDER BY sub.challenge_id, sub.total_score DESC, sub.challenge_ended_at ASC`,
+    [challengeIds, limitPerChallenge]
+  );
+  return result.rows;
+}

--- a/apps/api/src/middleware/rate-limit.test.ts
+++ b/apps/api/src/middleware/rate-limit.test.ts
@@ -1,0 +1,273 @@
+import express from "express";
+import rateLimit from "express-rate-limit";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  apiLimiter,
+  authLimiter,
+  challengeStartLimiter,
+  uploadLimiter,
+} from "./rate-limit";
+
+// ─── Mock heavy dependencies so the module can be imported in tests ───────────
+
+vi.mock("../lib/redis", () => ({
+  redis: {
+    call: vi.fn(),
+    on: vi.fn(),
+    connect: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// Unique key counter — prevents state bleed between tests.
+let keySeq = 0;
+const nextIp = () =>
+  `10.${Math.floor(keySeq / 65025)}.${Math.floor((keySeq % 65025) / 255)}.${(keySeq++ % 255) + 1}`;
+const nextUser = () => `test-user-${keySeq++}`;
+
+type Limiter = ReturnType<typeof rateLimit>;
+
+/** Creates a minimal Express app protected by the given limiter. */
+function makeApp(limiter: Limiter, userSub?: string) {
+  const app = express();
+  app.set("trust proxy", true);
+  if (userSub) {
+    app.use((_req, _res, next) => {
+      (_req as any).user = { sub: userSub };
+      next();
+    });
+  }
+  app.use(limiter);
+  app.get("/", (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+/** Fires `n` requests from `ip`, all expected to succeed (200). */
+async function exhaust(app: express.Express, ip: string, n: number) {
+  for (let i = 0; i < n; i++) {
+    const res = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(res.status, `request ${i + 1}/${n} should be 200`).toBe(200);
+  }
+}
+
+// ─── Per-policy boundary tests ─────────────────────────────────────────────────
+
+describe("apiLimiter — 100 req / 15 min", () => {
+  let ip: string;
+
+  beforeEach(() => { ip = nextIp(); });
+
+  it("allows exactly 100 requests and blocks the 101st with 429", async () => {
+    const app = makeApp(apiLimiter);
+    await exhaust(app, ip, 100);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.status).toBe(429);
+  });
+
+  it("sets Retry-After on the rate-limited response", async () => {
+    const app = makeApp(apiLimiter);
+    await exhaust(app, ip, 100);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.headers["retry-after"]).toBeDefined();
+  });
+});
+
+describe("authLimiter — 10 req / 15 min", () => {
+  let ip: string;
+
+  beforeEach(() => { ip = nextIp(); });
+
+  it("allows exactly 10 requests and blocks the 11th with 429", async () => {
+    const app = makeApp(authLimiter);
+    await exhaust(app, ip, 10);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.status).toBe(429);
+  });
+
+  it("sets Retry-After on the rate-limited response", async () => {
+    const app = makeApp(authLimiter);
+    await exhaust(app, ip, 10);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.headers["retry-after"]).toBeDefined();
+  });
+
+  it("returns the custom error message", async () => {
+    const app = makeApp(authLimiter);
+    await exhaust(app, ip, 10);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.body.error).toMatch(/login attempts/i);
+  });
+});
+
+describe("challengeStartLimiter — 5 req / 1 h", () => {
+  let ip: string;
+
+  beforeEach(() => { ip = nextIp(); });
+
+  it("allows exactly 5 requests and blocks the 6th with 429", async () => {
+    const app = makeApp(challengeStartLimiter);
+    await exhaust(app, ip, 5);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.status).toBe(429);
+  });
+
+  it("sets Retry-After on the rate-limited response", async () => {
+    const app = makeApp(challengeStartLimiter);
+    await exhaust(app, ip, 5);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.headers["retry-after"]).toBeDefined();
+  });
+});
+
+describe("uploadLimiter — 20 req / 1 h", () => {
+  let ip: string;
+
+  beforeEach(() => { ip = nextIp(); });
+
+  it("allows exactly 20 requests and blocks the 21st with 429", async () => {
+    const app = makeApp(uploadLimiter);
+    await exhaust(app, ip, 20);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.status).toBe(429);
+  });
+
+  it("sets Retry-After on the rate-limited response", async () => {
+    const app = makeApp(uploadLimiter);
+    await exhaust(app, ip, 20);
+    const over = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(over.headers["retry-after"]).toBeDefined();
+  });
+});
+
+// ─── Key derivation ────────────────────────────────────────────────────────────
+
+describe("key derivation", () => {
+  it("unauthenticated requests from the same IP share a bucket", async () => {
+    const ip = nextIp();
+    const app = makeApp(challengeStartLimiter); // max=5, easy to exhaust
+    await exhaust(app, ip, 5);
+
+    // Second request — same IP, still unauthenticated — should be blocked
+    const blocked = await request(app).get("/").set("X-Forwarded-For", ip);
+    expect(blocked.status).toBe(429);
+  });
+
+  it("authenticated requests for the same user ID share a bucket regardless of IP", async () => {
+    const userId = nextUser();
+    const app = makeApp(challengeStartLimiter, userId); // attaches user.sub
+    const ip1 = nextIp();
+    const ip2 = nextIp();
+
+    // Exhaust using ip1
+    await exhaust(app, ip1, 5);
+
+    // Different IP, same user — should still be rate-limited
+    const blocked = await request(app).get("/").set("X-Forwarded-For", ip2);
+    expect(blocked.status).toBe(429);
+  });
+
+  it("two different authenticated users get independent buckets", async () => {
+    const user1 = nextUser();
+    const user2 = nextUser();
+    const ip = nextIp();
+
+    const app1 = makeApp(challengeStartLimiter, user1);
+    const app2 = makeApp(challengeStartLimiter, user2);
+
+    await exhaust(app1, ip, 5);
+
+    // user1 is rate-limited…
+    expect((await request(app1).get("/").set("X-Forwarded-For", ip)).status).toBe(429);
+
+    // …but user2 is unaffected — first request returns 200
+    expect((await request(app2).get("/").set("X-Forwarded-For", ip)).status).toBe(200);
+  });
+});
+
+// ─── Window reset ──────────────────────────────────────────────────────────────
+
+describe("window reset", () => {
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("counter resets after the window expires and allows requests again", async () => {
+    vi.useFakeTimers();
+
+    // Use a fresh short-window limiter to avoid state sharing with other tests
+    const shortLimiter = rateLimit({
+      windowMs: 500,
+      max: 3,
+      standardHeaders: "draft-7",
+      legacyHeaders: false,
+    });
+    const ip = nextIp();
+    const app = makeApp(shortLimiter);
+
+    await exhaust(app, ip, 3);
+    expect((await request(app).get("/").set("X-Forwarded-For", ip)).status).toBe(429);
+
+    // Advance past the window
+    vi.advanceTimersByTime(600);
+
+    // Counter should be reset — first request in the new window is 200
+    expect((await request(app).get("/").set("X-Forwarded-For", ip)).status).toBe(200);
+  });
+});
+
+// ─── Redis down → fail open ────────────────────────────────────────────────────
+
+describe("Redis store error — fail open", () => {
+  it("passes the request through (200) when the store throws", async () => {
+    const failingStore = {
+      increment: vi.fn().mockRejectedValue(new Error("redis unavailable")),
+      decrement: vi.fn(),
+      resetKey: vi.fn(),
+    };
+
+    const failOpenLimiter = rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 10,
+      standardHeaders: "draft-7",
+      legacyHeaders: false,
+      store: failingStore as any,
+      passOnStoreError: true,
+    });
+
+    const app = makeApp(failOpenLimiter);
+    const res = await request(app).get("/").set("X-Forwarded-For", nextIp());
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks with 500 (not silently) when passOnStoreError is false", async () => {
+    const failingStore = {
+      increment: vi.fn().mockRejectedValue(new Error("redis unavailable")),
+      decrement: vi.fn(),
+      resetKey: vi.fn(),
+    };
+
+    const failClosedLimiter = rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 10,
+      standardHeaders: "draft-7",
+      legacyHeaders: false,
+      store: failingStore as any,
+      passOnStoreError: false,
+    });
+
+    const app = express();
+    app.use(failClosedLimiter);
+    app.get("/", (_req, res) => res.json({ ok: true }));
+    // Add a minimal error handler so the test app returns a response
+    app.use((_err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      res.status(500).json({ error: "store error" });
+    });
+
+    const res = await request(app).get("/");
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,61 +1,87 @@
+import type { Request } from "express";
 import rateLimit from "express-rate-limit";
 import { RedisStore } from "rate-limit-redis";
 import { redis } from "../lib/redis";
+import { logger } from "../lib/logger";
 
-const redisStore = process.env.NODE_ENV === "test" ? undefined : new RedisStore({
-  sendCommand: (...args: string[]) => {
-    const command = typeof redis.call === "function" ? redis.call : (redis as any).sendCommand;
-    if (!command) {
-      throw new TypeError("Redis client does not support call/sendCommand");
-    }
-    return command.apply(redis as any, args) as any;
-  },
-});
+// Use authenticated user ID as the rate-limit key when available; fall back to IP.
+// This gives each authenticated user their own bucket independent of shared IPs.
+function userAwareKey(req: Request): string {
+  return req.user?.sub ?? req.ip ?? "anonymous";
+}
 
-// General API rate limit: 100 req/15 min per IP
+function makeRedisStore() {
+  return new RedisStore({
+    sendCommand: async (...args: string[]) => {
+      const command = typeof (redis as any).call === "function"
+        ? (redis as any).call
+        : (redis as any).sendCommand;
+      if (!command) throw new TypeError("Redis client does not support call/sendCommand");
+      try {
+        return await command.apply(redis, args);
+      } catch (err) {
+        logger.warn("Rate-limit: Redis store error; failing open", {
+          error: (err as Error).message,
+        });
+        throw err;
+      }
+    },
+  });
+}
+
+const redisStore = process.env.NODE_ENV === "test" ? undefined : makeRedisStore();
+
+// General API rate limit: 100 req/15 min per key
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 100,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  keyGenerator: userAwareKey,
+  passOnStoreError: true,
   store: redisStore,
 });
 
-// Auth endpoints: 10 req/15 min per IP
+// Auth endpoints: 10 req/15 min per IP (always IP — pre-authentication)
 export const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 10,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  passOnStoreError: true,
   store: redisStore,
   message: { error: "Too many login attempts, please try again later" },
 });
 
-// Challenge start: 5 req/hour per IP
+// Challenge start: 5 req/hour per key
 export const challengeStartLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 5,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  keyGenerator: userAwareKey,
+  passOnStoreError: true,
   store: redisStore,
   message: { error: "Too many challenge attempts" },
 });
 
-// Upload presign: 20 req/hour per IP
+// Upload presign: 20 req/hour per key
 export const uploadLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 20,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  keyGenerator: userAwareKey,
+  passOnStoreError: true,
   store: redisStore,
 });
 
-// Webhook endpoints: 1000 req/hour (higher limit as it is internal-to-internal)
+// Webhook endpoints: 1000 req/hour (internal-to-internal, always uses Redis)
 export const webhookLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 1000,
   standardHeaders: "draft-7",
   legacyHeaders: false,
-  store: new RedisStore({ sendCommand: (...args: string[]) => redis.call(...args) as any }),
+  store: new RedisStore({ sendCommand: (...args: string[]) => (redis as any).call(...args) }),
 });
 

--- a/apps/api/src/routes/leaderboard.test.ts
+++ b/apps/api/src/routes/leaderboard.test.ts
@@ -1,99 +1,180 @@
+import express from "express";
 import request from "supertest";
-import { createApp } from "../../app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import leaderboardRouter from "./leaderboard";
 
-// Mock leaderboard service (adjust path if different in your project)
-let dbCallCount = 0;
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
 
-const mockLeaderboard = [
-  { userId: "1", score: 100, flagged: false },
-  { userId: "2", score: 90, flagged: false },
-  { userId: "3", score: 80, flagged: false },
-  { userId: "4", score: 70, flagged: true }, // should be excluded
-];
-
-jest.mock("../../services/leaderboard-service", () => ({
-  getGlobalLeaderboard: jest.fn(() => {
-    dbCallCount++;
-    return Promise.resolve(mockLeaderboard);
-  }),
-  getChallengeLeaderboard: jest.fn(() => {
-    dbCallCount++;
-    return Promise.resolve(mockLeaderboard);
-  }),
+const mocks = vi.hoisted(() => ({
+  getActiveChallenges: vi.fn(),
+  getTopSessionsPerChallenge: vi.fn(),
+  getLeaderboard: vi.fn(),
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+  dbQueryCount: { value: 0 },
 }));
 
-describe("Leaderboard Routes (Integration)", () => {
-  let app: any;
+vi.mock("../db/queries/challenges", () => ({
+  getActiveChallenges: mocks.getActiveChallenges,
+}));
 
-  beforeAll(async () => {
-    // You may need to pass a mock datasource depending on your createApp signature
-    app = createApp({} as any, {} as any);
-  });
+vi.mock("../db/queries/sessions", () => ({
+  getLeaderboard: mocks.getLeaderboard,
+  getTopSessionsPerChallenge: (...args: unknown[]) => {
+    mocks.dbQueryCount.value++;
+    return mocks.getTopSessionsPerChallenge(...args);
+  },
+}));
 
+vi.mock("../lib/redis", () => ({
+  redis: {
+    get: mocks.redisGet,
+    set: mocks.redisSet,
+  },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/leaderboard", leaderboardRouter);
+  return app;
+}
+
+const CHALLENGES = [{ id: "challenge-aaa" }, { id: "challenge-bbb" }];
+
+const TOP_SESSIONS = [
+  {
+    id: "s1", user_id: "u1", challenge_id: "challenge-aaa",
+    username: "alice", avatar_url: null, total_score: 300, challenge_ended_at: "2026-01-01T01:00:00Z",
+  },
+  {
+    id: "s2", user_id: "u2", challenge_id: "challenge-aaa",
+    username: "bob", avatar_url: null, total_score: 200, challenge_ended_at: "2026-01-01T02:00:00Z",
+  },
+  {
+    id: "s3", user_id: "u3", challenge_id: "challenge-bbb",
+    username: "carol", avatar_url: "https://cdn.example.com/carol.png", total_score: 400, challenge_ended_at: "2026-01-01T03:00:00Z",
+  },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /leaderboard/global", () => {
   beforeEach(() => {
-    dbCallCount = 0;
-    jest.clearAllMocks();
+    vi.clearAllMocks();
+    mocks.dbQueryCount.value = 0;
+    mocks.redisGet.mockResolvedValue(null);
+    mocks.redisSet.mockResolvedValue("OK");
+    mocks.getActiveChallenges.mockResolvedValue(CHALLENGES);
+    mocks.getTopSessionsPerChallenge.mockResolvedValue(TOP_SESSIONS);
   });
 
-  // -------------------------
-  // GLOBAL LEADERBOARD
-  // -------------------------
-  describe("GET /leaderboard", () => {
-    it("returns top 10 sorted leaderboard", async () => {
-      const res = await request(app).get("/leaderboard");
-
-      expect(res.status).toBe(200);
-
-      const data = res.body.data;
-
-      expect(data.length).toBeLessThanOrEqual(10);
-
-      const scores = data.map((u: any) => u.score);
-      expect(scores).toEqual([...scores].sort((a, b) => b - a));
-    });
-
-    it("excludes flagged sessions", async () => {
-      const res = await request(app).get("/leaderboard");
-
-      const flagged = res.body.data.find((u: any) => u.flagged);
-      expect(flagged).toBeUndefined();
-    });
+  it("returns 200 with a leaderboard array", async () => {
+    const res = await request(createApp()).get("/leaderboard/global");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.leaderboard)).toBe(true);
   });
 
-  // -------------------------
-  // PER CHALLENGE
-  // -------------------------
-  describe("GET /leaderboard/:challengeId", () => {
-    it("respects offset and limit", async () => {
-      const res = await request(app)
-        .get("/leaderboard/challenge-1")
-        .query({ limit: 2, offset: 1 });
-
-      expect(res.status).toBe(200);
-      expect(res.body.data.length).toBe(2);
-    });
+  it("issues exactly one DB query — not N+1", async () => {
+    await request(createApp()).get("/leaderboard/global");
+    expect(mocks.dbQueryCount.value).toBe(1);
+    expect(mocks.getLeaderboard).not.toHaveBeenCalled();
   });
 
-  // -------------------------
-  // CACHE TESTS
-  // -------------------------
-  describe("Caching behavior", () => {
-    it("does not hit DB on second call within TTL", async () => {
-      await request(app).get("/leaderboard");
-      await request(app).get("/leaderboard");
+  it("calls getTopSessionsPerChallenge with all challenge IDs", async () => {
+    await request(createApp()).get("/leaderboard/global");
+    expect(mocks.getTopSessionsPerChallenge).toHaveBeenCalledWith(
+      ["challenge-aaa", "challenge-bbb"],
+      10
+    );
+  });
 
-      expect(dbCallCount).toBe(1);
-    });
+  it("assigns sequential rank per challenge, restarting at 1 for each", async () => {
+    const res = await request(createApp()).get("/leaderboard/global");
+    const lb = res.body.leaderboard as Array<{ challengeId: string; rank: number }>;
 
-    it("refreshes after TTL expires", async () => {
-      await request(app).get("/leaderboard");
+    const aaa = lb.filter((e) => e.challengeId === "challenge-aaa");
+    const bbb = lb.filter((e) => e.challengeId === "challenge-bbb");
 
-      // simulate TTL expiry (adjust if your TTL differs)
-      await new Promise((r) => setTimeout(r, 1100));
+    expect(aaa.map((e) => e.rank)).toEqual([1, 2]);
+    expect(bbb.map((e) => e.rank)).toEqual([1]);
+  });
 
-      await request(app).get("/leaderboard");
+  it("orders sessions by descending score within each challenge", async () => {
+    const res = await request(createApp()).get("/leaderboard/global");
+    const aaaScores = (res.body.leaderboard as Array<{ challengeId: string; totalScore: number }>)
+      .filter((e) => e.challengeId === "challenge-aaa")
+      .map((e) => e.totalScore);
+    expect(aaaScores).toEqual([300, 200]);
+  });
 
-      expect(dbCallCount).toBe(2);
-    });
+  it("includes cachedAt ISO timestamp in the response", async () => {
+    const res = await request(createApp()).get("/leaderboard/global");
+    expect(typeof res.body.cachedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(res.body.cachedAt))).toBe(false);
+  });
+
+  it("writes the result to Redis with a 300 s TTL", async () => {
+    await request(createApp()).get("/leaderboard/global");
+    expect(mocks.redisSet).toHaveBeenCalledWith(
+      "leaderboard:global",
+      expect.any(String),
+      "EX",
+      300
+    );
+  });
+
+  it("returns the cached payload without hitting the DB on a cache hit", async () => {
+    const cachedPayload = {
+      leaderboard: [{ rank: 1, challengeId: "challenge-aaa", username: "cached", avatarUrl: null, totalScore: 999 }],
+      cachedAt: "2026-01-01T00:00:00.000Z",
+    };
+    mocks.redisGet.mockResolvedValue(JSON.stringify(cachedPayload));
+
+    const res = await request(createApp()).get("/leaderboard/global");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(cachedPayload);
+    expect(mocks.dbQueryCount.value).toBe(0);
+  });
+
+  it("handles an empty active-challenges list gracefully", async () => {
+    mocks.getActiveChallenges.mockResolvedValue([]);
+    mocks.getTopSessionsPerChallenge.mockResolvedValue([]);
+
+    const res = await request(createApp()).get("/leaderboard/global");
+
+    expect(res.status).toBe(200);
+    expect(res.body.leaderboard).toEqual([]);
+  });
+});
+
+describe("GET /leaderboard/:challengeId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getLeaderboard.mockResolvedValue([
+      { id: "s1", user_id: "u1", challenge_id: "c1", username: "alice", avatar_url: null, total_score: 500 },
+      { id: "s2", user_id: "u2", challenge_id: "c1", username: "bob",   avatar_url: null, total_score: 400 },
+    ]);
+  });
+
+  it("returns sessions with rank starting at offset+1", async () => {
+    const res = await request(createApp())
+      .get("/leaderboard/c1")
+      .query({ offset: 5 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.sessions[0].rank).toBe(6);
+    expect(res.body.sessions[1].rank).toBe(7);
+  });
+
+  it("passes limit and offset to getLeaderboard", async () => {
+    await request(createApp())
+      .get("/leaderboard/c1")
+      .query({ limit: 5, offset: 10 });
+
+    expect(mocks.getLeaderboard).toHaveBeenCalledWith("c1", 5, 10);
   });
 });

--- a/apps/api/src/routes/leaderboard.ts
+++ b/apps/api/src/routes/leaderboard.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import { getActiveChallenges } from "../db/queries/challenges";
-import { getLeaderboard } from "../db/queries/sessions";
+import { getLeaderboard, getTopSessionsPerChallenge } from "../db/queries/sessions";
 import { redis } from "../lib/redis";
 
 const router = Router();
@@ -9,6 +9,7 @@ const router = Router();
 /**
  * GET /leaderboard/global
  * Cross-challenge leaderboard (cached in Redis, 5 min TTL).
+ * Single aggregated query via ROW_NUMBER() — no N+1.
  */
 router.get("/global", async (_req, res) => {
   const cacheKey = "leaderboard:global";
@@ -20,18 +21,21 @@ router.get("/global", async (_req, res) => {
   }
 
   const challenges = await getActiveChallenges(10);
-  const allSessions: unknown[] = [];
+  const challengeIds = challenges.map((c) => c.id);
+  const topSessions = await getTopSessionsPerChallenge(challengeIds, 10);
 
-  for (const challenge of challenges) {
-    const sessions = await getLeaderboard(challenge.id, 10);
-    allSessions.push(...sessions.map((s, i) => ({
-      rank: i + 1,
-      challengeId: challenge.id,
+  const rankPerChallenge = new Map<string, number>();
+  const allSessions = topSessions.map((s) => {
+    const rank = (rankPerChallenge.get(s.challenge_id) ?? 0) + 1;
+    rankPerChallenge.set(s.challenge_id, rank);
+    return {
+      rank,
+      challengeId: s.challenge_id,
       username: s.username,
       avatarUrl: s.avatar_url,
       totalScore: s.total_score,
-    })));
-  }
+    };
+  });
 
   const response = { leaderboard: allSessions, cachedAt: new Date().toISOString() };
   await redis.set(cacheKey, JSON.stringify(response), "EX", 300);

--- a/apps/web/src/components/brand/upload-field.test.tsx
+++ b/apps/web/src/components/brand/upload-field.test.tsx
@@ -1,0 +1,318 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UploadField } from "./upload-field";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  post: vi.fn(),
+  fetchImpl: vi.fn(),
+  onUploaded: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  createApiClient: () => ({ post: mocks.post }),
+}));
+
+vi.stubGlobal("fetch", mocks.fetchImpl);
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeFile(name: string, type: string, sizeBytes: number) {
+  return new File([new Uint8Array(sizeBytes)], name, { type });
+}
+
+function defaultPresignResolve() {
+  mocks.post.mockImplementation(async (url: string) => {
+    if (url === "/upload/presign") {
+      return {
+        data: {
+          presignedUrl: "https://s3.example.com/presigned-url",
+          key: "uploads/test-key.png",
+          publicUrl: "https://cdn.example.com/uploads/test-key.png",
+        },
+      };
+    }
+    if (url === "/upload/verify") {
+      return { data: { ok: true } };
+    }
+    throw new Error(`Unexpected POST to ${url}`);
+  });
+  mocks.fetchImpl.mockResolvedValue({ ok: true, status: 200 });
+}
+
+function getFileInput() {
+  return document.querySelector('input[type="file"]') as HTMLInputElement;
+}
+
+function uploadFile(file: File) {
+  fireEvent.change(getFileInput(), { target: { files: [file] } });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("UploadField", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.onUploaded.mockReset();
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────────
+
+  it("happy path: presign → PUT to presigned URL → verify → onUploaded fires", async () => {
+    defaultPresignResolve();
+
+    render(
+      <UploadField
+        label="Brand Logo"
+        accept="image/*"
+        uploadType="brand-logo"
+        apiToken="tok-test"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("logo.png", "image/png", 512));
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith("/upload/presign", {
+        filename: "logo.png",
+        contentType: "image/png",
+        uploadType: "brand-logo",
+      });
+    });
+
+    await waitFor(() => {
+      expect(mocks.fetchImpl).toHaveBeenCalledWith(
+        "https://s3.example.com/presigned-url",
+        expect.objectContaining({ method: "PUT", body: expect.any(File) })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith("/upload/verify", {
+        key: "uploads/test-key.png",
+      });
+    });
+
+    await waitFor(() => {
+      expect(mocks.onUploaded).toHaveBeenCalledWith(
+        "uploads/test-key.png",
+        "https://cdn.example.com/uploads/test-key.png"
+      );
+    });
+  });
+
+  it("shows the uploaded image preview after a successful upload", async () => {
+    defaultPresignResolve();
+
+    render(
+      <UploadField
+        label="Brand Logo"
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("logo.png", "image/png", 512));
+
+    await waitFor(() => {
+      expect(screen.getByText(/uploaded/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── MIME validation ───────────────────────────────────────────────────────────
+
+  it("disallowed MIME → shows inline error without making any network calls", async () => {
+    render(
+      <UploadField
+        label="Logo"
+        accept="image/png,image/jpeg"
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("clip.mp4", "video/mp4", 512));
+
+    await waitFor(() => {
+      expect(screen.getByText(/not allowed/i)).toBeInTheDocument();
+    });
+
+    expect(mocks.post).not.toHaveBeenCalled();
+    expect(mocks.fetchImpl).not.toHaveBeenCalled();
+    expect(mocks.onUploaded).not.toHaveBeenCalled();
+  });
+
+  it("accepts any image/* mime type when accept defaults to image/*", async () => {
+    defaultPresignResolve();
+
+    render(
+      <UploadField
+        label="Logo"
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("logo.webp", "image/webp", 512));
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith("/upload/presign", expect.anything());
+    });
+
+    expect(screen.queryByText(/not allowed/i)).not.toBeInTheDocument();
+  });
+
+  // ── Size validation ───────────────────────────────────────────────────────────
+
+  it("oversize file → shows inline error without making any network calls", async () => {
+    render(
+      <UploadField
+        label="Logo"
+        accept="image/*"
+        maxSizeBytes={100}
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("big.png", "image/png", 200)); // 200 B > 100 B limit
+
+    await waitFor(() => {
+      expect(screen.getByText(/too large/i)).toBeInTheDocument();
+    });
+
+    expect(mocks.post).not.toHaveBeenCalled();
+    expect(mocks.fetchImpl).not.toHaveBeenCalled();
+    expect(mocks.onUploaded).not.toHaveBeenCalled();
+  });
+
+  it("file at exactly maxSizeBytes is allowed", async () => {
+    defaultPresignResolve();
+
+    render(
+      <UploadField
+        label="Logo"
+        accept="image/*"
+        maxSizeBytes={512}
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("exact.png", "image/png", 512)); // exactly at limit
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith("/upload/presign", expect.anything());
+    });
+
+    expect(screen.queryByText(/too large/i)).not.toBeInTheDocument();
+  });
+
+  // ── PUT failure + retry ───────────────────────────────────────────────────────
+
+  it("PUT failure → shows error with Retry button", async () => {
+    mocks.post.mockImplementation(async (url: string) => {
+      if (url === "/upload/presign") {
+        return {
+          data: {
+            presignedUrl: "https://s3.example.com/presigned-url",
+            key: "uploads/test-key.png",
+            publicUrl: "https://cdn.example.com/uploads/test-key.png",
+          },
+        };
+      }
+      throw new Error(`Unexpected POST to ${url}`);
+    });
+    mocks.fetchImpl.mockResolvedValue({ ok: false, status: 500 });
+
+    render(
+      <UploadField
+        label="Logo"
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("logo.png", "image/png", 512));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    });
+
+    expect(mocks.onUploaded).not.toHaveBeenCalled();
+  });
+
+  it("Retry button re-attempts the full upload and fires onUploaded on success", async () => {
+    // First PUT fails, subsequent ones succeed
+    mocks.post.mockImplementation(async (url: string) => {
+      if (url === "/upload/presign") {
+        return {
+          data: {
+            presignedUrl: "https://s3.example.com/presigned-url",
+            key: "uploads/test-key.png",
+            publicUrl: "https://cdn.example.com/uploads/test-key.png",
+          },
+        };
+      }
+      if (url === "/upload/verify") {
+        return { data: { ok: true } };
+      }
+      throw new Error(`Unexpected POST to ${url}`);
+    });
+    mocks.fetchImpl
+      .mockResolvedValueOnce({ ok: false, status: 500 }) // first PUT fails
+      .mockResolvedValue({ ok: true, status: 200 });     // retry succeeds
+
+    render(
+      <UploadField
+        label="Logo"
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("logo.png", "image/png", 512));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(mocks.onUploaded).toHaveBeenCalledWith(
+        "uploads/test-key.png",
+        "https://cdn.example.com/uploads/test-key.png"
+      );
+    });
+  });
+
+  it("MIME error does not show a Retry button (no file to retry with)", async () => {
+    render(
+      <UploadField
+        label="Logo"
+        accept="image/png"
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    uploadFile(makeFile("video.mp4", "video/mp4", 512));
+
+    await waitFor(() => {
+      expect(screen.getByText(/not allowed/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/brand/upload-field.tsx
+++ b/apps/web/src/components/brand/upload-field.tsx
@@ -8,15 +8,29 @@ import { cn } from "@/lib/utils";
 interface UploadFieldProps {
   label: string;
   accept?: string;
+  maxSizeBytes?: number;
   uploadType: "brand-logo" | "product-image" | "user-avatar";
   apiToken: string;
   onUploaded: (key: string, publicUrl: string) => void;
   className?: string;
 }
 
+/** Returns true if mimeType is covered by the `accept` attribute value. */
+function isAcceptedMime(mimeType: string, accept: string): boolean {
+  return accept
+    .split(",")
+    .map((a) => a.trim())
+    .some((a) => {
+      if (a === "*" || a === "*/*") return true;
+      if (a.endsWith("/*")) return mimeType.startsWith(a.slice(0, -1));
+      return mimeType === a;
+    });
+}
+
 export function UploadField({
   label,
   accept = "image/*",
+  maxSizeBytes,
   uploadType,
   apiToken,
   onUploaded,
@@ -26,10 +40,28 @@ export function UploadField({
   const [uploading, setUploading] = useState(false);
   const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
 
   const handleFile = async (file: File) => {
-    setUploading(true);
     setError(null);
+
+    // MIME validation — no network calls on failure
+    if (!isAcceptedMime(file.type, accept)) {
+      setError(`File type "${file.type}" is not allowed.`);
+      setPendingFile(null);
+      return;
+    }
+
+    // Size validation — no network calls on failure
+    if (maxSizeBytes !== undefined && file.size > maxSizeBytes) {
+      const maxMB = (maxSizeBytes / 1024 / 1024).toFixed(1);
+      setError(`File is too large. Maximum size is ${maxMB} MB.`);
+      setPendingFile(null);
+      return;
+    }
+
+    setUploading(true);
+    setPendingFile(file);
 
     try {
       const api = createApiClient(apiToken);
@@ -44,15 +76,20 @@ export function UploadField({
       const { presignedUrl, key, publicUrl } = presignRes.data;
 
       // 2. Upload directly to S3/MinIO
-      await fetch(presignedUrl, {
+      const putRes = await fetch(presignedUrl, {
         method: "PUT",
         body: file,
         headers: { "Content-Type": file.type },
       });
 
+      if (!putRes.ok) {
+        throw new Error(`PUT failed with status ${putRes.status}`);
+      }
+
       // 3. Verify upload
       await api.post("/upload/verify", { key });
 
+      setPendingFile(null);
       setUploadedUrl(publicUrl);
       onUploaded(key, publicUrl);
     } catch {
@@ -115,7 +152,20 @@ export function UploadField({
         </button>
       )}
 
-      {error && <p className="text-sm text-red-500">{error}</p>}
+      {error && (
+        <div className="space-y-1">
+          <p className="text-sm text-red-500">{error}</p>
+          {pendingFile && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleFile(pendingFile)}
+            >
+              Retry
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Resolves

* Closes #23
* Closes #13
* Closes #49
* Closes #212

---

## Summary

* **perf(leaderboard):** Replace 1+N query loop in `GET /leaderboard/global` with a single `ROW_NUMBER() OVER (PARTITION BY challenge_id)` aggregation; verified via mock-count assertion in tests (#13)

* **feat(rate-limit):** Add per-user key derivation (`user.sub` when authenticated, IP as fallback), `passOnStoreError: true` for Redis fail-open, and logged store-error wrapper (#23)

* **test(rate-limit):** New `rate-limit.test.ts` — boundary, Retry-After, key derivation, window reset, Redis fail-open/fail-closed (#23)

* **feat(upload-field):** Add MIME validation, file-size validation (`maxSizeBytes` prop), and Retry button on PUT failure (#49)

* **test(upload-field):** New `upload-field.test.tsx` — happy path, MIME error, size error, PUT failure + retry (#49)

* **refactor(spending-policy):** Extract pure `checkSpendingPolicy` to `agent/spending-policy.ts` (mutable-state fix); fix timezone bug (`localDateString` uses local TZ, not UTC) (#212)

* **test(spending-policy):** New `agent/tools.test.ts` — monthly budget, daily cap, approval threshold, independent categories, timezone boundary (#212)

* **chore(careguard):** Add Vitest, `vitest.config.ts`, and `test` script (#212)

---

## Test plan

* [ ] `pnpm --filter @brandblitz/api test` — all rate-limit and leaderboard tests pass
* [ ] `pnpm --filter @brandblitz/web test` — upload-field tests pass
* [ ] `cd careguard && npm install && npm test` — spending-policy tests pass
* [ ] Run `EXPLAIN ANALYZE` on the new `getTopSessionsPerChallenge` query against a populated DB to confirm index use on `(challenge_id, total_score, challenge_ended_at)`

Resolves #23                                                                                                     
Resolves #13                                                                                                   
Resolves #49
Resolves #212  