### PR TITLE
test(web): cover ChallengeRound render, click, timer expiry and reaction time

### DIFF
--- a/apps/web/src/components/game/challenge-round.test.tsx
+++ b/apps/web/src/components/game/challenge-round.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChallengeRound } from "./challenge-round";
+import { ROUND_SECONDS } from "./constants";
+import type { ChallengeQuestion } from "@/lib/api";
+
+let capturedOnExpire: (() => void) | undefined;
+
+vi.mock("./countdown-timer", () => ({
+  CountdownTimer: (props: { durationSeconds: number; onExpire?: () => void; className?: string }) => {
+    capturedOnExpire = props.onExpire;
+    return <div data-testid="countdown-timer">{props.durationSeconds}</div>;
+  },
+}));
+
+function buildQuestion(overrides?: Partial<ChallengeQuestion>): ChallengeQuestion {
+  return {
+    id: "q-1",
+    challenge_id: "ch-1",
+    round: 1,
+    question_type: "brand_recall",
+    prompt_type: "text",
+    question_text: "Which brand uses this tagline?",
+    option_a: "Nike",
+    option_b: "Adidas",
+    option_c: "Puma",
+    option_d: "Reebok",
+    ...overrides,
+  };
+}
+
+describe("ChallengeRound", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    capturedOnExpire = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("renders the question prompt and all 4 options", () => {
+    const onAnswer = vi.fn();
+    render(<ChallengeRound question={buildQuestion()} round={1} onAnswer={onAnswer} />);
+
+    expect(screen.getByText("Which brand uses this tagline?")).toBeDefined();
+    expect(screen.getByText("Nike")).toBeDefined();
+    expect(screen.getByText("Adidas")).toBeDefined();
+    expect(screen.getByText("Puma")).toBeDefined();
+    expect(screen.getByText("Reebok")).toBeDefined();
+  });
+
+  it("displays the round indicator", () => {
+    const onAnswer = vi.fn();
+    render(<ChallengeRound question={buildQuestion()} round={2} onAnswer={onAnswer} />);
+
+    expect(screen.getByText("Round 2 of 3")).toBeDefined();
+  });
+
+  it("clicking an option calls onAnswer with the option letter and reactionTimeMs", () => {
+    const onAnswer = vi.fn();
+    const now = 1000;
+    vi.setSystemTime(now);
+
+    render(<ChallengeRound question={buildQuestion()} round={1} onAnswer={onAnswer} />);
+
+    vi.setSystemTime(now + 2500);
+    fireEvent.click(screen.getByText("Puma"));
+
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+    expect(onAnswer).toHaveBeenCalledWith("C", 2500);
+  });
+
+  it("prevents double-answering after an option is selected", () => {
+    const onAnswer = vi.fn();
+    render(<ChallengeRound question={buildQuestion()} round={1} onAnswer={onAnswer} />);
+
+    fireEvent.click(screen.getByText("Nike"));
+    fireEvent.click(screen.getByText("Adidas"));
+    fireEvent.click(screen.getByText("Puma"));
+
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+    expect(onAnswer).toHaveBeenCalledWith("A", expect.any(Number));
+  });
+
+  it("timer reaching 0 calls onAnswer with sentinel default option A and rtMs = ROUND_SECONDS * 1000", () => {
+    const onAnswer = vi.fn();
+    render(<ChallengeRound question={buildQuestion()} round={1} onAnswer={onAnswer} />);
+
+    expect(capturedOnExpire).toBeDefined();
+    capturedOnExpire!();
+
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+    expect(onAnswer).toHaveBeenCalledWith("A", ROUND_SECONDS * 1000);
+  });
+
+  it("timer expiry does not fire if user already answered", () => {
+    const onAnswer = vi.fn();
+    render(<ChallengeRound question={buildQuestion()} round={1} onAnswer={onAnswer} />);
+
+    fireEvent.click(screen.getByText("Adidas"));
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+
+    capturedOnExpire!();
+
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders logo image when prompt_type is 'logo' and brandLogoUrl is provided", () => {
+    const onAnswer = vi.fn();
+    const question = buildQuestion({ prompt_type: "logo" });
+
+    const { container } = render(
+      <ChallengeRound
+        question={question}
+        round={1}
+        onAnswer={onAnswer}
+        brandLogoUrl="https://example.com/logo.png"
+      />
+    );
+
+    const img = container.querySelector('img[alt="Brand prompt"]') as HTMLImageElement;
+    expect(img).not.toBeNull();
+    expect(img.src).toBe("https://example.com/logo.png");
+  });
+
+  it("renders product image when prompt_type is 'productImage1' and brandProductImageUrl is provided", () => {
+    const onAnswer = vi.fn();
+    const question = buildQuestion({ prompt_type: "productImage1" });
+
+    const { container } = render(
+      <ChallengeRound
+        question={question}
+        round={1}
+        onAnswer={onAnswer}
+        brandProductImageUrl="https://example.com/product.png"
+      />
+    );
+
+    const img = container.querySelector('img[alt="Product prompt"]') as HTMLImageElement;
+    expect(img).not.toBeNull();
+    expect(img.src).toBe("https://example.com/product.png");
+  });
+
+  it("does not render images when prompt_type does not match or URLs are missing", () => {
+    const onAnswer = vi.fn();
+    const question = buildQuestion({ prompt_type: "text" });
+
+    const { container } = render(
+      <ChallengeRound question={question} round={1} onAnswer={onAnswer} />
+    );
+
+    expect(container.querySelector('img[alt="Brand prompt"]')).toBeNull();
+    expect(container.querySelector('img[alt="Product prompt"]')).toBeNull();
+  });
+
+  it("resets state when round prop changes", () => {
+    const onAnswer = vi.fn();
+    const now = 5000;
+    vi.setSystemTime(now);
+
+    const { rerender } = render(
+      <ChallengeRound question={buildQuestion()} round={1} onAnswer={onAnswer} />
+    );
+
+    fireEvent.click(screen.getByText("Nike"));
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(now + 10000);
+    rerender(
+      <ChallengeRound question={buildQuestion()} round={2} onAnswer={onAnswer} />
+    );
+
+    vi.setSystemTime(now + 10000 + 1200);
+    fireEvent.click(screen.getByText("Adidas"));
+
+    expect(onAnswer).toHaveBeenCalledTimes(2);
+    expect(onAnswer).toHaveBeenLastCalledWith("B", 1200);
+  });
+
+  describe("keyboard navigation", () => {
+    it.todo("number keys 1-4 select options (keyboard parity)");
+    it.todo("arrow keys navigate between options");
+  });
+});


### PR DESCRIPTION
Resolves #44 

## Description
Comprehensive test suite for the `ChallengeRound` component covering render output, user interactions, timer expiration behaviour, image rendering, and round reset logic.

## Changes Made
- Created `apps/web/src/components/game/challenge-round.test.tsx` with 10 passing tests and 2 todo stubs.

## Acceptance Criteria Coverage
- **Renders the prompt + 4 options:** Verified question text and all option labels render correctly.
- **Clicking an option calls onAnswer(option, reactionTimeMs):** Verified with controlled `Date.now()` via fake timers. Reaction time is measured from mount as expected.
- **Double-answer prevention:** Confirmed only the first click fires `onAnswer`.
- **Timer reaching 0:** Verified `onAnswer("A", ROUND_SECONDS * 1000)` is called as the sentinel default. Timer expiry is suppressed if a user already answered.
- **Image rendering:** Tested logo and product image conditional rendering based on `prompt_type` and URL props.
- **Round reset:** Verified state clears and `startTimeRef` resets when the `round` prop changes.
- **No console errors/warnings:** Confirmed zero stderr output by mocking `CountdownTimer` to isolate the component under test.
- **Keyboard navigation (todo):** The component does not currently implement keyboard handlers. Two `it.todo()` stubs document the intended behaviour for arrow keys and number keys 1–4, ready for implementation.
