### PR TITLE
test(scripts): add unit tests and dev runner implementation

### DIFF
--- a/scripts/dev.test.ts
+++ b/scripts/dev.test.ts
@@ -1,0 +1,178 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+import { SERVICE_DEFINITIONS, createPrefix, routeOutput, runDevRunner } from "./dev";
+
+type ExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+
+class MockChildProcess extends EventEmitter {
+  killed = false;
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  readonly kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    this.killed = true;
+    return true;
+  });
+
+  override once(event: "exit", listener: ExitListener): this;
+  override once(event: string | symbol, listener: (...args: unknown[]) => void): this;
+  override once(event: string | symbol, listener: (...args: unknown[]) => void): this {
+    return super.once(event, listener);
+  }
+}
+
+class MockProcess extends EventEmitter {
+  env = { ...process.env };
+  stdout = { write: vi.fn<(message: string) => boolean>(() => true) };
+  stderr = { write: vi.fn<(message: string) => boolean>(() => true) };
+  exit = vi.fn<(code?: string | number | null | undefined) => never>();
+}
+
+const spawnMock = vi.mocked(spawn);
+
+function createRunnerHarness() {
+  const mockProcess = new MockProcess();
+  const children: MockChildProcess[] = [];
+
+  spawnMock.mockImplementation(() => {
+    const child = new MockChildProcess();
+    children.push(child);
+    return child as never;
+  });
+
+  runDevRunner(mockProcess as unknown as NodeJS.Process);
+
+  return { children, mockProcess };
+}
+
+describe("runDevRunner", () => {
+  afterEach(() => {
+    spawnMock.mockReset();
+    vi.clearAllMocks();
+  });
+
+  it("spawns exactly 5 child processes, one per service definition", () => {
+    createRunnerHarness();
+
+    expect(spawnMock).toHaveBeenCalledTimes(SERVICE_DEFINITIONS.length);
+
+    for (const [index, service] of SERVICE_DEFINITIONS.entries()) {
+      expect(spawnMock).toHaveBeenNthCalledWith(
+        index + 1,
+        service.command,
+        service.args,
+        expect.objectContaining({
+          env: expect.any(Object),
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+      );
+    }
+  });
+
+  it("routes stdout and stderr with a per-service color prefix", async () => {
+    const { children, mockProcess } = createRunnerHarness();
+
+    children[0].stdout.write("ready\n");
+    children[0].stderr.write("warning\n");
+    children[0].stdout.end("partial");
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const prefix = createPrefix(SERVICE_DEFINITIONS[0].name);
+
+    expect(mockProcess.stdout.write).toHaveBeenCalledWith(`${prefix} ready\n`);
+    expect(mockProcess.stderr.write).toHaveBeenCalledWith(`${prefix} warning\n`);
+    expect(mockProcess.stdout.write).toHaveBeenCalledWith(`${prefix} partial\n`);
+  });
+
+  it("ignores missing streams when wiring output", () => {
+    const write = vi.fn<(message: string) => void>();
+
+    routeOutput(null, write, createPrefix("api"));
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("kills all other children and exits 1 when any child exits non-zero", () => {
+    const { children, mockProcess } = createRunnerHarness();
+
+    children[2].emit("exit", 1, null);
+
+    expect(children[0].kill).toHaveBeenCalledTimes(1);
+    expect(children[1].kill).toHaveBeenCalledTimes(1);
+    expect(children[2].kill).not.toHaveBeenCalled();
+    expect(children[3].kill).toHaveBeenCalledTimes(1);
+    expect(children[4].kill).toHaveBeenCalledTimes(1);
+    expect(mockProcess.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not shut down when a child exits cleanly", () => {
+    const { children, mockProcess } = createRunnerHarness();
+
+    children[1].emit("exit", 0, null);
+
+    for (const child of children) {
+      expect(child.kill).not.toHaveBeenCalled();
+    }
+    expect(mockProcess.exit).not.toHaveBeenCalled();
+  });
+
+  it("kills all children and exits 0 on SIGINT", () => {
+    const { children, mockProcess } = createRunnerHarness();
+
+    mockProcess.emit("SIGINT");
+
+    for (const child of children) {
+      expect(child.kill).toHaveBeenCalledTimes(1);
+    }
+    expect(mockProcess.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("shuts down only once and skips children already marked as killed", () => {
+    const { children, mockProcess } = createRunnerHarness();
+
+    children[0].killed = true;
+
+    mockProcess.emit("SIGINT");
+    mockProcess.emit("SIGTERM");
+    children[1].emit("exit", 1, null);
+
+    expect(children[0].kill).not.toHaveBeenCalled();
+    expect(children[1].kill).toHaveBeenCalledTimes(1);
+    expect(children[2].kill).toHaveBeenCalledTimes(1);
+    expect(children[3].kill).toHaveBeenCalledTimes(1);
+    expect(children[4].kill).toHaveBeenCalledTimes(1);
+    expect(mockProcess.exit).toHaveBeenCalledTimes(1);
+    expect(mockProcess.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("kills all children and exits 0 on SIGTERM", () => {
+    const { children, mockProcess } = createRunnerHarness();
+
+    mockProcess.emit("SIGTERM");
+
+    for (const child of children) {
+      expect(child.kill).toHaveBeenCalledTimes(1);
+    }
+    expect(mockProcess.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("treats signal-based child exits as failures", () => {
+    const { children, mockProcess } = createRunnerHarness();
+
+    children[0].emit("exit", null, "SIGTERM");
+
+    expect(children[0].kill).not.toHaveBeenCalled();
+    expect(children[1].kill).toHaveBeenCalledTimes(1);
+    expect(children[2].kill).toHaveBeenCalledTimes(1);
+    expect(children[3].kill).toHaveBeenCalledTimes(1);
+    expect(children[4].kill).toHaveBeenCalledTimes(1);
+    expect(mockProcess.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,149 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import type { Readable } from "node:stream";
+
+const ANSI_RESET = "\u001b[0m";
+
+const SERVICE_COLORS = {
+  api: "\u001b[32m",
+  worker: "\u001b[33m",
+  web: "\u001b[36m",
+  stellar: "\u001b[35m",
+  storage: "\u001b[34m",
+} as const;
+
+export type ServiceDefinition = {
+  name: keyof typeof SERVICE_COLORS;
+  command: string;
+  args: string[];
+};
+
+type ManagedChildProcess = {
+  killed: boolean;
+  kill: (signal?: NodeJS.Signals | number) => boolean;
+  once: (event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void) => ManagedChildProcess;
+  stdout: Readable | null;
+  stderr: Readable | null;
+};
+
+type ProcessLike = Pick<NodeJS.Process, "env" | "exit" | "once" | "stdout" | "stderr">;
+
+export const SERVICE_DEFINITIONS: ServiceDefinition[] = [
+  {
+    name: "web",
+    command: "pnpm",
+    args: ["--filter", "@brandblitz/web", "dev"],
+  },
+  {
+    name: "api",
+    command: "pnpm",
+    args: ["--filter", "@brandblitz/api", "dev"],
+  },
+  {
+    name: "worker",
+    command: "pnpm",
+    args: ["--filter", "@brandblitz/api", "dev:worker"],
+  },
+  {
+    name: "stellar",
+    command: "pnpm",
+    args: ["--filter", "@brandblitz/stellar", "dev"],
+  },
+  {
+    name: "storage",
+    command: "pnpm",
+    args: ["--filter", "@brandblitz/storage", "dev"],
+  },
+];
+
+export function createPrefix(serviceName: ServiceDefinition["name"]): string {
+  return `${SERVICE_COLORS[serviceName]}[${serviceName}]${ANSI_RESET}`;
+}
+
+export function routeOutput(
+  stream: Readable | null,
+  write: (message: string) => void,
+  prefix: string,
+): void {
+  if (!stream) {
+    return;
+  }
+
+  let buffer = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk: string) => {
+    buffer += chunk;
+
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      write(`${prefix} ${line}\n`);
+    }
+  });
+
+  stream.on("end", () => {
+    if (buffer.length > 0) {
+      write(`${prefix} ${buffer}\n`);
+    }
+  });
+}
+
+export function runDevRunner(proc: ProcessLike = process): ManagedChildProcess[] {
+  const children = SERVICE_DEFINITIONS.map((service) => {
+    const child = spawn(service.command, service.args, {
+      env: proc.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    }) as ManagedChildProcess;
+
+    const prefix = createPrefix(service.name);
+    routeOutput(child.stdout, (message) => proc.stdout.write(message), prefix);
+    routeOutput(child.stderr, (message) => proc.stderr.write(message), prefix);
+
+    return child;
+  });
+
+  let isShuttingDown = false;
+
+  const shutdown = (exitCode: 0 | 1, source?: ManagedChildProcess) => {
+    if (isShuttingDown) {
+      return;
+    }
+
+    isShuttingDown = true;
+
+    for (const child of children) {
+      if (child !== source && !child.killed) {
+        child.kill();
+      }
+    }
+
+    proc.exit(exitCode);
+  };
+
+  for (const child of children) {
+    child.once("exit", (code, signal) => {
+      if (isShuttingDown) {
+        return;
+      }
+
+      if ((code ?? 0) !== 0 || signal !== null) {
+        shutdown(1, child);
+      }
+    });
+  }
+
+  proc.once("SIGINT", () => shutdown(0));
+  proc.once("SIGTERM", () => shutdown(0));
+
+  return children;
+}
+
+const entrypoint = process.argv[1];
+const currentFile = fileURLToPath(import.meta.url);
+
+/* v8 ignore next -- exercised by invoking the script directly rather than importing it in tests */
+if (entrypoint && path.resolve(entrypoint) === currentFile) {
+  runDevRunner();
+}

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { defineProject } from "vitest/config";
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(projectRoot, "..");
+
+export default defineProject({
+  test: {
+    name: "@brandblitz/scripts",
+    root: repoRoot,
+    environment: "node",
+    include: ["scripts/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["scripts/dev.ts"],
+      reportsDirectory: "./coverage/scripts",
+      thresholds: {
+        branches: 90,
+        functions: 90,
+        lines: 90,
+        statements: 90,
+      },
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     projects: [
+      "./scripts/vitest.config.ts",
       "./apps/api/vitest.config.ts",
       "./apps/web/vitest.config.ts",
       "./packages/stellar/vitest.config.ts",


### PR DESCRIPTION
## Description
This PR closes #219 by implementing the multi-process dev runner and introducing a robust unit test suite to ensure stable local development. 

The runner reliably spawns the 5 required services, pipes standard output/error with color-coded prefixes for readability, and handles graceful teardown. To avoid silent stuck processes (a major DX pain point), the script is tested with mocked `node:child_process` spawns to guarantee that if *any* process fails, the rest are immediately killed and the parent exits appropriately.

## Changes Made
* **`scripts/dev.ts`**: Reconstructed the dev runner logic to handle the 5 core services (`web`, `api`, `worker`, `stellar`, `storage`).
* **`scripts/dev.test.ts`**: Added a thorough unit test suite that mocks `spawn` and standard streams to simulate process crashes, clean exits, and incoming terminal signals.
* **`scripts/vitest.config.ts`**: Created a dedicated Vitest project for scripts to explicitly enforce the 90% code coverage threshold.
* **`vitest.config.ts`**: Hooked the new script project into the root workspace configurations.

## Acceptance Criteria Verified
- [x] Spawns exactly 5 child processes, one per service definition.
- [x] `stdout`/`stderr` routed with per-service colour prefix.
- [x] Exit code ≠ 0 from any child → all other children receive `kill()`, parent exits `1`.
- [x] SIGINT → all children receive `kill()`, parent exits `0`.
- [x] SIGTERM → all children receive `kill()`, parent exits `0`.
- [x] Coverage ≥ 90% (verified via `scripts/vitest.config.ts`).

## Testing Instructions
1. Run the targeted test suite: `pnpm vitest run --project @brandblitz/scripts`
2. Run coverage to verify the thresholds: `pnpm vitest run --project @brandblitz/scripts --coverage`