### PR TITLE
Fix keyboard shortcuts, live leaderboard, and theme toggle

### DIFF
--- a/apps/api/src/db/queries/sessions.ts
+++ b/apps/api/src/db/queries/sessions.ts
@@ -31,6 +31,9 @@ export interface RoundScore {
 export interface LeaderboardSession extends GameSession {
   username: string;
   avatar_url: string;
+  display_name: string;
+  league: "bronze" | "silver" | "gold" | null;
+  total_earned_usdc: string;
   stellar_address: string | null;
 }
 
@@ -158,6 +161,9 @@ export async function getLeaderboard(
     `SELECT gs.*,
             u.email AS username,
             u.avatar_url,
+            u.display_name,
+            u.league,
+            u.total_earned_usdc,
             COALESCE(
               NULLIF(to_jsonb(u) ->> 'embedded_wallet_address', ''),
               NULLIF(to_jsonb(u) ->> 'stellar_address', '')
@@ -187,11 +193,14 @@ export async function getTopSessionsPerChallenge(
             sub.round_1_score, sub.round_2_score, sub.round_3_score,
             sub.total_score, sub.flagged, sub.flag_reasons,
             sub.is_practice, sub.created_at,
-            sub.username, sub.avatar_url, sub.stellar_address
+            sub.username, sub.avatar_url, sub.display_name, sub.league, sub.total_earned_usdc, sub.stellar_address
      FROM (
        SELECT gs.*,
               u.email        AS username,
               u.avatar_url,
+              u.display_name,
+              u.league,
+              u.total_earned_usdc,
               COALESCE(
                 NULLIF(to_jsonb(u) ->> 'embedded_wallet_address', ''),
                 NULLIF(to_jsonb(u) ->> 'stellar_address', '')

--- a/apps/api/src/routes/challenges.ts
+++ b/apps/api/src/routes/challenges.ts
@@ -76,9 +76,13 @@ router.get("/:id/leaderboard", async (req, res) => {
     challengeId: challenge.id,
     sessions: sessions.map((s, i) => ({
       rank: offset + i + 1,
+      userId: s.user_id,
       username: s.username,
+      displayName: s.display_name,
+      league: s.league,
       avatarUrl: s.avatar_url,
       totalScore: s.total_score,
+      totalEarned: s.total_earned_usdc,
       endedAt: s.completed_at,
     })),
   });

--- a/apps/api/src/routes/leaderboard.ts
+++ b/apps/api/src/routes/leaderboard.ts
@@ -6,6 +6,92 @@ import { redis } from "../lib/redis";
 
 const router = Router();
 
+function writeSse(res: any, payload: unknown) {
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+/**
+ * GET /leaderboard/stream
+ * Server-Sent Events feed for global or per-challenge leaderboard snapshots.
+ *
+ * Query params:
+ *  - challengeId?: string
+ *  - intervalMs?: number (default 2000, min 500)
+ */
+router.get("/stream", async (req, res) => {
+  const { challengeId, intervalMs } = z.object({
+    challengeId: z.string().optional(),
+    intervalMs: z.coerce.number().min(500).max(30_000).default(2000),
+  }).parse(req.query);
+
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.flushHeaders?.();
+
+  const sendSnapshot = async () => {
+    if (challengeId) {
+      const sessions = await getLeaderboard(challengeId, 100, 0);
+      writeSse(res, {
+        challengeId,
+        sessions: sessions.map((s, i) => ({
+          rank: i + 1,
+          userId: s.user_id,
+          username: s.username,
+          displayName: s.display_name,
+          league: s.league,
+          avatarUrl: s.avatar_url,
+          totalScore: s.total_score,
+          totalEarned: s.total_earned_usdc,
+          endedAt: s.completed_at,
+        })),
+        updatedAt: new Date().toISOString(),
+      });
+      return;
+    }
+
+    const challenges = await getActiveChallenges(10);
+    const challengeIds = challenges.map((c) => c.id);
+    const topSessions = await getTopSessionsPerChallenge(challengeIds, 10);
+
+    const rankPerChallenge = new Map<string, number>();
+    const leaderboard = topSessions.map((s) => {
+      const rank = (rankPerChallenge.get(s.challenge_id) ?? 0) + 1;
+      rankPerChallenge.set(s.challenge_id, rank);
+      return {
+        rank,
+        challengeId: s.challenge_id,
+        userId: s.user_id,
+        username: s.username,
+        displayName: s.display_name,
+        league: s.league,
+        avatarUrl: s.avatar_url,
+        totalScore: s.total_score,
+        totalEarned: s.total_earned_usdc,
+      };
+    });
+
+    writeSse(res, { leaderboard, updatedAt: new Date().toISOString() });
+  };
+
+  const heartbeat = setInterval(() => res.write(`:keep-alive\n\n`), 15_000);
+
+  try {
+    await sendSnapshot();
+  } catch {
+    // ignore initial snapshot error; clients will fall back to polling
+  }
+
+  const timer = setInterval(() => {
+    sendSnapshot().catch(() => {});
+  }, intervalMs);
+
+  req.on("close", () => {
+    clearInterval(timer);
+    clearInterval(heartbeat);
+  });
+});
+
 /**
  * GET /leaderboard/global
  * Cross-challenge leaderboard (cached in Redis, 5 min TTL).
@@ -31,9 +117,13 @@ router.get("/global", async (_req, res) => {
     return {
       rank,
       challengeId: s.challenge_id,
+      userId: s.user_id,
       username: s.username,
+      displayName: s.display_name,
+      league: s.league,
       avatarUrl: s.avatar_url,
       totalScore: s.total_score,
+      totalEarned: s.total_earned_usdc,
     };
   });
 
@@ -57,9 +147,13 @@ router.get("/:challengeId", async (req, res) => {
   res.json({
     sessions: sessions.map((s, i) => ({
       rank: offset + i + 1,
+      userId: s.user_id,
       username: s.username,
+      displayName: s.display_name,
+      league: s.league,
       avatarUrl: s.avatar_url,
       totalScore: s.total_score,
+      totalEarned: s.total_earned_usdc,
     })),
   });
 });

--- a/apps/web/src/app/(brand)/brand/[id]/page.tsx
+++ b/apps/web/src/app/(brand)/brand/[id]/page.tsx
@@ -8,9 +8,10 @@ import Image from "next/image";
 import { createApiClient } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { formatScore, formatUsdc } from "@/lib/utils";
+import { formatUsdc } from "@/lib/utils";
 import type { LeaderboardEntry } from "@/lib/api";
 import { EmptyState } from "@/components/ui/empty-state";
+import { LiveChallengeLeaderboard } from "@/components/leaderboard/live-challenge-leaderboard";
 
 function normalizeBrand(brand: any) {
   if (!brand) return null;
@@ -161,33 +162,11 @@ export default function BrandAnalyticsPage() {
                 <CardTitle>Current Leaderboard</CardTitle>
               </CardHeader>
               <CardContent className="p-0">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-[var(--border)]">
-                      <th className="text-left px-6 py-3 text-[var(--muted-foreground)]">Rank</th>
-                      <th className="text-left px-6 py-3 text-[var(--muted-foreground)]">Player</th>
-                      <th className="text-right px-6 py-3 text-[var(--muted-foreground)]">Score</th>
-                      <th className="text-right px-6 py-3 text-[var(--muted-foreground)]">Est. Payout</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {leaderboard.slice(0, 10).map((entry) => (
-                      <tr
-                        key={`${entry.rank}-${entry.username}`}
-                        className="border-b border-[var(--border)] last:border-0"
-                      >
-                        <td className="px-6 py-3 font-bold">#{entry.rank}</td>
-                        <td className="px-6 py-3">{entry.username}</td>
-                        <td className="px-6 py-3 text-right font-mono">
-                          {formatScore(entry.totalScore)}
-                        </td>
-                        <td className="px-6 py-3 text-right text-green-600">
-                          {"—"}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <LiveChallengeLeaderboard
+                  key={challenge.id}
+                  challengeId={challenge.id}
+                  initial={leaderboard}
+                />
               </CardContent>
             </Card>
           )}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -29,26 +29,29 @@
   --brand-secondary: #818cf8;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0f172a;
-    --foreground: #f8fafc;
-    --card: #1e293b;
-    --card-foreground: #f8fafc;
-    --popover: #1e293b;
-    --popover-foreground: #f8fafc;
-    --primary: #818cf8;
-    --primary-foreground: #0f172a;
-    --secondary: #1e293b;
-    --secondary-foreground: #f8fafc;
-    --muted: #1e293b;
-    --muted-foreground: #94a3b8;
-    --accent: #1e293b;
-    --accent-foreground: #f8fafc;
-    --border: #334155;
-    --input: #334155;
-    --ring: #818cf8;
-  }
+html {
+  color-scheme: light;
+}
+
+html.dark {
+  color-scheme: dark;
+  --background: #0f172a;
+  --foreground: #f8fafc;
+  --card: #1e293b;
+  --card-foreground: #f8fafc;
+  --popover: #1e293b;
+  --popover-foreground: #f8fafc;
+  --primary: #818cf8;
+  --primary-foreground: #0f172a;
+  --secondary: #1e293b;
+  --secondary-foreground: #f8fafc;
+  --muted: #1e293b;
+  --muted-foreground: #94a3b8;
+  --accent: #1e293b;
+  --accent-foreground: #f8fafc;
+  --border: #334155;
+  --input: #334155;
+  --ring: #818cf8;
 }
 
 /* ── Tailwind v4 theme extension ──────────────────────────────────────────── */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import { SessionProvider } from "next-auth/react";
 import "./globals.css";
 
@@ -22,6 +23,24 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={inter.className}>
+      <head>
+        <Script id="theme-init" strategy="beforeInteractive">
+          {`
+            (function () {
+              try {
+                var key = "theme";
+                var mode = localStorage.getItem(key);
+                if (mode !== "light" && mode !== "dark" && mode !== "system") mode = "system";
+                var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+                var isDark = mode === "dark" || (mode === "system" && prefersDark);
+                var html = document.documentElement;
+                if (isDark) html.classList.add("dark"); else html.classList.remove("dark");
+                html.dataset.theme = mode;
+              } catch (e) {}
+            })();
+          `}
+        </Script>
+      </head>
       <body className="min-h-screen flex flex-col antialiased bg-[var(--background)] text-[var(--foreground)]">
         <SessionProvider>{children}</SessionProvider>
       </body>

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,12 +1,7 @@
 import { api } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { formatScore, formatUsdc } from "@/lib/utils";
 import type { LeaderboardEntry } from "@/lib/api";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { EmptyState } from "@/components/ui/empty-state";
-import Image from "next/image";
+import { LiveGlobalLeaderboard } from "@/components/leaderboard/live-global-leaderboard";
 
 async function getGlobalLeaderboard(): Promise<LeaderboardEntry[]> {
   try {
@@ -16,8 +11,6 @@ async function getGlobalLeaderboard(): Promise<LeaderboardEntry[]> {
     return [];
   }
 }
-
-const MEDAL: Record<number, string> = { 1: "🥇", 2: "🥈", 3: "🥉" };
 
 export default async function LeaderboardPage() {
   const entries = await getGlobalLeaderboard();
@@ -32,80 +25,7 @@ export default async function LeaderboardPage() {
           <CardTitle>All-Time Rankings</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
-          {entries.length === 0 ? (
-            <div className="p-6">
-              <EmptyState
-                title="No games played yet"
-                description="Be the first to climb the leaderboard."
-                action={
-                  <Link href="/challenge">
-                    <Button>Browse Challenges</Button>
-                  </Link>
-                }
-              />
-            </div>
-          ) : (
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-[var(--border)]">
-                  <th className="text-left px-6 py-3 font-medium text-[var(--muted-foreground)]">
-                    Rank
-                  </th>
-                  <th className="text-left px-6 py-3 font-medium text-[var(--muted-foreground)]">
-                    Player
-                  </th>
-                  <th className="text-right px-6 py-3 font-medium text-[var(--muted-foreground)]">
-                    Score
-                  </th>
-                  <th className="text-right px-6 py-3 font-medium text-[var(--muted-foreground)]">
-                    Earned
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {entries.map((entry) => (
-                  <tr
-                    key={entry.userId}
-                    className="border-b border-[var(--border)] last:border-0 hover:bg-[var(--muted)]/50 transition-colors"
-                  >
-                    <td className="px-6 py-4 font-bold">
-                      {MEDAL[entry.rank] ?? `#${entry.rank}`}
-                    </td>
-                    <td className="px-6 py-4">
-                      <div className="flex items-center gap-3">
-                        {entry.avatarUrl ? (
-                          <Image
-                            src={entry.avatarUrl}
-                            alt={entry.displayName}
-                            width={32}
-                            height={32}
-                            sizes="32px"
-                            className="h-8 w-8 rounded-full object-cover"
-                          />
-                        ) : (
-                          <div className="h-8 w-8 rounded-full bg-[var(--primary)] flex items-center justify-center text-white text-xs font-bold">
-                            {entry.displayName.charAt(0).toUpperCase()}
-                          </div>
-                        )}
-                        <span className="font-medium">{entry.displayName}</span>
-                        {entry.league && (
-                          <Badge variant={entry.league as "gold" | "silver" | "bronze"}>
-                            {entry.league}
-                          </Badge>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 text-right font-mono">
-                      {formatScore(entry.totalScore)}
-                    </td>
-                    <td className="px-6 py-4 text-right text-green-600 font-medium">
-                      {entry.totalEarned ? `${formatUsdc(entry.totalEarned)} USDC` : "—"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
+          <LiveGlobalLeaderboard initial={entries} />
         </CardContent>
       </Card>
     </main>

--- a/apps/web/src/components/game/challenge-round.tsx
+++ b/apps/web/src/components/game/challenge-round.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { CountdownTimer } from "./countdown-timer";
@@ -35,13 +35,43 @@ export function ChallengeRound({
     setAnswered(false);
   }, [round]);
 
-  const handleSelect = (option: "A" | "B" | "C" | "D") => {
+  const handleSelect = useCallback((option: "A" | "B" | "C" | "D") => {
     if (answered) return;
     const reactionTimeMs = Date.now() - startTimeRef.current;
     setSelected(option);
     setAnswered(true);
     onAnswer(option, reactionTimeMs);
-  };
+  }, [answered, onAnswer]);
+
+  useEffect(() => {
+    if (answered) return;
+
+    const keyToOption: Record<string, "A" | "B" | "C" | "D" | undefined> = {
+      a: "A",
+      b: "B",
+      c: "C",
+      d: "D",
+      1: "A",
+      2: "B",
+      3: "C",
+      4: "D",
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      if (tag === "input" || tag === "textarea" || target?.isContentEditable) return;
+
+      const opt = keyToOption[event.key.toLowerCase()];
+      if (!opt) return;
+
+      event.preventDefault();
+      handleSelect(opt);
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [answered, handleSelect]);
 
   const handleTimeExpire = () => {
     if (!answered) {
@@ -112,8 +142,11 @@ export function ChallengeRound({
               answered && "pointer-events-none"
             )}
             onClick={() => handleSelect(opt)}
+            aria-label={`${opt}: ${getOptionLabel(opt)}`}
           >
-            <span className="font-bold mr-3 text-[var(--muted-foreground)]">{opt}</span>
+            <kbd className="font-bold mr-3 text-[var(--muted-foreground)] inline-flex items-center justify-center min-w-6 h-6 px-1 rounded border border-[var(--border)] bg-[var(--muted)]">
+              {opt}
+            </kbd>
             <span>{getOptionLabel(opt)}</span>
           </Button>
         ))}

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useSession, signOut } from "next-auth/react";
 import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "./theme-toggle";
 
 export function Header() {
   const { data: session, status } = useSession();
@@ -39,6 +40,7 @@ export function Header() {
         </nav>
 
         <div className="flex items-center gap-3">
+          <ThemeToggle />
           {status === "loading" ? null : session ? (
             <div className="flex items-center gap-3">
               {session.user?.image ? (

--- a/apps/web/src/components/layout/theme-toggle.tsx
+++ b/apps/web/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+type ThemeMode = "light" | "dark" | "system";
+
+const STORAGE_KEY = "theme";
+
+function getStoredTheme(): ThemeMode {
+  if (typeof window === "undefined") return "system";
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (raw === "light" || raw === "dark" || raw === "system") return raw;
+  return "system";
+}
+
+function prefersDark(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia?.("(prefers-color-scheme: dark)")?.matches ?? false;
+}
+
+function applyTheme(mode: ThemeMode) {
+  const html = document.documentElement;
+  const isDark = mode === "dark" || (mode === "system" && prefersDark());
+  html.classList.toggle("dark", isDark);
+  html.dataset.theme = mode;
+}
+
+export function ThemeToggle() {
+  const [mode, setMode] = useState<ThemeMode>("system");
+
+  useEffect(() => {
+    const initial = getStoredTheme();
+    setMode(initial);
+    applyTheme(initial);
+
+    const media = window.matchMedia?.("(prefers-color-scheme: dark)");
+    const onChange = () => {
+      const current = getStoredTheme();
+      if (current !== "system") return;
+      applyTheme("system");
+    };
+
+    media?.addEventListener?.("change", onChange);
+    return () => media?.removeEventListener?.("change", onChange);
+  }, []);
+
+  const nextMode = useMemo(() => {
+    if (mode === "system") return "light";
+    if (mode === "light") return "dark";
+    return "system";
+  }, [mode]);
+
+  const label = useMemo(() => {
+    if (mode === "system") return "System";
+    if (mode === "light") return "Light";
+    return "Dark";
+  }, [mode]);
+
+  const onClick = () => {
+    const next = nextMode;
+    setMode(next);
+    window.localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+  };
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      onClick={onClick}
+      aria-label={`Theme: ${label}. Switch to ${nextMode}.`}
+      aria-pressed={mode !== "system"}
+    >
+      {label}
+    </Button>
+  );
+}
+

--- a/apps/web/src/components/leaderboard/live-challenge-leaderboard.tsx
+++ b/apps/web/src/components/leaderboard/live-challenge-leaderboard.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { formatScore } from "@/lib/utils";
+import type { LeaderboardEntry } from "@/lib/api";
+import { useLiveLeaderboard } from "@/hooks/use-live-leaderboard";
+
+export function LiveChallengeLeaderboard({
+  challengeId,
+  initial,
+}: {
+  challengeId: string;
+  initial: LeaderboardEntry[];
+}) {
+  const { entries } = useLiveLeaderboard({ challengeId, initial });
+  const prevRankByUserRef = useRef<Map<string, number>>(new Map());
+  const [changedUsers, setChangedUsers] = useState<Set<string>>(new Set());
+
+  const rows = useMemo(() => {
+    return entries.slice(0, 10).map((e) => {
+      const userKey = e.userId ?? e.username;
+      return { ...e, _key: userKey };
+    });
+  }, [entries]);
+
+  useEffect(() => {
+    const prev = prevRankByUserRef.current;
+    const changed = new Set<string>();
+    for (const row of rows) {
+      const prevRank = prev.get(row._key);
+      if (prevRank !== undefined && prevRank !== row.rank) changed.add(row._key);
+      prev.set(row._key, row.rank);
+    }
+    if (changed.size === 0) return;
+    setChangedUsers(changed);
+    const t = window.setTimeout(() => setChangedUsers(new Set()), 600);
+    return () => window.clearTimeout(t);
+  }, [rows]);
+
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b border-[var(--border)]">
+          <th className="text-left px-6 py-3 text-[var(--muted-foreground)]">Rank</th>
+          <th className="text-left px-6 py-3 text-[var(--muted-foreground)]">Player</th>
+          <th className="text-right px-6 py-3 text-[var(--muted-foreground)]">Score</th>
+          <th className="text-right px-6 py-3 text-[var(--muted-foreground)]">Est. Payout</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((entry) => (
+          <tr
+            key={entry._key}
+            className={[
+              "border-b border-[var(--border)] last:border-0 transition-colors",
+              changedUsers.has(entry._key) ? "bg-[var(--muted)]" : "",
+            ].join(" ")}
+          >
+            <td className="px-6 py-3 font-bold">#{entry.rank}</td>
+            <td className="px-6 py-3">{entry.displayName ?? entry.username}</td>
+            <td className="px-6 py-3 text-right font-mono">{formatScore(entry.totalScore)}</td>
+            <td className="px-6 py-3 text-right text-green-600">{"—"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/apps/web/src/components/leaderboard/live-global-leaderboard.tsx
+++ b/apps/web/src/components/leaderboard/live-global-leaderboard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { formatScore, formatUsdc } from "@/lib/utils";
+import type { LeaderboardEntry } from "@/lib/api";
+import { useLiveLeaderboard } from "@/hooks/use-live-leaderboard";
+
+const MEDAL: Record<number, string> = { 1: "🥇", 2: "🥈", 3: "🥉" };
+
+export function LiveGlobalLeaderboard({ initial }: { initial: LeaderboardEntry[] }) {
+  const { entries } = useLiveLeaderboard({ initial });
+  const prevRankByUserRef = useRef<Map<string, number>>(new Map());
+  const [changedUsers, setChangedUsers] = useState<Set<string>>(new Set());
+
+  const rows = useMemo(() => {
+    return entries.map((e) => {
+      const userKey = e.userId ?? e.username;
+      return { ...e, _key: userKey };
+    });
+  }, [entries]);
+
+  useEffect(() => {
+    const prev = prevRankByUserRef.current;
+    const changed = new Set<string>();
+    for (const row of rows) {
+      const prevRank = prev.get(row._key);
+      if (prevRank !== undefined && prevRank !== row.rank) changed.add(row._key);
+      prev.set(row._key, row.rank);
+    }
+    if (changed.size === 0) return;
+    setChangedUsers(changed);
+    const t = window.setTimeout(() => setChangedUsers(new Set()), 600);
+    return () => window.clearTimeout(t);
+  }, [rows]);
+
+  if (rows.length === 0) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          title="No games played yet"
+          description="Be the first to climb the leaderboard."
+          action={
+            <Link href="/challenge">
+              <Button>Browse Challenges</Button>
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b border-[var(--border)]">
+          <th className="text-left px-6 py-3 font-medium text-[var(--muted-foreground)]">
+            Rank
+          </th>
+          <th className="text-left px-6 py-3 font-medium text-[var(--muted-foreground)]">
+            Player
+          </th>
+          <th className="text-right px-6 py-3 font-medium text-[var(--muted-foreground)]">
+            Score
+          </th>
+          <th className="text-right px-6 py-3 font-medium text-[var(--muted-foreground)]">
+            Earned
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((entry) => (
+          <tr
+            key={entry._key}
+            className={[
+              "border-b border-[var(--border)] last:border-0 hover:bg-[var(--muted)]/50 transition-colors",
+              changedUsers.has(entry._key) ? "bg-[var(--muted)]" : "",
+            ].join(" ")}
+          >
+            <td className="px-6 py-4 font-bold">{MEDAL[entry.rank] ?? `#${entry.rank}`}</td>
+            <td className="px-6 py-4">
+              <div className="flex items-center gap-3">
+                {entry.avatarUrl ? (
+                  <Image
+                    src={entry.avatarUrl}
+                    alt={entry.displayName ?? entry.username}
+                    width={32}
+                    height={32}
+                    sizes="32px"
+                    className="h-8 w-8 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="h-8 w-8 rounded-full bg-[var(--primary)] flex items-center justify-center text-white text-xs font-bold">
+                    {(entry.displayName ?? entry.username).charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <span className="font-medium">{entry.displayName ?? entry.username}</span>
+                {entry.league && (
+                  <Badge variant={entry.league as "gold" | "silver" | "bronze"}>
+                    {entry.league}
+                  </Badge>
+                )}
+              </div>
+            </td>
+            <td className="px-6 py-4 text-right font-mono">{formatScore(entry.totalScore)}</td>
+            <td className="px-6 py-4 text-right text-green-600 font-medium">
+              {entry.totalEarned ? `${formatUsdc(entry.totalEarned)} USDC` : "—"}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/apps/web/src/hooks/use-live-leaderboard.ts
+++ b/apps/web/src/hooks/use-live-leaderboard.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { api } from "@/lib/api";
+import type { LeaderboardEntry } from "@/lib/api";
+
+type LiveState =
+  | { status: "idle" | "connecting" | "polling"; entries: LeaderboardEntry[] }
+  | { status: "live"; entries: LeaderboardEntry[]; updatedAt?: string };
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost/api";
+
+function buildStreamUrl(challengeId?: string) {
+  const url = new URL("/leaderboard/stream", API_BASE);
+  if (challengeId) url.searchParams.set("challengeId", challengeId);
+  return url.toString();
+}
+
+export function useLiveLeaderboard(opts?: {
+  challengeId?: string;
+  initial?: LeaderboardEntry[];
+}): LiveState {
+  const challengeId = opts?.challengeId;
+  const [state, setState] = useState<LiveState>({
+    status: "idle",
+    entries: opts?.initial ?? [],
+  });
+
+  const pollTimerRef = useRef<number | null>(null);
+  const sourceRef = useRef<EventSource | null>(null);
+
+  const pollUrl = useMemo(() => {
+    if (challengeId) return `/leaderboard/${challengeId}?limit=100&offset=0`;
+    return "/leaderboard/global";
+  }, [challengeId]);
+
+  useEffect(() => {
+    setState((prev) => ({ ...prev, status: "connecting" }));
+
+    const stopPolling = () => {
+      if (pollTimerRef.current) {
+        window.clearInterval(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+
+    const startPolling = () => {
+      stopPolling();
+      setState((prev) => ({ ...prev, status: "polling" }));
+
+      const fetchOnce = async () => {
+        try {
+          const res = await api.get(pollUrl);
+          const nextEntries: LeaderboardEntry[] = challengeId
+            ? res.data.sessions
+            : res.data.leaderboard;
+          setState({ status: "polling", entries: nextEntries });
+        } catch {
+          // ignore
+        }
+      };
+
+      fetchOnce().catch(() => {});
+      pollTimerRef.current = window.setInterval(() => {
+        fetchOnce().catch(() => {});
+      }, 5000);
+    };
+
+    stopPolling();
+    sourceRef.current?.close();
+    sourceRef.current = null;
+
+    let closed = false;
+
+    try {
+      const source = new EventSource(buildStreamUrl(challengeId));
+      sourceRef.current = source;
+
+      source.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (closed) return;
+          const nextEntries: LeaderboardEntry[] = challengeId
+            ? data.sessions
+            : data.leaderboard;
+          setState({ status: "live", entries: nextEntries, updatedAt: data.updatedAt });
+        } catch {
+          // ignore parse errors
+        }
+      };
+
+      source.onerror = () => {
+        if (closed) return;
+        source.close();
+        startPolling();
+      };
+    } catch {
+      startPolling();
+    }
+
+    return () => {
+      closed = true;
+      stopPolling();
+      sourceRef.current?.close();
+      sourceRef.current = null;
+    };
+  }, [challengeId, pollUrl]);
+
+  return state;
+}
+

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -47,9 +47,13 @@ export interface ChallengeQuestion {
 
 export interface LeaderboardEntry {
   rank: number;
+  userId?: string;
   username: string;
+  displayName?: string;
+  league?: "bronze" | "silver" | "gold" | null;
   avatarUrl: string | null;
   totalScore: number;
+  totalEarned?: string;
   endedAt: string | null;
 }
 


### PR DESCRIPTION
Closes #171
Closes #172
Closes #174
Closes #176

Implements keyboard shortcuts for ChallengeRound answers, adds SSE-backed live leaderboard updates (with polling fallback), and adds a Light/Dark/System theme toggle persisted to localStorage with pre-hydration theme init.