### PR TITLE
Prod deploy workflow + gitleaks + brand soft-delete + leagues

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,115 @@
+name: Deploy (prod)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to deploy (e.g. v1.2.3)"
+        required: true
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  staging-healthcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Pre-deploy healthcheck (staging)
+        env:
+          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+        run: |
+          test -n "$STAGING_BASE_URL"
+          curl -fsSL "$STAGING_BASE_URL/api/health" >/dev/null
+          curl -fsSL "$STAGING_BASE_URL/" >/dev/null
+
+  deploy:
+    needs: [staging-healthcheck]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine tag + previous tag
+        id: tags
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+
+          git fetch --tags --force
+          PREV_TAG="$(git tag --list 'v*' --sort=-version:refname | grep -v "^${TAG}$" | head -n 1)"
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy (pull exact tagged images)
+        id: deploy
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd "${{ secrets.PROD_APP_DIR }}"
+            export APP_VERSION="${{ steps.tags.outputs.tag }}"
+            export IMAGE_REGISTRY="${{ secrets.IMAGE_REGISTRY }}"
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml pull api worker web
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --remove-orphans
+
+            BASE_URL="${{ secrets.PROD_BASE_URL }}"
+            test -n "$BASE_URL"
+            curl -fsSL "$BASE_URL/api/health" >/dev/null
+            curl -fsSL "$BASE_URL/" >/dev/null
+
+      - name: Auto-rollback on failure (previous tag)
+        if: failure() && steps.tags.outputs.prev_tag != ''
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd "${{ secrets.PROD_APP_DIR }}"
+            export APP_VERSION="${{ steps.tags.outputs.prev_tag }}"
+            export IMAGE_REGISTRY="${{ secrets.IMAGE_REGISTRY }}"
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml pull api worker web
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --remove-orphans
+
+      - name: Notify Slack (success)
+        if: success() && secrets.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@v1.27.1
+        with:
+          payload: |
+            {"text":"✅ Prod deploy succeeded: ${{ github.repository }} @ ${{ steps.tags.outputs.tag }}"}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack (failure)
+        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
+        uses: slackapi/slack-github-action@v1.27.1
+        with:
+          payload: |
+            {"text":"❌ Prod deploy failed: ${{ github.repository }} @ ${{ steps.tags.outputs.tag }}"}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,20 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 3 * * 0" # weekly (Sun) 03:00 UTC
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks
+        uses: zricethezav/gitleaks-action@v2
+        with:
+          config-path: .gitleaks.toml
+

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+title = "BrandBlitz gitleaks config"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "stellar-secret-key"
+description = "Stellar secret key (S...)"
+regex = '''\bS[ABCDEFGHIJKLMNOPQRSTUVWXYZ234567]{55}\b'''
+tags = ["stellar", "secret"]
+

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+pnpm -s gitleaks:pre-commit
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        args: ["detect", "--redact", "--config", ".gitleaks.toml"]
+

--- a/apps/api/src/db/queries/brands.ts
+++ b/apps/api/src/db/queries/brands.ts
@@ -12,6 +12,7 @@ export interface Brand {
   usp: string | null;
   product_image_1_url: string | null;
   product_image_2_url: string | null;
+  deleted_at?: string | null;
   created_at: string;
 }
 
@@ -40,14 +41,24 @@ export async function createBrand(data: Omit<Brand, "id" | "created_at">): Promi
 
 export async function getBrandsByOwner(ownerUserId: string): Promise<Brand[]> {
   const result = await query<Brand>(
-    "SELECT * FROM brands WHERE owner_user_id = $1 ORDER BY created_at DESC",
+    "SELECT * FROM brands WHERE owner_user_id = $1 AND deleted_at IS NULL ORDER BY created_at DESC",
     [ownerUserId]
   );
   return result.rows;
 }
 
 export async function getBrandById(id: string): Promise<Brand | null> {
-  const result = await query<Brand>("SELECT * FROM brands WHERE id = $1", [id]);
+  const result = await query<Brand>("SELECT * FROM brands WHERE id = $1 AND deleted_at IS NULL", [id]);
+  return result.rows[0] ?? null;
+}
+
+export async function getBrandMetaById(
+  id: string
+): Promise<Pick<Brand, "id" | "owner_user_id" | "deleted_at"> | null> {
+  const result = await query<Pick<Brand, "id" | "owner_user_id" | "deleted_at">>(
+    "SELECT id, owner_user_id, deleted_at FROM brands WHERE id = $1",
+    [id]
+  );
   return result.rows[0] ?? null;
 }
 
@@ -59,7 +70,7 @@ export async function getActiveDistractorBrands(excludeBrandId: string): Promise
   const result = await query<Brand>(
     `SELECT *
      FROM brands
-     WHERE id <> $1
+     WHERE id <> $1 AND deleted_at IS NULL
      ORDER BY created_at DESC
      LIMIT 20`,
     [excludeBrandId]
@@ -89,7 +100,7 @@ export async function updateBrand(
 
 export async function deleteBrand(id: string, ownerUserId: string): Promise<boolean> {
   const result = await query(
-    "DELETE FROM brands WHERE id = $1 AND owner_user_id = $2 RETURNING id",
+    "UPDATE brands SET deleted_at = NOW() WHERE id = $1 AND owner_user_id = $2 AND deleted_at IS NULL RETURNING id",
     [id, ownerUserId]
   );
   return (result.rowCount ?? 0) > 0;

--- a/apps/api/src/db/queries/leagues.ts
+++ b/apps/api/src/db/queries/leagues.ts
@@ -1,0 +1,235 @@
+import { query } from "../index";
+
+type LeagueTier = "bronze" | "silver" | "gold";
+
+export interface LeagueGroupRow {
+  user_id: string;
+  display_name: string;
+  avatar_url: string | null;
+  league: LeagueTier;
+  week_start: string;
+  group_id: number;
+  weekly_points: number;
+  rank_in_group: number | null;
+}
+
+export async function ensureAssignmentForUserThisWeek(
+  userId: string,
+  weekStart: string
+): Promise<{ league: LeagueTier; group_id: number }> {
+  const result = await query<{ league: LeagueTier; group_id: number }>(
+    `
+    WITH user_league AS (
+      SELECT COALESCE(league, 'bronze')::text AS league
+      FROM users
+      WHERE id = $1
+    ),
+    existing AS (
+      SELECT league, group_id
+      FROM league_assignments
+      WHERE user_id = $1 AND week_start = $2
+      LIMIT 1
+    ),
+    target_league AS (
+      SELECT league FROM existing
+      UNION ALL
+      SELECT league FROM user_league WHERE NOT EXISTS (SELECT 1 FROM existing)
+      LIMIT 1
+    ),
+    available_group AS (
+      SELECT la.group_id
+      FROM league_assignments la
+      WHERE la.week_start = $2 AND la.league = (SELECT league FROM target_league)
+      GROUP BY la.group_id
+      HAVING COUNT(*) < 30
+      ORDER BY la.group_id
+      LIMIT 1
+    ),
+    next_group AS (
+      SELECT COALESCE((SELECT group_id FROM available_group), COALESCE(MAX(group_id), 0) + 1) AS group_id
+      FROM league_assignments la
+      WHERE la.week_start = $2 AND la.league = (SELECT league FROM target_league)
+    ),
+    inserted AS (
+      INSERT INTO league_assignments (user_id, league, group_id, week_start)
+      SELECT $1, (SELECT league FROM target_league), (SELECT group_id FROM next_group), $2
+      WHERE NOT EXISTS (SELECT 1 FROM existing)
+      RETURNING league, group_id
+    )
+    SELECT league, group_id
+    FROM inserted
+    UNION ALL
+    SELECT league, group_id FROM existing
+    LIMIT 1
+    `,
+    [userId, weekStart]
+  );
+
+  return result.rows[0];
+}
+
+export async function getCurrentLeagueGroup(
+  userId: string,
+  weekStart: string
+): Promise<{ league: LeagueTier; group_id: number; group: LeagueGroupRow[] } | null> {
+  const me = await query<{ league: LeagueTier; group_id: number }>(
+    "SELECT league, group_id FROM league_assignments WHERE user_id = $1 AND week_start = $2",
+    [userId, weekStart]
+  );
+  const mine = me.rows[0];
+  if (!mine) return null;
+
+  const group = await query<LeagueGroupRow>(
+    `
+    WITH window AS (
+      SELECT $1::date AS start_date, ($1::date + INTERVAL '7 days') AS end_date
+    ),
+    sums AS (
+      SELECT
+        gs.user_id,
+        COALESCE(SUM(gs.total_score), 0)::bigint AS points
+      FROM game_sessions gs, window w
+      WHERE gs.status = 'completed'
+        AND gs.completed_at >= w.start_date
+        AND gs.completed_at < w.end_date
+      GROUP BY gs.user_id
+    ),
+    scoped AS (
+      SELECT
+        la.user_id,
+        la.league,
+        la.week_start,
+        la.group_id,
+        COALESCE(s.points, 0)::bigint AS weekly_points
+      FROM league_assignments la
+      LEFT JOIN sums s ON s.user_id = la.user_id
+      WHERE la.week_start = $1 AND la.league = $2 AND la.group_id = $3
+    )
+    SELECT
+      s.user_id,
+      u.display_name,
+      u.avatar_url,
+      s.league,
+      s.week_start,
+      s.group_id,
+      s.weekly_points,
+      ROW_NUMBER() OVER (ORDER BY s.weekly_points DESC, s.user_id ASC) AS rank_in_group
+    FROM scoped s
+    JOIN users u ON u.id = s.user_id
+    ORDER BY s.weekly_points DESC, s.user_id ASC
+    LIMIT 30
+    `,
+    [weekStart, mine.league, mine.group_id]
+  );
+
+  return { league: mine.league, group_id: mine.group_id, group: group.rows };
+}
+
+export async function recalculateWeeklyPoints(weekStart: string): Promise<void> {
+  await query(
+    `
+    WITH window AS (
+      SELECT $1::date AS start_date, ($1::date + INTERVAL '7 days') AS end_date
+    ),
+    sums AS (
+      SELECT
+        gs.user_id,
+        COALESCE(SUM(gs.total_score), 0)::bigint AS points
+      FROM game_sessions gs, window w
+      WHERE gs.status = 'completed'
+        AND gs.completed_at >= w.start_date
+        AND gs.completed_at < w.end_date
+      GROUP BY gs.user_id
+    )
+    UPDATE league_assignments la
+    SET weekly_points = COALESCE(s.points, 0)
+    FROM window w
+    LEFT JOIN sums s ON s.user_id = la.user_id
+    WHERE la.week_start = w.start_date
+    `,
+    [weekStart]
+  );
+}
+
+export async function rankAndFlagWeek(weekStart: string): Promise<void> {
+  await query(
+    `
+    WITH ranked AS (
+      SELECT
+        la.id,
+        la.league,
+        la.group_id,
+        la.week_start,
+        la.user_id,
+        la.weekly_points,
+        ROW_NUMBER() OVER (
+          PARTITION BY la.league, la.group_id
+          ORDER BY la.weekly_points DESC, la.user_id ASC
+        ) AS rnk,
+        COUNT(*) OVER (PARTITION BY la.league, la.group_id) AS grp_count
+      FROM league_assignments la
+      WHERE la.week_start = $1::date
+    )
+    UPDATE league_assignments la
+    SET
+      rank_in_group = r.rnk,
+      promoted = (r.league IN ('bronze', 'silver') AND r.rnk <= 3),
+      demoted  = (r.league IN ('silver', 'gold') AND r.rnk > GREATEST(r.grp_count - 3, 0))
+    FROM ranked r
+    WHERE la.id = r.id
+    `,
+    [weekStart]
+  );
+}
+
+export async function seedWeekAssignments(weekStart: string): Promise<void> {
+  await query(
+    `
+    WITH params AS (
+      SELECT $1::date AS week_start, ($1::date - INTERVAL '7 days')::date AS prev_week_start
+    ),
+    prev AS (
+      SELECT la.user_id, la.league, la.promoted, la.demoted
+      FROM league_assignments la
+      JOIN params p ON la.week_start = p.prev_week_start
+    ),
+    targets AS (
+      SELECT
+        u.id AS user_id,
+        CASE
+          WHEN p.user_id IS NULL THEN 'bronze'
+          WHEN p.promoted AND p.league = 'bronze' THEN 'silver'
+          WHEN p.promoted AND p.league = 'silver' THEN 'gold'
+          WHEN p.demoted AND p.league = 'gold' THEN 'silver'
+          WHEN p.demoted AND p.league = 'silver' THEN 'bronze'
+          ELSE p.league
+        END AS league
+      FROM users u
+      LEFT JOIN prev p ON p.user_id = u.id
+    ),
+    numbered AS (
+      SELECT
+        t.user_id,
+        t.league,
+        CEIL(ROW_NUMBER() OVER (PARTITION BY t.league ORDER BY t.user_id)::numeric / 30)::int AS group_id
+      FROM targets t
+    ),
+    inserted AS (
+      INSERT INTO league_assignments (user_id, league, group_id, week_start)
+      SELECT n.user_id, n.league, n.group_id, p.week_start
+      FROM numbered n, params p
+      WHERE NOT EXISTS (
+        SELECT 1 FROM league_assignments la
+        WHERE la.user_id = n.user_id AND la.week_start = p.week_start
+      )
+      RETURNING user_id, league
+    )
+    UPDATE users u
+    SET league = t.league
+    FROM targets t, params p
+    WHERE u.id = t.user_id
+      AND EXISTS (SELECT 1 FROM league_assignments la WHERE la.user_id = u.id AND la.week_start = p.week_start)
+    `,
+    [weekStart]
+  );
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,7 @@ import { apiLimiter } from "./middleware/rate-limit";
 import { connectDb, closeDb } from "./db";
 import { connectRedis, redis } from "./lib/redis";
 import { payoutQueue } from "./queues/payout.queue";
+import { leagueQueue } from "./queues/league.queue";
 import { logger } from "./lib/logger";
 import { config } from "./lib/config";
 
@@ -65,6 +66,7 @@ async function start(): Promise<void> {
     server.close(async () => {
       try {
         await payoutQueue.close();
+        await leagueQueue.close();
         await closeDb();
         await redis.disconnect();
         logger.info("Shutdown complete");

--- a/apps/api/src/lib/week.ts
+++ b/apps/api/src/lib/week.ts
@@ -1,0 +1,20 @@
+export function getUtcWeekStart(date = new Date()): string {
+  const utcYear = date.getUTCFullYear();
+  const utcMonth = date.getUTCMonth();
+  const utcDate = date.getUTCDate();
+
+  const d = new Date(Date.UTC(utcYear, utcMonth, utcDate, 0, 0, 0, 0));
+  const day = d.getUTCDay(); // 0 Sun ... 6 Sat
+  const diffToMonday = (day + 6) % 7; // Monday => 0
+  d.setUTCDate(d.getUTCDate() - diffToMonday);
+
+  return d.toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+export function addUtcDays(yyyyMmDd: string, days: number): string {
+  const [y, m, d] = yyyyMmDd.split("-").map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d, 0, 0, 0, 0));
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+

--- a/apps/api/src/queues/league.queue.ts
+++ b/apps/api/src/queues/league.queue.ts
@@ -1,0 +1,37 @@
+import { Queue, type JobsOptions } from "bullmq";
+import { redis } from "../lib/redis";
+
+export const leagueJobOptions = {
+  attempts: 2,
+  backoff: { type: "exponential", delay: 10_000 },
+  removeOnComplete: { count: 50 },
+  removeOnFail: { count: 50 },
+} satisfies JobsOptions;
+
+export const leagueQueue = new Queue("league", {
+  connection: redis,
+  defaultJobOptions: leagueJobOptions,
+});
+
+export async function ensureLeagueRepeatableJobs(): Promise<void> {
+  // Sunday 23:59 UTC — finalize week (rank + promoted/demoted flags)
+  await leagueQueue.add(
+    "finalize-week",
+    {},
+    {
+      jobId: "league:finalize-week",
+      repeat: { pattern: "59 23 * * 0", tz: "UTC" },
+    }
+  );
+
+  // Monday 00:00 UTC — seed new week assignments (new users => bronze)
+  await leagueQueue.add(
+    "start-week",
+    {},
+    {
+      jobId: "league:start-week",
+      repeat: { pattern: "0 0 * * 1", tz: "UTC" },
+    }
+  );
+}
+

--- a/apps/api/src/queues/processors/league.processor.ts
+++ b/apps/api/src/queues/processors/league.processor.ts
@@ -1,0 +1,34 @@
+import { Worker, type Job, type WorkerOptions } from "bullmq";
+import { redis } from "../../lib/redis";
+import { logger } from "../../lib/logger";
+import { addUtcDays, getUtcWeekStart } from "../../lib/week";
+import { rankAndFlagWeek, recalculateWeeklyPoints, seedWeekAssignments } from "../../db/queries/leagues";
+
+export function createLeagueWorker(WorkerCtor: typeof Worker = Worker, opts?: WorkerOptions) {
+  return new WorkerCtor(
+    "league",
+    async (job: Job) => {
+      if (job.name === "finalize-week") {
+        const weekStart = getUtcWeekStart(new Date());
+        logger.info("Finalizing league week", { weekStart, weekEndExclusive: addUtcDays(weekStart, 7) });
+        await recalculateWeeklyPoints(weekStart);
+        await rankAndFlagWeek(weekStart);
+        return;
+      }
+
+      if (job.name === "start-week") {
+        const weekStart = getUtcWeekStart(new Date());
+        logger.info("Seeding league week", { weekStart });
+        await seedWeekAssignments(weekStart);
+        return;
+      }
+
+      logger.warn("Unknown league job", { name: job.name, id: job.id });
+    },
+    {
+      connection: redis,
+      ...opts,
+    }
+  );
+}
+

--- a/apps/api/src/routes/brands.ts
+++ b/apps/api/src/routes/brands.ts
@@ -5,8 +5,10 @@ import {
   createBrand,
   getBrandsByOwner,
   getBrandById,
+  getBrandMetaById,
   getActiveDistractorBrands,
   updateBrand,
+  deleteBrand,
 } from "../db/queries/brands";
 import {
   createChallenge,
@@ -57,6 +59,21 @@ router.get("/:id", authenticate, async (req, res) => {
   if (!brand) throw createError("Brand not found", 404);
   if (brand.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
   res.json({ brand });
+});
+
+/**
+ * DELETE /brands/:id
+ * Soft-delete a brand kit (prevents new activity; existing challenges continue).
+ */
+router.delete("/:id", authenticate, async (req, res) => {
+  const meta = await getBrandMetaById(req.params.id);
+  if (!meta || meta.deleted_at) throw createError("Brand not found", 404);
+  if (meta.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
+
+  const deleted = await deleteBrand(req.params.id, req.user!.sub);
+  if (!deleted) throw createError("Brand not found", 404);
+
+  res.status(204).send();
 });
 
 /**

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -7,6 +7,7 @@ import uploadRoutes from "./upload";
 import usersRoutes from "./users";
 import leaderboardRoutes from "./leaderboard";
 import webhooksRoutes from "./webhooks";
+import leaguesRoutes from "./leagues";
 
 export function registerRoutes(app: Express): void {
   app.use("/auth", authRoutes);
@@ -17,4 +18,5 @@ export function registerRoutes(app: Express): void {
   app.use("/users", usersRoutes);
   app.use("/leaderboard", leaderboardRoutes);
   app.use("/webhooks", webhooksRoutes);
+  app.use("/leagues", leaguesRoutes);
 }

--- a/apps/api/src/routes/leagues.ts
+++ b/apps/api/src/routes/leagues.ts
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/authenticate";
+import { createError } from "../middleware/error";
+import { addUtcDays, getUtcWeekStart } from "../lib/week";
+import { ensureAssignmentForUserThisWeek, getCurrentLeagueGroup } from "../db/queries/leagues";
+
+const router = Router();
+
+/**
+ * GET /leagues/current
+ * Returns the caller's current league + their 30-player group with points.
+ */
+router.get("/current", authenticate, async (req, res) => {
+  const weekStart = getUtcWeekStart(new Date());
+
+  await ensureAssignmentForUserThisWeek(req.user!.sub, weekStart);
+  const current = await getCurrentLeagueGroup(req.user!.sub, weekStart);
+  if (!current) throw createError("League not found", 404);
+
+  res.json({
+    weekStart,
+    weekEndExclusive: addUtcDays(weekStart, 7),
+    league: current.league,
+    groupId: current.group_id,
+    group: current.group,
+  });
+});
+
+export default router;
+

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -2,6 +2,8 @@ import "dotenv/config";
 import { connectDb, closeDb } from "./db";
 import { connectRedis, redis } from "./lib/redis";
 import { createPayoutWorker } from "./queues/processors/payout.processor";
+import { createLeagueWorker } from "./queues/processors/league.processor";
+import { ensureLeagueRepeatableJobs } from "./queues/league.queue";
 import { logger } from "./lib/logger";
 
 async function startWorker(): Promise<void> {
@@ -9,11 +11,14 @@ async function startWorker(): Promise<void> {
   await connectRedis();
 
   const payoutWorker = createPayoutWorker();
-  logger.info("BullMQ worker started — processing payout jobs");
+  const leagueWorker = createLeagueWorker();
+  await ensureLeagueRepeatableJobs();
+  logger.info("BullMQ worker started — processing payout + league jobs");
 
   const shutdown = async (signal: string) => {
     logger.info(`${signal} received — closing worker`);
     await payoutWorker.close();
+    await leagueWorker.close();
     await closeDb();
     await redis.disconnect();
     logger.info("Worker shutdown complete");

--- a/apps/web/src/app/(brand)/dashboard/page.tsx
+++ b/apps/web/src/app/(brand)/dashboard/page.tsx
@@ -31,6 +31,7 @@ export default function DashboardPage() {
   const router = useRouter();
   const [brands, setBrands] = useState<BrandWithChallenges[]>([]);
   const [loading, setLoading] = useState(true);
+  const [deletingBrandId, setDeletingBrandId] = useState<string | null>(null);
 
   useEffect(() => {
     if (status === "unauthenticated") {
@@ -46,6 +47,23 @@ export default function DashboardPage() {
       .catch(() => setBrands([]))
       .finally(() => setLoading(false));
   }, [session, status, router]);
+
+  async function handleDeleteBrand(brand: BrandWithChallenges) {
+    if (deletingBrandId) return;
+    const ok = window.confirm(`Delete "${brand.name}"? This can’t be undone.`);
+    if (!ok) return;
+
+    setDeletingBrandId(brand.id);
+    try {
+      const api = createApiClient((session as any).apiToken);
+      await api.delete(`/brands/${brand.id}`);
+      setBrands((prev) => prev.filter((b) => b.id !== brand.id));
+    } catch {
+      // Best-effort UI: keep state if request fails.
+    } finally {
+      setDeletingBrandId(null);
+    }
+  }
 
   if (loading) {
     return (
@@ -113,6 +131,14 @@ export default function DashboardPage() {
                     <Link href={`/brand/${brand.id}/challenge/new`}>
                       <Button size="sm">Launch Challenge</Button>
                     </Link>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={deletingBrandId === brand.id}
+                      onClick={() => handleDeleteBrand(brand)}
+                    >
+                      {deletingBrandId === brand.id ? "Deleting..." : "Delete"}
+                    </Button>
                   </div>
                 </div>
               </CardHeader>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     restart: on-failure
 
   api:
+    image: ${IMAGE_REGISTRY:-ghcr.io/privexlabs}/brandblitz-api:${APP_VERSION:-dev}
     build:
       context: .
       dockerfile: apps/api/Dockerfile
@@ -98,6 +99,7 @@ services:
         condition: service_healthy
 
   worker:
+    image: ${IMAGE_REGISTRY:-ghcr.io/privexlabs}/brandblitz-worker:${APP_VERSION:-dev}
     build:
       context: .
       dockerfile: apps/api/Dockerfile
@@ -127,6 +129,7 @@ services:
         condition: service_healthy
 
   web:
+    image: ${IMAGE_REGISTRY:-ghcr.io/privexlabs}/brandblitz-web:${APP_VERSION:-dev}
     build:
       context: .
       dockerfile: apps/web/Dockerfile

--- a/docs/runbooks/leaked-secret.md
+++ b/docs/runbooks/leaked-secret.md
@@ -1,0 +1,47 @@
+# Leaked secret runbook
+
+This runbook covers what to do if a secret is accidentally committed and detected by Gitleaks (locally or in CI).
+
+## 1) Contain
+
+1. **Assume compromise**. Disable the secret immediately (rotate/revoke) before doing anything else.
+2. **Identify scope**: where the secret is used (API, worker, CI, web), and who has access to the affected system.
+3. **Check blast radius**: look for suspicious usage in provider logs (Stellar, Google, Twilio, etc.).
+
+## 2) Rotate / revoke
+
+### Stellar hot wallet secret
+
+1. Generate a new keypair.
+2. Update the runtime secret store / environment (e.g. `HOT_WALLET_SECRET` + `HOT_WALLET_PUBLIC_KEY`).
+3. If the old key was funded, move funds to the new account.
+4. Update any allow-lists or monitoring that reference the old address.
+
+### Google OAuth client secret
+
+1. Rotate the OAuth client secret in Google Cloud Console.
+2. Update `GOOGLE_CLIENT_SECRET` in the environment/secret manager.
+3. Validate login flow in staging, then production.
+
+### Twilio tokens / Verify service
+
+1. Rotate `TWILIO_AUTH_TOKEN` and any API keys in Twilio Console.
+2. Update the runtime secret store / environment.
+3. Validate SMS verification flow.
+
+## 3) Remove from Git history (if required)
+
+Even if you delete the secret from the latest commit, it may still exist in Git history.
+
+1. Remove the secret from the codebase.
+2. Use a history rewriting tool (e.g. `git filter-repo`) to purge the secret from all commits.
+3. Force-push rewritten history and coordinate with all contributors (they must re-clone or hard reset).
+
+If the repo is public, assume the secret was copied already and keep it rotated regardless.
+
+## 4) Post-incident
+
+1. Add/adjust detection rules in `.gitleaks.toml` to prevent recurrence.
+2. Review where secrets are stored and ensure all secrets come from the secret manager / environment variables.
+3. Add a short incident note in internal tracking (what leaked, when rotated, impact).
+

--- a/init.sql
+++ b/init.sql
@@ -56,11 +56,13 @@ CREATE TABLE brands (
   product_image_2_url TEXT,
   primary_color       TEXT DEFAULT '#6366f1',
   secondary_color     TEXT DEFAULT '#a5b4fc',
+  deleted_at          TIMESTAMPTZ,
   created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX idx_brands_owner_user_id ON brands (owner_user_id);
+CREATE INDEX idx_brands_deleted_at    ON brands (deleted_at);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- CHALLENGES
@@ -209,12 +211,16 @@ CREATE TABLE league_assignments (
   id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   league       TEXT NOT NULL CHECK (league IN ('bronze', 'silver', 'gold')),
+  group_id     INTEGER NOT NULL,
   week_start   DATE NOT NULL,
-  score        BIGINT NOT NULL DEFAULT 0,
+  weekly_points BIGINT NOT NULL DEFAULT 0,
+  rank_in_group INTEGER,
+  promoted    BOOLEAN NOT NULL DEFAULT FALSE,
+  demoted     BOOLEAN NOT NULL DEFAULT FALSE,
   UNIQUE (user_id, week_start)
 );
 
-CREATE INDEX idx_league_assignments_week ON league_assignments (week_start, league, score DESC);
+CREATE INDEX idx_league_assignments_week ON league_assignments (week_start, league, group_id, weekly_points DESC);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- USER BADGES

--- a/migrations/004_add_brands_deleted_at.sql
+++ b/migrations/004_add_brands_deleted_at.sql
@@ -1,0 +1,5 @@
+ALTER TABLE brands
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_brands_deleted_at ON brands (deleted_at);
+

--- a/migrations/005_league_assignments.sql
+++ b/migrations/005_league_assignments.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS league_assignments (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  league        TEXT NOT NULL CHECK (league IN ('bronze', 'silver', 'gold')),
+  group_id      INTEGER NOT NULL,
+  week_start    DATE NOT NULL,
+  weekly_points BIGINT NOT NULL DEFAULT 0,
+  rank_in_group INTEGER,
+  promoted      BOOLEAN NOT NULL DEFAULT FALSE,
+  demoted       BOOLEAN NOT NULL DEFAULT FALSE,
+  UNIQUE (user_id, week_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_league_assignments_week
+  ON league_assignments (week_start, league, group_id, weekly_points DESC);
+

--- a/package.json
+++ b/package.json
@@ -13,12 +13,16 @@
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "clean": "turbo run clean && rm -rf node_modules",
-    "format": "prettier --write \"**/*.{ts,tsx,json,md}\" --ignore-path .gitignore"
+    "format": "prettier --write \"**/*.{ts,tsx,json,md}\" --ignore-path .gitignore",
+    "prepare": "husky",
+    "gitleaks": "node scripts/gitleaks.mjs",
+    "gitleaks:pre-commit": "pnpm -s gitleaks detect --redact --config .gitleaks.toml"
   },
   "devDependencies": {
     "@playwright/test": "1.51.1",
     "@vitest/coverage-v8": "4.1.2",
     "eslint": "10.1.0",
+    "husky": "9.1.7",
     "prettier": "3.8.1",
     "prettier-plugin-tailwindcss": "0.6.12",
     "turbo": "2.8.21",

--- a/scripts/gitleaks.mjs
+++ b/scripts/gitleaks.mjs
@@ -1,0 +1,94 @@
+import { createWriteStream, existsSync, mkdirSync } from "node:fs";
+import { chmod, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const GITLEAKS_VERSION = "8.30.1";
+
+function getPlatformAsset() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === "linux" && arch === "x64") return `gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz`;
+  if (platform === "linux" && arch === "arm64") return `gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz`;
+  if (platform === "darwin" && arch === "x64") return `gitleaks_${GITLEAKS_VERSION}_darwin_x64.tar.gz`;
+  if (platform === "darwin" && arch === "arm64") return `gitleaks_${GITLEAKS_VERSION}_darwin_arm64.tar.gz`;
+  if (platform === "win32" && arch === "x64") return `gitleaks_${GITLEAKS_VERSION}_windows_x64.zip`;
+
+  throw new Error(`Unsupported platform/arch: ${platform}/${arch}`);
+}
+
+function getBinaryName() {
+  return process.platform === "win32" ? "gitleaks.exe" : "gitleaks";
+}
+
+function getCacheDir() {
+  return join(process.cwd(), ".cache", "tools", "gitleaks", `v${GITLEAKS_VERSION}`);
+}
+
+async function download(url, destPath) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to download ${url} (${res.status})`);
+  await pipeline(res.body, createWriteStream(destPath));
+}
+
+async function ensureGitleaksBinary() {
+  const cacheDir = getCacheDir();
+  const binaryPath = join(cacheDir, getBinaryName());
+
+  if (existsSync(binaryPath)) {
+    const s = await stat(binaryPath);
+    if (s.isFile() && s.size > 0) return binaryPath;
+  }
+
+  mkdirSync(cacheDir, { recursive: true });
+
+  const asset = getPlatformAsset();
+  const url = `https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}`;
+  const tempArchive = join(tmpdir(), `brandblitz-gitleaks-${Date.now()}-${asset}`);
+
+  await download(url, tempArchive);
+
+  if (asset.endsWith(".tar.gz")) {
+    await execFileAsync("tar", ["-xzf", tempArchive, "-C", cacheDir]);
+  } else if (asset.endsWith(".zip")) {
+    await execFileAsync("unzip", ["-o", tempArchive, "-d", cacheDir]);
+  } else {
+    throw new Error(`Unknown archive type for asset: ${asset}`);
+  }
+
+  if (!existsSync(binaryPath)) {
+    throw new Error(`Downloaded archive did not contain ${getBinaryName()} at expected path: ${binaryPath}`);
+  }
+
+  if (process.platform !== "win32") {
+    await chmod(binaryPath, 0o755);
+  }
+
+  return binaryPath;
+}
+
+async function main() {
+  const binary = await ensureGitleaksBinary();
+  const [, , cmd, ...args] = process.argv;
+
+  if (!cmd) {
+    console.error("Usage: pnpm gitleaks <command> [args...]");
+    process.exit(2);
+  }
+
+  const { spawn } = await import("node:child_process");
+  const child = spawn(binary, [cmd, ...args], { stdio: "inherit" });
+  child.on("exit", (code) => process.exit(code ?? 1));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
Closes #81
Closes #84
Closes #89
Closes #91

Implements:
- Tag-triggered prod deploy workflow with staging healthcheck, smoke checks, and rollback
- Gitleaks in CI + local pre-commit scanning
- Soft-delete brand kits via API + dashboard
- Minimal league assignments wiring + /leagues/current
