### PR TITLE
fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,12 @@ TWILIO_AUTH_TOKEN=your-twilio-auth-token
 TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 PHONE_HASH_SALT=replace_with_a_random_32_byte_secret
 
+# === Session Integrity ===
+# Used to HMAC-sign completed game sessions. Rotated independently from JWT_SECRET.
+# Required in production; payout job verifies this before broadcasting Stellar transactions.
+# Generate with: openssl rand -hex 32
+SESSION_INTEGRITY_KEY=replace-with-at-least-32-random-chars-openssl-rand-hex-32
+
 # === Logging ===
 # error, warn, info, http, verbose, debug, silly
 LOG_LEVEL=info

--- a/apps/api/src/db/queries/sessions.ts
+++ b/apps/api/src/db/queries/sessions.ts
@@ -9,13 +9,18 @@ export interface GameSession {
   warmup_completed_at: string | null;
   challenge_started_at: string | null;
   completed_at: string | null;
+  round_1_answer: string | null;
   round_1_score: number;
+  round_2_answer: string | null;
   round_2_score: number;
+  round_3_answer: string | null;
   round_3_score: number;
   total_score: number;
+  rank: number | null;
   flagged: boolean;
   flag_reasons: string[] | null;
   is_practice: boolean;
+  integrity_hmac: string | null;
   created_at: string;
 }
 
@@ -97,13 +102,15 @@ export async function markChallengeStarted(sessionId: string): Promise<void> {
 export async function recordRoundScore(
   sessionId: string,
   round: 1 | 2 | 3,
-  score: number
+  score: number,
+  answer: string | null = null
 ): Promise<void> {
   if (![1, 2, 3].includes(round)) {
     throw new Error("Invalid round");
   }
 
   const roundColumn = `round_${round}_score`;
+  const answerColumn = `round_${round}_answer`;
 
   await query(
     `WITH upserted AS (
@@ -115,9 +122,10 @@ export async function recordRoundScore(
        RETURNING session_id, score
      )
      UPDATE game_sessions
-     SET ${roundColumn} = (SELECT score FROM upserted)
+     SET ${roundColumn} = (SELECT score FROM upserted),
+         ${answerColumn} = $4
      WHERE id = $1`,
-    [sessionId, round, score]
+    [sessionId, round, score, answer]
   );
 }
 
@@ -136,6 +144,13 @@ export async function finishSession(sessionId: string): Promise<GameSession> {
     [sessionId]
   );
   return result.rows[0];
+}
+
+export async function storeSessionHmac(sessionId: string, hmac: string): Promise<void> {
+  await query(
+    "UPDATE game_sessions SET integrity_hmac = $1 WHERE id = $2",
+    [hmac, sessionId]
+  );
 }
 
 export async function flagSession(

--- a/apps/api/src/lib/config.ts
+++ b/apps/api/src/lib/config.ts
@@ -36,6 +36,9 @@ const configSchema = z.object({
 
   // Logging
   LOG_LEVEL: z.enum(["error", "warn", "info", "http", "verbose", "debug", "silly"]).default("info"),
+
+  // Session integrity — rotated independently of JWT_SECRET; optional for backwards compat
+  SESSION_INTEGRITY_KEY: z.string().min(32).optional(),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/apps/api/src/lib/fingerprint.ts
+++ b/apps/api/src/lib/fingerprint.ts
@@ -1,0 +1,20 @@
+import { createHash } from "crypto";
+
+export function computeFingerprint(params: {
+  visitorId: string | undefined;
+  deviceId: string | undefined;
+  ip: string | undefined;
+  userAgent: string | undefined;
+}): string {
+  const { visitorId, deviceId, ip, userAgent } = params;
+
+  // Combine both client-supplied IDs — rotating just one doesn't escape the fingerprint
+  const clientSig = `${visitorId ?? ""}|${deviceId ?? ""}`;
+  // 24-bit prefix collapses NAT siblings without exposing the full address
+  const ip24 = ip ? ip.split(".").slice(0, 3).join(".") : "";
+  const uaHash = createHash("sha256").update(userAgent ?? "").digest("hex").slice(0, 8);
+
+  return createHash("sha256")
+    .update(`${clientSig}:${ip24}:${uaHash}`)
+    .digest("hex");
+}

--- a/apps/api/src/lib/integrity.ts
+++ b/apps/api/src/lib/integrity.ts
@@ -1,0 +1,32 @@
+import { createHmac, timingSafeEqual } from "crypto";
+import { config } from "./config";
+
+export function computeSessionHmac(
+  sessionId: string,
+  totalScore: number,
+  completedAt: string
+): string {
+  if (!config.SESSION_INTEGRITY_KEY) return "";
+  return createHmac("sha256", config.SESSION_INTEGRITY_KEY)
+    .update(`${sessionId}:${totalScore}:${completedAt}`)
+    .digest("hex");
+}
+
+export function verifySessionHmac(
+  sessionId: string,
+  totalScore: number,
+  completedAt: string,
+  storedHmac: string | null | undefined
+): boolean {
+  if (!config.SESSION_INTEGRITY_KEY || !storedHmac) return true;
+  const expected = computeSessionHmac(sessionId, totalScore, completedAt);
+  if (!expected) return true;
+  try {
+    return timingSafeEqual(
+      Buffer.from(expected, "hex"),
+      Buffer.from(storedHmac, "hex")
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/api/src/lib/metrics.ts
+++ b/apps/api/src/lib/metrics.ts
@@ -1,0 +1,7 @@
+import { logger } from "./logger";
+
+export const metrics = {
+  inc(name: string, labels?: Record<string, unknown>): void {
+    logger.info("metric", { name, value: 1, ...labels });
+  },
+};

--- a/apps/api/src/middleware/anti-cheat.test.ts
+++ b/apps/api/src/middleware/anti-cheat.test.ts
@@ -1,14 +1,28 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { validateReactionTime, BOT_REACTION_THRESHOLD_MS, MIN_HUMAN_REACTION_MS } from "./anti-cheat";
+import { validateReactionTime, validateDeviceFingerprint, BOT_REACTION_THRESHOLD_MS, MIN_HUMAN_REACTION_MS } from "./anti-cheat";
 import * as fraudQueries from "../db/queries/fraud-flags";
 import { metrics } from "../lib/metrics";
 
 vi.mock("../db/queries/fraud-flags");
 vi.mock("../db/queries/sessions");
-vi.mock("../lib/redis");
+vi.mock("../lib/redis", () => ({
+  redis: {
+    sadd: vi.fn().mockResolvedValue(1),
+    expire: vi.fn().mockResolvedValue(1),
+    scard: vi.fn().mockResolvedValue(1),
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}));
 vi.mock("../lib/metrics", () => ({
   metrics: { inc: vi.fn() }
 }));
+vi.mock("../lib/fingerprint", () => ({
+  computeFingerprint: vi.fn().mockReturnValue("test-fingerprint-hash"),
+}));
+
+import { redis } from "../lib/redis";
+import { computeFingerprint } from "../lib/fingerprint";
 
 describe("anti-cheat middleware", () => {
   let req: any;
@@ -16,36 +30,43 @@ describe("anti-cheat middleware", () => {
   let next: any;
 
   beforeEach(() => {
-    req = { 
-      body: {}, 
-      user: { sub: "user-1" }, 
-      params: { challengeId: "challenge-1" }, 
-      headers: {},
-      sessionId: "session-1" 
+    req = {
+      body: {},
+      user: { sub: "user-1" },
+      params: { challengeId: "challenge-1" },
+      headers: {
+        "x-device-id": "device-abc",
+      },
+      ip: "1.2.3.4",
+      sessionId: "session-1"
     };
     res = {};
     next = vi.fn();
     vi.clearAllMocks();
+    (computeFingerprint as any).mockReturnValue("test-fingerprint-hash");
+    (redis.sadd as any).mockResolvedValue(1);
+    (redis.expire as any).mockResolvedValue(1);
+    (redis.scard as any).mockResolvedValue(1);
   });
 
   describe("validateReactionTime", () => {
     it("blocks with 403 if reaction time is below bot threshold", async () => {
       req.body.reactionTimeMs = BOT_REACTION_THRESHOLD_MS - 1;
-      
+
       await expect(validateReactionTime(req, res, next)).rejects.toMatchObject({
         statusCode: 403,
         code: "REACTION_IMPOSSIBLE"
       });
-      
+
       expect(fraudQueries.createFraudFlag).toHaveBeenCalled();
       expect(metrics.inc).toHaveBeenCalledWith("antiCheat.flags_total", expect.objectContaining({ severity: "critical" }));
     });
 
     it("flags but allows if reaction time is between bot and human minimum", async () => {
       req.body.reactionTimeMs = MIN_HUMAN_REACTION_MS - 10;
-      
+
       await validateReactionTime(req, res, next);
-      
+
       expect(next).toHaveBeenCalled();
       expect(fraudQueries.createFraudFlag).toHaveBeenCalled();
       expect(metrics.inc).toHaveBeenCalledWith("antiCheat.flags_total", expect.objectContaining({ severity: "warning" }));
@@ -53,12 +74,77 @@ describe("anti-cheat middleware", () => {
 
     it("flags with info severity if reaction time is above maximum", async () => {
       req.body.reactionTimeMs = 35000;
-      
+
       await validateReactionTime(req, res, next);
-      
+
       expect(next).toHaveBeenCalled();
       expect(fraudQueries.createFraudFlag).toHaveBeenCalled();
       expect(metrics.inc).toHaveBeenCalledWith("antiCheat.flags_total", expect.objectContaining({ severity: "info" }));
+    });
+  });
+
+  describe("validateDeviceFingerprint", () => {
+    it("rejects with 400 when neither x-device-id nor x-visitor-id is provided", async () => {
+      req.headers = {};
+
+      await expect(validateDeviceFingerprint(req, res, next)).rejects.toMatchObject({
+        statusCode: 400,
+        code: "MISSING_DEVICE_ID",
+      });
+    });
+
+    it("passes and calls next when fingerprint has <3 accounts", async () => {
+      (redis.scard as any).mockResolvedValue(2);
+
+      await validateDeviceFingerprint(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(metrics.inc).not.toHaveBeenCalledWith("antiCheat.fingerprint_collision_total", expect.anything());
+    });
+
+    it("rejects with 403 FINGERPRINT_COLLISION when fingerprint has >=3 accounts", async () => {
+      (redis.scard as any).mockResolvedValue(3);
+
+      await expect(validateDeviceFingerprint(req, res, next)).rejects.toMatchObject({
+        statusCode: 403,
+        code: "FINGERPRINT_COLLISION",
+      });
+
+      expect(metrics.inc).toHaveBeenCalledWith(
+        "antiCheat.fingerprint_collision_total",
+        expect.objectContaining({ fingerprint: expect.any(String) })
+      );
+    });
+
+    it("combines x-visitor-id and x-device-id in the fingerprint", async () => {
+      req.headers["x-visitor-id"] = "fp-visitor-id";
+      (redis.scard as any).mockResolvedValue(1);
+
+      await validateDeviceFingerprint(req, res, next);
+
+      expect(computeFingerprint).toHaveBeenCalledWith(
+        expect.objectContaining({
+          visitorId: "fp-visitor-id",
+          deviceId: "device-abc",
+        })
+      );
+    });
+
+    it("calls next without checking Redis when there is no authenticated user", async () => {
+      req.user = undefined;
+
+      await validateDeviceFingerprint(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(redis.sadd).not.toHaveBeenCalled();
+    });
+
+    it("fails open when Redis is unavailable", async () => {
+      (redis.sadd as any).mockRejectedValue(new Error("Redis down"));
+
+      await validateDeviceFingerprint(req, res, next);
+
+      expect(next).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/middleware/anti-cheat.ts
+++ b/apps/api/src/middleware/anti-cheat.ts
@@ -4,16 +4,12 @@ import { createFraudFlag } from "../db/queries/fraud-flags";
 import { getSession } from "../db/queries/sessions";
 import { logger } from "../lib/logger";
 import { metrics } from "../lib/metrics";
+import { computeFingerprint } from "../lib/fingerprint";
 import { createError } from "./error";
 
 export const BOT_REACTION_THRESHOLD_MS = 80;
 export const MIN_HUMAN_REACTION_MS = 150;
 export const MAX_HUMAN_REACTION_MS = 30_000;
-
-function getDeviceId(req: Request): string | undefined {
-  const rawHeader = req.headers["x-device-id"] ?? req.headers["x-visitor-id"];
-  return Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
-}
 
 async function resolveSessionId(req: Request): Promise<string | undefined> {
   const existingSessionId = (req as any).sessionId as string | undefined;
@@ -124,45 +120,66 @@ export async function enforceOneSessionPerChallenge(
 }
 
 /**
- * Anti-cheat Layer 2 — device fingerprint check.
- * Validates a stable device fingerprint header and flags shared-device abuse.
+ * Anti-cheat Layer 2 — stable device fingerprint check.
+ * Derives a server-side fingerprint from (visitorId | deviceId) + IP /24 + UA hash.
+ * Rejects sessions when the fingerprint is shared by >2 accounts in 24 h.
  */
 export async function validateDeviceFingerprint(
   req: Request,
   _res: Response,
   next: NextFunction
 ): Promise<void> {
-  const deviceId = getDeviceId(req);
-  const userId = req.user?.sub;
+  const rawVisitorId = req.headers["x-visitor-id"];
+  const rawDeviceId = req.headers["x-device-id"];
 
-  if (!deviceId) {
+  const visitorId = Array.isArray(rawVisitorId) ? rawVisitorId[0] : rawVisitorId;
+  const deviceId = Array.isArray(rawDeviceId) ? rawDeviceId[0] : rawDeviceId;
+
+  if (!visitorId && !deviceId) {
     throw createError("Missing X-Device-Id header", 400, "MISSING_DEVICE_ID");
   }
 
+  const userId = req.user?.sub;
   if (!userId) {
     next();
     return;
   }
 
   try {
-    // Check if this device is associated with too many accounts (>2 in 24h)
-    const deviceKey = `device:${deviceId}:accounts`;
-    await redis.sadd(deviceKey, userId);
-    await redis.expire(deviceKey, 86400); // 24h
-    const count = await redis.scard(deviceKey);
+    const fingerprint = computeFingerprint({
+      visitorId,
+      deviceId,
+      ip: req.ip,
+      userAgent: req.headers["user-agent"],
+    });
+
+    const fpKey = `fp:${fingerprint}:accounts`;
+    await redis.sadd(fpKey, userId);
+    await redis.expire(fpKey, 86400); // 24 h window
+    const count = await redis.scard(fpKey);
 
     if (count >= 3) {
-      await recordFraudFlag(req, "multi_account_device", {
-        deviceId,
+      metrics.inc("antiCheat.fingerprint_collision_total", {
+        fingerprint: fingerprint.slice(0, 8),
+      });
+      await recordFraudFlag(req, "multi_account_fingerprint", {
+        fingerprint: fingerprint.slice(0, 8),
         accountCount: count,
         windowSeconds: 86400,
-        severity: "warning",
+        severity: "critical",
       }).catch(() => {});
+      throw createError(
+        "Session rejected due to fingerprint collision",
+        403,
+        "FINGERPRINT_COLLISION"
+      );
     }
   } catch (error) {
+    if ((error as { statusCode?: number }).statusCode) {
+      throw error;
+    }
     logger.warn("Redis unavailable during device fingerprint validation; failing open", {
       userId,
-      deviceId,
       error: (error as Error).message,
     });
   }

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -29,6 +29,9 @@ vi.mock("../middleware/anti-cheat", () => ({
 vi.mock("../middleware/rate-limit", () => ({
   challengeStartLimiter: (req: any, res: any, next: any) => next(),
 }));
+vi.mock("../lib/integrity", () => ({
+  computeSessionHmac: vi.fn().mockReturnValue("test-hmac"),
+}));
 
 import * as challengeQueries from "../db/queries/challenges";
 import * as sessionQueries from "../db/queries/sessions";
@@ -136,7 +139,7 @@ describe("Sessions API", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.score).toBe(100);
-      expect(sessionQueries.recordRoundScore).toHaveBeenCalledWith("s1", 1, 100);
+      expect(sessionQueries.recordRoundScore).toHaveBeenCalledWith("s1", 1, 100, "A");
     });
 
     it("should accept timeout answer and score 0", async () => {
@@ -158,7 +161,7 @@ describe("Sessions API", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.score).toBe(0);
-      expect(sessionQueries.recordRoundScore).toHaveBeenCalledWith("s1", 1, 0);
+      expect(sessionQueries.recordRoundScore).toHaveBeenCalledWith("s1", 1, 0, null);
       expect(scoringService.calculateRoundScore).toHaveBeenCalledWith({
         selectedOption: null,
         correctOption: "A",
@@ -166,7 +169,7 @@ describe("Sessions API", () => {
       });
     });
 
-    it("should finalize session on round 3", async () => {
+    it("should finalize session on round 3 and store HMAC", async () => {
       (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
       (sessionQueries.getSession as any).mockResolvedValue({
         id: "s1",
@@ -176,6 +179,11 @@ describe("Sessions API", () => {
       (challengeQueries.getChallengeQuestions as any).mockResolvedValue([
         { round: 3, correct_option: "B" },
       ]);
+      (sessionQueries.finishSession as any).mockResolvedValue({
+        id: "s1",
+        total_score: 300,
+        completed_at: new Date().toISOString(),
+      });
 
       const res = await request(app)
         .post("/sessions/c1/answer/3")
@@ -183,9 +191,10 @@ describe("Sessions API", () => {
 
       expect(res.status).toBe(200);
       expect(sessionQueries.finishSession).toHaveBeenCalledWith("s1");
+      expect(sessionQueries.storeSessionHmac).toHaveBeenCalledWith("s1", "test-hmac");
     });
 
-    it("should 409 if session already completed", async () => {
+    it("should 409 if session already completed on round 1", async () => {
       (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
       (sessionQueries.getSession as any).mockResolvedValue({
         id: "s1",
@@ -199,6 +208,58 @@ describe("Sessions API", () => {
         .send({ selectedOption: "A", reactionTimeMs: 500 });
 
       expect(res.status).toBe(409);
+    });
+
+    it("should return 200 with cached result on idempotent round-3 replay", async () => {
+      (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
+      (sessionQueries.getSession as any).mockResolvedValue({
+        id: "s1",
+        user_id: "user123",
+        challenge_started_at: new Date(),
+        completed_at: new Date(),
+        round_3_answer: "A",
+        round_3_score: 100,
+        total_score: 300,
+        rank: 2,
+      });
+      (challengeQueries.getChallengeQuestions as any).mockResolvedValue([
+        { round: 3, correct_option: "A" },
+      ]);
+      (scoringService.validateAnswer as any).mockReturnValue(true);
+
+      const res = await request(app)
+        .post("/sessions/c1/answer/3")
+        .send({ selectedOption: "A", reactionTimeMs: 500 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.score).toBe(100);
+      expect(res.body.total_score).toBe(300);
+      expect(res.body.rank).toBe(2);
+      expect(sessionQueries.recordRoundScore).not.toHaveBeenCalled();
+      expect(sessionQueries.finishSession).not.toHaveBeenCalled();
+    });
+
+    it("should return 409 CONFLICT_REPLAY when round-3 replay has a different answer", async () => {
+      (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
+      (sessionQueries.getSession as any).mockResolvedValue({
+        id: "s1",
+        user_id: "user123",
+        challenge_started_at: new Date(),
+        completed_at: new Date(),
+        round_3_answer: "A",
+        round_3_score: 100,
+        total_score: 300,
+      });
+      (challengeQueries.getChallengeQuestions as any).mockResolvedValue([
+        { round: 3, correct_option: "A" },
+      ]);
+
+      const res = await request(app)
+        .post("/sessions/c1/answer/3")
+        .send({ selectedOption: "B", reactionTimeMs: 500 });
+
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe("CONFLICT_REPLAY");
     });
 
     it("should 403 if session is flagged", async () => {

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -9,6 +9,7 @@ import {
   markChallengeStarted,
   recordRoundScore,
   finishSession,
+  storeSessionHmac,
 } from "../db/queries/sessions";
 import { calculateRoundScore, validateAnswer } from "../services/scoring";
 import { authenticate } from "../middleware/authenticate";
@@ -20,6 +21,7 @@ import {
 import { createError } from "../middleware/error";
 import { challengeStartLimiter } from "../middleware/rate-limit";
 import { redis } from "../lib/redis";
+import { computeSessionHmac } from "../lib/integrity";
 import { WARMUP_MIN_SECONDS } from "@brandblitz/stellar";
 
 const router = Router();
@@ -130,6 +132,7 @@ router.post(
  * POST /sessions/:challengeId/answer/:round
  * Submit an answer for a round. Validates + scores server-side.
  * Correct answers are NEVER sent to the client.
+ * Round-3 is idempotent: duplicate requests return the cached result.
  */
 router.post(
   "/:challengeId/answer/:round",
@@ -148,12 +151,14 @@ router.post(
     if (session.user_id !== req.user!.sub) throw createError("Forbidden", 403);
     if (!session.challenge_started_at) throw createError("Challenge not started", 400);
 
-    // Edge Cases
-    if (session.completed_at) throw createError("Session already completed", 409);
+    // For non-round-3, a completed session is always a hard stop
+    if (session.completed_at && round !== 3) {
+      throw createError("Session already completed", 409);
+    }
     if (session.is_flagged) throw createError("Session flagged for review", 403);
-    
+
     // Double answer check
-    const existingScores = (session as any).scores || []; // Assume scores are joined or we need to check DB
+    const existingScores = (session as any).scores || [];
     if (existingScores.some((s: any) => s.round === round)) {
       throw createError("Round already answered", 400);
     }
@@ -163,17 +168,41 @@ router.post(
     const question = questions.find((q) => q.round === round);
     if (!question) throw createError("Question not found", 404);
 
+    // Idempotent round-3 replay: return cached result if answer matches; reject if it differs
+    if (session.completed_at && round === 3) {
+      if (session.round_3_answer !== body.selectedOption) {
+        throw createError("Answer conflict detected", 409, "CONFLICT_REPLAY");
+      }
+      return res.json({
+        correct: validateAnswer(question, body.selectedOption),
+        score: session.round_3_score,
+        round: 3,
+        total_score: session.total_score,
+        rank: session.rank ?? null,
+      });
+    }
+
     const score = calculateRoundScore({
       selectedOption: body.selectedOption,
       correctOption: question.correct_option,
       reactionTimeMs: body.reactionTimeMs,
     });
 
-    await recordRoundScore(session.id, round, score);
+    await recordRoundScore(session.id, round, score, body.selectedOption);
 
-    // On last round — finalize the session
+    // On last round — finalize the session and stamp an integrity HMAC
     if (round === 3) {
-      await finishSession(session.id);
+      const completed = await finishSession(session.id);
+      if (completed) {
+        const hmac = computeSessionHmac(
+          completed.id,
+          completed.total_score,
+          completed.completed_at!
+        );
+        if (hmac) {
+          await storeSessionHmac(session.id, hmac);
+        }
+      }
     }
 
     res.json({

--- a/apps/api/src/services/payout.test.ts
+++ b/apps/api/src/services/payout.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   submitBatchPayout: vi.fn(),
   queueAdd: vi.fn(),
   emitCounterMetric: vi.fn(),
+  verifySessionHmac: vi.fn().mockReturnValue(true),
+  metricsInc: vi.fn(),
   logger: {
     info: vi.fn(),
     warn: vi.fn(),
@@ -59,6 +61,14 @@ vi.mock("../lib/logger", () => ({
   logger: mocks.logger,
 }));
 
+vi.mock("../lib/integrity", () => ({
+  verifySessionHmac: mocks.verifySessionHmac,
+}));
+
+vi.mock("../lib/metrics", () => ({
+  metrics: { inc: mocks.metricsInc },
+}));
+
 import { processPayout } from "./payout";
 
 // ── Fixtures ───────────────────────────────────────────────────────────────────
@@ -89,16 +99,24 @@ function buildLeaderboardSession(
     warmup_completed_at: null,
     challenge_started_at: null,
     completed_at: "2026-04-24T10:30:00.000Z",
+    round_1_answer: null,
     round_1_score: 100,
+    round_2_answer: null,
     round_2_score: 100,
+    round_3_answer: null,
     round_3_score: 100,
     total_score: 300,
+    rank: null,
     flagged: false,
     flag_reasons: null,
     is_practice: false,
+    integrity_hmac: "valid-hmac",
     created_at: "2026-04-24T10:00:00.000Z",
     username: "player@example.com",
     avatar_url: "https://example.com/avatar.png",
+    display_name: "Player One",
+    league: null,
+    total_earned_usdc: "0.0000000",
     stellar_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
     ...overrides,
   };
@@ -113,6 +131,7 @@ describe("processPayout", () => {
     process.env.HOT_WALLET_SECRET = "SBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
     process.env.STELLAR_NETWORK = "testnet";
 
+    mocks.verifySessionHmac.mockReturnValue(true);
     mocks.getChallengeById.mockResolvedValue(challengeFixture);
     mocks.createPayout.mockImplementation(async ({ userId }: { userId: string }) => ({
       id: `payout-${userId}`,
@@ -271,5 +290,46 @@ describe("processPayout", () => {
       "testnet",
       expect.any(Object)
     );
+  });
+
+  it("aborts payout and logs critical error when a session integrity HMAC does not match", async () => {
+    mocks.getChallengeById.mockResolvedValue({ ...challengeFixture, id: "challenge-6" });
+    mocks.getLeaderboard.mockResolvedValue([
+      buildLeaderboardSession({
+        id: "session-tampered",
+        user_id: "user-1",
+        total_score: 999,
+        integrity_hmac: "invalid-hmac",
+        stellar_address: "GUSER1",
+      }),
+    ]);
+    mocks.verifySessionHmac.mockReturnValue(false);
+
+    await expect(processPayout("challenge-6")).rejects.toThrow("session-tampered");
+
+    expect(mocks.submitBatchPayout).not.toHaveBeenCalled();
+    expect(mocks.metricsInc).toHaveBeenCalledWith("antiCheat.integrity_hmac_tampered_total");
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      "Session integrity check failed — payout aborted",
+      expect.objectContaining({ sessionId: "session-tampered" })
+    );
+  });
+
+  it("proceeds normally when all sessions pass integrity verification", async () => {
+    mocks.getLeaderboard.mockResolvedValue([
+      buildLeaderboardSession({
+        id: "session-ok",
+        user_id: "user-1",
+        total_score: 300,
+        integrity_hmac: "valid-hmac",
+        stellar_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      }),
+    ]);
+    mocks.verifySessionHmac.mockReturnValue(true);
+
+    await processPayout("challenge-1");
+
+    expect(mocks.submitBatchPayout).toHaveBeenCalledTimes(1);
+    expect(mocks.metricsInc).not.toHaveBeenCalledWith("antiCheat.integrity_hmac_tampered_total");
   });
 });

--- a/apps/api/src/services/payout.ts
+++ b/apps/api/src/services/payout.ts
@@ -6,7 +6,10 @@ import { createPayout, updatePayoutStatus } from "../db/queries/payouts";
 import { calculatePayoutShare, rankWinners } from "./scoring";
 import { payoutJobOptions, payoutQueue } from "../queues/payout.queue";
 import { logger } from "../lib/logger";
+import { metrics } from "../lib/metrics";
 import { config } from "../lib/config";
+import { stellarSequenceStore } from "../lib/redis";
+import { verifySessionHmac } from "../lib/integrity";
 
 /**
  * Enqueue a payout job for a completed challenge.
@@ -34,6 +37,25 @@ export async function processPayout(challengeId: string): Promise<void> {
   }
 
   const sessions = await getLeaderboard(challengeId, 1000); // all ranked sessions
+
+  // Verify session integrity before any payout; abort if any record was tampered with
+  for (const session of sessions) {
+    if (!verifySessionHmac(
+      session.id,
+      session.total_score,
+      session.completed_at ?? "",
+      session.integrity_hmac
+    )) {
+      metrics.inc("antiCheat.integrity_hmac_tampered_total");
+      logger.error("Session integrity check failed — payout aborted", {
+        challengeId,
+        sessionId: session.id,
+        userId: session.user_id,
+      });
+      throw new Error(`Session ${session.id} failed integrity check`);
+    }
+  }
+
   if (sessions.length === 0) {
     await updateChallengeStatus(challengeId, "settled");
     return;
@@ -99,7 +121,8 @@ export async function processPayout(challengeId: string): Promise<void> {
     recipients,
     config.HOT_WALLET_SECRET,
     challengeId,
-    network
+    network,
+    { sequenceStore: stellarSequenceStore }
   );
 
   const txHashes: string[] = [];

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { createApiClient } from "./api";
+
+describe("createApiClient", () => {
+  it("sets withCredentials to true so cookies are sent on cross-origin requests", () => {
+    const client = createApiClient();
+    expect(client.defaults.withCredentials).toBe(true);
+  });
+
+  it("sets withCredentials to true even when a bearer token is provided", () => {
+    const client = createApiClient("test-token");
+    expect(client.defaults.withCredentials).toBe(true);
+  });
+
+  it("includes the Authorization header when a token is provided", () => {
+    const client = createApiClient("my-jwt");
+    expect(client.defaults.headers.Authorization).toBe("Bearer my-jwt");
+  });
+
+  it("does not include an Authorization header when no token is provided", () => {
+    const client = createApiClient();
+    expect(client.defaults.headers.Authorization).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -6,6 +6,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost/api";
 export function createApiClient(token?: string): AxiosInstance {
   return axios.create({
     baseURL: BASE_URL,
+    withCredentials: true,
     headers: token ? { Authorization: `Bearer ${token}` } : {},
     timeout: 10_000,
   });

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,0 +1,30 @@
+# API Authentication
+
+BrandBlitz supports two parallel authentication mechanisms. Both are accepted simultaneously so clients can migrate gradually.
+
+## Bearer Token (current default)
+
+A short-lived JWT is issued at login and sent as an `Authorization: Bearer <token>` header on every request. The API validates it via the `authenticate` middleware.
+
+## Cookie / Session (httpOnly)
+
+The API enables `cors({ credentials: true })` and is scoped to the specific dashboard origin (`WEB_URL` env var — never a wildcard). The frontend axios client sets `withCredentials: true` so the browser attaches cookies automatically.
+
+This means:
+- An `httpOnly` session cookie set by a future `/auth/session` endpoint will travel with every cross-origin request.
+- The CORS policy rejects requests from unlisted origins even with credentials.
+
+### Why both?
+
+| Mechanism | Benefit |
+|---|---|
+| Bearer token | Stateless; easy to use from native apps and CLIs |
+| httpOnly cookie | Not accessible to JavaScript; resistant to XSS token theft |
+
+### Required API server config
+
+```
+WEB_URL=https://app.brandblitz.io   # must NOT be *
+```
+
+The browser will refuse to send credentials to a wildcard origin, so `WEB_URL` must always be a specific origin.

--- a/migrations/008_session_integrity_hmac.sql
+++ b/migrations/008_session_integrity_hmac.sql
@@ -1,0 +1,5 @@
+-- Add integrity HMAC column to game_sessions for tamper detection.
+-- The HMAC covers (session_id, total_score, completed_at) keyed by SESSION_INTEGRITY_KEY.
+-- Payout job verifies this before broadcasting Stellar transactions.
+ALTER TABLE game_sessions
+  ADD COLUMN IF NOT EXISTS integrity_hmac TEXT;


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2><p>Resolves four security and reliability issues across the BrandBlitz API and frontend (Stellar Wave #4).</p><h3>Closes</h3><p>Closes #187<br>Closes #189<br>Closes #190<br>Closes #191</p><hr><h2>Changes</h2><h3>#187 — Device fingerprint trusts client-supplied <code inline="">X-Device-Id</code></h3><ul><li><p><strong>New</strong> <code inline="">apps/api/src/lib/fingerprint.ts</code> — <code inline="">computeFingerprint()</code> hashes <code inline="">(visitorId | X-Device-Id) : ip_24bit_prefix : ua_hash</code> using SHA-256 so rotating a single header no longer evades detection.</p></li><li><p><strong>New</strong> <code inline="">apps/api/src/lib/metrics.ts</code> — creates the <code inline="">metrics.inc()</code> module (was imported but missing).</p></li><li><p>Updated <code inline="">validateDeviceFingerprint</code> in <code inline="">anti-cheat.ts</code> to derive the stable server-side fingerprint instead of using the raw header as the Redis key.</p></li><li><p>Sessions where the fingerprint is shared by ≥ 3 accounts in 24 h are now <strong>rejected</strong> (HTTP 403 <code inline="">FINGERPRINT_COLLISION</code>) rather than silently flagged.</p></li><li><p>Emits <code inline="">antiCheat.fingerprint_collision_total</code> metric on collision.</p></li><li><p>Tests added for rejection, metric emission, <code inline="">x-visitor-id</code> / <code inline="">x-device-id</code> combination, unauthenticated pass-through, and Redis-down fail-open.</p></li></ul><hr><h3>#189 — Completed sessions have no integrity signature</h3><ul><li><p><strong>New</strong> <code inline="">apps/api/src/lib/integrity.ts</code> — <code inline="">computeSessionHmac()</code> / <code inline="">verifySessionHmac()</code> using HMAC-SHA-256 over <code inline="">(session_id:total_score:completed_at)</code> keyed by <code inline="">SESSION_INTEGRITY_KEY</code> (timed-safe comparison).</p></li><li><p><strong>New</strong> <code inline="">migrations/008_session_integrity_hmac.sql</code> — <code inline="">ALTER TABLE game_sessions ADD COLUMN IF NOT EXISTS integrity_hmac TEXT</code>.</p></li><li><p><code inline="">SESSION_INTEGRITY_KEY</code> added to config (optional for backward compat; documented as required in production).</p></li><li><p>Session finalize (<code inline="">routes/sessions.ts</code>) now computes and stores the HMAC via <code inline="">storeSessionHmac()</code> after <code inline="">finishSession()</code>.</p></li><li><p><code inline="">processPayout</code> verifies every session's HMAC before building recipients; a mismatch throws, increments <code inline="">antiCheat.integrity_hmac_tampered_total</code>, and logs <code inline="">logger.error</code>.</p></li><li><p>Also passes <code inline="">stellarSequenceStore</code> as the 5th <code inline="">options</code> arg to <code inline="">submitBatchPayout</code> (was missing, now matches the existing test assertion).</p></li><li><p>Tests: tampered HMAC → payout aborts + metric; all-valid → payout proceeds.</p></li></ul><hr><h3>#190 — <code inline="">finishSession</code> is not idempotent — replays return 409</h3><ul><li><p><code inline="">recordRoundScore</code> now persists the player's <code inline="">selectedOption</code> into <code inline="">round_X_answer</code> columns (already in schema, never populated).</p></li><li><p>On a round-3 <code inline="">POST /sessions/:challengeId/answer/3</code> where <code inline="">session.completed_at</code> is set:</p><ul><li><p>Matching answer → <strong>200</strong> with cached <code inline="">score</code>, <code inline="">total_score</code>, <code inline="">rank</code>.</p></li><li><p>Differing answer → <strong>409</strong> with <code inline="">code: "CONFLICT_REPLAY"</code>.</p></li></ul></li><li><p>Non-round-3 replays still return <strong>409</strong> immediately (unchanged).</p></li><li><p>Tests: idempotent replay → 200, no duplicate DB write; conflicting replay → 409 <code inline="">CONFLICT_REPLAY</code>.</p></li></ul><hr><h3>#191 — API client doesn't send credentials despite CORS allowing them</h3><ul><li><p><code inline="">createApiClient</code> in <code inline="">apps/web/src/lib/api.ts</code> now sets <code inline="">withCredentials: true</code>.</p></li><li><p>API CORS already uses <code inline="">config.WEB_URL</code> (not <code inline="">*</code>), which is correct and left unchanged.</p></li><li><p><strong>New</strong> <code inline="">apps/web/src/lib/api.test.ts</code> — four Vitest tests asserting <code inline="">withCredentials</code>, bearer token, and no-token cases.</p></li><li><p><strong>New</strong> <code inline="">docs/api/auth.md</code> — documents the cookie / Bearer dual-auth strategy and the <code inline="">WEB_URL ≠ *</code> requirement.</p></li></ul><hr><h2>Files changed</h2>
File | Change
-- | --
apps/api/src/lib/fingerprint.ts | New
apps/api/src/lib/metrics.ts | New
apps/api/src/lib/integrity.ts | New
migrations/008_session_integrity_hmac.sql | New
docs/api/auth.md | New
apps/web/src/lib/api.test.ts | New
apps/api/src/lib/config.ts | Add SESSION_INTEGRITY_KEY
apps/api/src/middleware/anti-cheat.ts | Server-side fingerprint, reject on collision
apps/api/src/middleware/anti-cheat.test.ts | Tests for fingerprint path
apps/api/src/db/queries/sessions.ts | Add integrity_hmac, answer fields, storeSessionHmac, recordRoundScore answer param
apps/api/src/routes/sessions.ts | HMAC stamp on finalize; idempotent round-3 replay
apps/api/src/routes/sessions.test.ts | Tests for HMAC stamp, idempotent replay, CONFLICT_REPLAY
apps/api/src/services/payout.ts | HMAC verification before broadcast; pass stellarSequenceStore
apps/api/src/services/payout.test.ts | Tamper test; fixture updated
apps/web/src/lib/api.ts | withCredentials: true
.env.example | Document SESSION_INTEGRITY_KEY

<hr><h2>Closes</h2><p>Closes #187<br>Closes #189<br>Closes #190<br>Closes #191</p></body></html>