### PR TITLE
fix(api): harden security headers and CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ JWT_SECRET=super-secret-random-string-at-least-32-chars
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 WEB_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # NextAuth configuration
 NEXTAUTH_SECRET=same-as-jwt-secret-for-nextauth

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -136,6 +136,7 @@ The API listens on `PORT` (default `3001`). In the full Docker stack, Nginx prox
 | `TWILIO_AUTH_TOKEN` | No | Twilio auth token |
 | `TWILIO_VERIFY_SERVICE_SID` | No | Twilio Verify service SID |
 | `WEBHOOK_SECRET` | Yes | `X-Webhook-Secret` header value |
+| `NEXT_PUBLIC_APP_URL` | Yes | Frontend origin allowed by API CORS |
 | `NEXTAUTH_URL` | Yes | Frontend base URL (for CORS) |
 
 ---

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,7 +1,5 @@
 import "dotenv/config";
 import express from "express";
-import helmet from "helmet";
-import cors from "cors";
 import cookieParser from "cookie-parser";
 import { registerRoutes } from "./routes";
 import { errorHandler } from "./middleware/error";
@@ -12,19 +10,14 @@ import { payoutQueue } from "./queues/payout.queue";
 import { leagueQueue } from "./queues/league.queue";
 import { logger } from "./lib/logger";
 import { config } from "./lib/config";
+import { applySecurityMiddleware } from "./middleware/security";
 
 const app = express();
 const PORT = config.PORT;
 let isShuttingDown = false;
 
 // ── Security & Parsing ─────────────────────────────────────────────────────
-app.use(helmet());
-app.use(
-  cors({
-    origin: config.WEB_URL,
-    credentials: true,
-  })
-);
+applySecurityMiddleware(app, config);
 app.use(cookieParser());
 app.use(express.json({ limit: "1mb" }));
 app.use(express.urlencoded({ extended: true }));

--- a/apps/api/src/lib/config.ts
+++ b/apps/api/src/lib/config.ts
@@ -12,6 +12,7 @@ const configSchema = z.object({
   GOOGLE_CLIENT_ID: z.string().min(1),
   GOOGLE_CLIENT_SECRET: z.string().min(1),
   WEB_URL: z.string().url().default("http://localhost:3000"),
+  NEXT_PUBLIC_APP_URL: z.string().url().optional(),
 
   // Stellar
   STELLAR_NETWORK: z.enum(["testnet", "public"]).default("testnet"),

--- a/apps/api/src/middleware/security.test.ts
+++ b/apps/api/src/middleware/security.test.ts
@@ -1,0 +1,82 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { applySecurityMiddleware, type SecurityConfig } from "./security";
+
+const baseConfig = {
+  NODE_ENV: "production",
+  WEB_URL: "https://app.brandblitz.io",
+  NEXT_PUBLIC_APP_URL: "https://play.brandblitz.io",
+  S3_PUBLIC_URL: "https://cdn.brandblitz.io/assets",
+} satisfies SecurityConfig;
+
+function createApp(config: SecurityConfig = baseConfig) {
+  const app = express();
+  applySecurityMiddleware(app, config);
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+  return app;
+}
+
+describe("security middleware", () => {
+  it("sets strict security headers on API responses", async () => {
+    const response = await request(createApp())
+      .get("/health")
+      .set("Origin", "https://play.brandblitz.io")
+      .expect(200);
+
+    expect(response.headers["content-security-policy"]).toContain("default-src 'self'");
+    expect(response.headers["content-security-policy"]).toContain(
+      "connect-src 'self' https://api.stellar.expert https://cdn.brandblitz.io"
+    );
+    expect(response.headers["content-security-policy"]).toContain(
+      "img-src 'self' https://cdn.brandblitz.io"
+    );
+    expect(response.headers["x-frame-options"]).toBe("SAMEORIGIN");
+    expect(response.headers["x-content-type-options"]).toBe("nosniff");
+    expect(response.headers["strict-transport-security"]).toBe(
+      "max-age=31536000; includeSubDomains; preload"
+    );
+    expect(response.headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+    expect(response.headers["access-control-allow-origin"]).toBe("https://play.brandblitz.io");
+  });
+
+  it("does not emit CORS credentials headers for unapproved origins", async () => {
+    const response = await request(createApp())
+      .get("/health")
+      .set("Origin", "https://evil.example")
+      .expect(200);
+
+    expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+    expect(response.headers["access-control-allow-credentials"]).toBeUndefined();
+  });
+
+  it("falls back to WEB_URL when NEXT_PUBLIC_APP_URL is not configured", async () => {
+    const configWithoutAppUrl: SecurityConfig = {
+      NODE_ENV: baseConfig.NODE_ENV,
+      WEB_URL: baseConfig.WEB_URL,
+      S3_PUBLIC_URL: baseConfig.S3_PUBLIC_URL,
+    };
+
+    const response = await request(createApp(configWithoutAppUrl))
+      .get("/health")
+      .set("Origin", "https://app.brandblitz.io")
+      .expect(200);
+
+    expect(response.headers["access-control-allow-origin"]).toBe("https://app.brandblitz.io");
+  });
+
+  it("only sends HSTS in production", async () => {
+    const response = await request(
+      createApp({
+        ...baseConfig,
+        NODE_ENV: "development",
+      })
+    )
+      .get("/health")
+      .expect(200);
+
+    expect(response.headers["strict-transport-security"]).toBeUndefined();
+  });
+});

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -1,0 +1,64 @@
+import type { Express } from "express";
+import helmet from "helmet";
+import cors from "cors";
+import type { Config } from "../lib/config";
+
+export type SecurityConfig = Pick<
+  Config,
+  "NODE_ENV" | "WEB_URL" | "NEXT_PUBLIC_APP_URL" | "S3_PUBLIC_URL"
+>;
+
+const STELLAR_EXPERT_API_ORIGIN = "https://api.stellar.expert";
+
+function originFromUrl(url: string): string {
+  return new URL(url).origin;
+}
+
+export function applySecurityMiddleware(app: Express, config: SecurityConfig): void {
+  const appOrigin = originFromUrl(config.NEXT_PUBLIC_APP_URL ?? config.WEB_URL);
+  const cdnOrigin = originFromUrl(config.S3_PUBLIC_URL);
+
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          baseUri: ["'self'"],
+          connectSrc: ["'self'", STELLAR_EXPERT_API_ORIGIN, cdnOrigin],
+          fontSrc: ["'self'", cdnOrigin],
+          formAction: ["'self'"],
+          frameAncestors: ["'none'"],
+          imgSrc: ["'self'", cdnOrigin],
+          objectSrc: ["'none'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'"],
+        },
+      },
+      hsts:
+        config.NODE_ENV === "production"
+          ? {
+              maxAge: 31_536_000,
+              includeSubDomains: true,
+              preload: true,
+            }
+          : false,
+      referrerPolicy: {
+        policy: "strict-origin-when-cross-origin",
+      },
+    })
+  );
+
+  app.use(
+    cors({
+      credentials: true,
+      origin(origin, callback) {
+        if (!origin) {
+          callback(null, true);
+          return;
+        }
+
+        callback(null, origin === appOrigin);
+      },
+    })
+  );
+}

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -8,7 +8,7 @@ A short-lived JWT is issued at login and sent as an `Authorization: Bearer <toke
 
 ## Cookie / Session (httpOnly)
 
-The API enables `cors({ credentials: true })` and is scoped to the specific dashboard origin (`WEB_URL` env var — never a wildcard). The frontend axios client sets `withCredentials: true` so the browser attaches cookies automatically.
+The API enables `cors({ credentials: true })` and is scoped to the specific dashboard origin (`NEXT_PUBLIC_APP_URL`, falling back to `WEB_URL` — never a wildcard). The frontend axios client sets `withCredentials: true` so the browser attaches cookies automatically.
 
 This means:
 - An `httpOnly` session cookie set by a future `/auth/session` endpoint will travel with every cross-origin request.
@@ -24,7 +24,8 @@ This means:
 ### Required API server config
 
 ```
-WEB_URL=https://app.brandblitz.io   # must NOT be *
+NEXT_PUBLIC_APP_URL=https://app.brandblitz.io   # must NOT be *
+WEB_URL=https://app.brandblitz.io               # fallback for existing deployments
 ```
 
-The browser will refuse to send credentials to a wildcard origin, so `WEB_URL` must always be a specific origin.
+The browser will refuse to send credentials to a wildcard origin, so the configured app URL must always be a specific origin.

--- a/docs/deployment/required-env.md
+++ b/docs/deployment/required-env.md
@@ -13,6 +13,7 @@ There are no safe defaults — a missing value causes the compose service to fai
 | `NEXTAUTH_SECRET` | web | NextAuth.js session signing key. |
 | `NEXTAUTH_URL` | api, web | Public URL of the web app, e.g. `https://brandblitz.io`. |
 | `WEB_URL` | api | Same as `NEXTAUTH_URL`. |
+| `NEXT_PUBLIC_APP_URL` | api, web | Public dashboard origin allowed by API CORS. |
 
 ## Database
 


### PR DESCRIPTION
Closes #110

## Summary
- mount a dedicated API security middleware before parsing, rate limiting, health, and routes
- configure Helmet CSP with self, Stellar Expert API, and the configured CDN origin
- enable production-only HSTS preload and strict-origin-when-cross-origin referrer policy
- tighten credentialed CORS to NEXT_PUBLIC_APP_URL, with WEB_URL as a backwards-compatible fallback
- document the new app origin env var

## Verification
- corepack pnpm --filter @brandblitz/api exec vitest run src/middleware/security.test.ts
- corepack pnpm --filter @brandblitz/api exec tsc --ignoreConfig --noEmit --target ES2022 --module CommonJS --moduleResolution node --ignoreDeprecations 6.0 --esModuleInterop --strict --skipLibCheck src/middleware/security.ts src/middleware/security.test.ts

Note: repo-wide API type-check currently fails on existing unrelated errors in tests/routes/workspace package resolution, so I kept verification focused to the security middleware changed here.