### PR TITLE
Add signed Stellar webhook replay protection

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -135,7 +135,7 @@ The API listens on `PORT` (default `3001`). In the full Docker stack, Nginx prox
 | `TWILIO_ACCOUNT_SID` | No | Twilio account SID |
 | `TWILIO_AUTH_TOKEN` | No | Twilio auth token |
 | `TWILIO_VERIFY_SERVICE_SID` | No | Twilio Verify service SID |
-| `WEBHOOK_SECRET` | Yes | `X-Webhook-Secret` header value |
+| `WEBHOOK_SECRET` | Yes | Shared secret used by `X-Webhook-Secret` and Stellar webhook HMAC signatures |
 | `NEXTAUTH_URL` | Yes | Frontend base URL (for CORS) |
 
 ---
@@ -463,7 +463,7 @@ Public profile — display name, stats, recent sessions. No auth required.
 
 #### `POST /webhooks/stellar`
 
-Called by a Stellar event listener when a USDC deposit is detected. Protected by `X-Webhook-Secret` header.
+Called by a Stellar event listener when a USDC deposit is detected. Protected by `X-Webhook-Secret`, a timestamped `X-Webhook-Signature`, and replay protection through `X-Webhook-Id`.
 
 **Body:**
 ```json

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,7 +26,14 @@ app.use(
   })
 );
 app.use(cookieParser());
-app.use(express.json({ limit: "1mb" }));
+app.use(
+  express.json({
+    limit: "1mb",
+    verify: (req, _res, buf) => {
+      (req as express.Request & { rawBody?: string }).rawBody = buf.toString("utf8");
+    },
+  })
+);
 app.use(express.urlencoded({ extended: true }));
 
 // ── Global rate limit ──────────────────────────────────────────────────────

--- a/apps/api/src/middleware/verify-webhook.ts
+++ b/apps/api/src/middleware/verify-webhook.ts
@@ -1,0 +1,108 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+import { config } from "../lib/config";
+import { redis } from "../lib/redis";
+import { logger } from "../lib/logger";
+
+export const WEBHOOK_MAX_AGE_MS = 5 * 60 * 1000;
+export const WEBHOOK_REPLAY_TTL_SECONDS = 10 * 60;
+
+type RawBodyRequest = Request & {
+  rawBody?: string;
+};
+
+function getHeader(req: Request, name: string): string | undefined {
+  const value = req.headers[name.toLowerCase()];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function webhookBody(req: RawBodyRequest): string {
+  return req.rawBody ?? JSON.stringify(req.body ?? {});
+}
+
+function parseTimestamp(value: string): number | undefined {
+  if (!/^\d+$/.test(value)) {
+    return undefined;
+  }
+
+  const timestamp = Number(value);
+  if (!Number.isFinite(timestamp)) {
+    return undefined;
+  }
+
+  return timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp;
+}
+
+function signatureMatches(received: string, expected: string): boolean {
+  const receivedBuffer = Buffer.from(received, "hex");
+  const expectedBuffer = Buffer.from(expected, "hex");
+
+  if (receivedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(receivedBuffer, expectedBuffer);
+}
+
+export function signWebhookPayload(secret: string, timestamp: string, body: string): string {
+  const digest = createHmac("sha256", secret).update(`${timestamp}.${body}`).digest("hex");
+  return `sha256=${digest}`;
+}
+
+export async function verifyStellarWebhook(
+  req: RawBodyRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  const sharedSecret = getHeader(req, "x-webhook-secret");
+  if (sharedSecret !== config.WEBHOOK_SECRET) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const webhookId = getHeader(req, "x-webhook-id");
+  const timestampHeader = getHeader(req, "x-webhook-timestamp");
+  const signatureHeader = getHeader(req, "x-webhook-signature");
+
+  if (!webhookId || !timestampHeader || !signatureHeader?.startsWith("sha256=")) {
+    res.status(401).json({ error: "Missing webhook signature headers" });
+    return;
+  }
+
+  const timestamp = parseTimestamp(timestampHeader);
+  if (!timestamp || Math.abs(Date.now() - timestamp) > WEBHOOK_MAX_AGE_MS) {
+    res.status(401).json({ error: "Stale webhook timestamp" });
+    return;
+  }
+
+  const expectedSignature = signWebhookPayload(
+    config.WEBHOOK_SECRET,
+    timestampHeader,
+    webhookBody(req)
+  );
+
+  const receivedDigest = signatureHeader.slice("sha256=".length);
+  const expectedDigest = expectedSignature.slice("sha256=".length);
+  if (!signatureMatches(receivedDigest, expectedDigest)) {
+    res.status(401).json({ error: "Invalid webhook signature" });
+    return;
+  }
+
+  const replayKey = `stellar-webhook:${webhookId}`;
+  try {
+    const stored = await redis.set(replayKey, "1", "EX", WEBHOOK_REPLAY_TTL_SECONDS, "NX");
+    if (stored !== "OK") {
+      res.status(200).json({ status: "duplicate_webhook_ignored" });
+      return;
+    }
+  } catch (error) {
+    logger.error("Webhook replay guard failed", {
+      webhookId,
+      err: error instanceof Error ? error.message : String(error),
+    });
+    res.status(503).json({ error: "Webhook replay guard unavailable" });
+    return;
+  }
+
+  next();
+}

--- a/apps/api/src/routes/webhooks.test.ts
+++ b/apps/api/src/routes/webhooks.test.ts
@@ -3,47 +3,72 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import express from "express";
 import { errorHandler } from "../middleware/error";
 import webhooksRouter from "./webhooks";
+import { signWebhookPayload, WEBHOOK_REPLAY_TTL_SECONDS } from "../middleware/verify-webhook";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
-const getChallengeByMemoMock = vi.fn();
-const getChallengeByDepositTxHashMock = vi.fn();
-const updateChallengeStatusMock = vi.fn();
-const findPayoutByTxHashMock = vi.fn();
-const loggerInfoMock = vi.fn();
-const loggerWarnMock = vi.fn();
+const mocks = vi.hoisted(() => ({
+  getChallengeByMemo: vi.fn(),
+  getChallengeByDepositTxHash: vi.fn(),
+  updateChallengeStatus: vi.fn(),
+  findPayoutByTxHash: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  redisSet: vi.fn(),
+}));
+
+const getChallengeByMemoMock = mocks.getChallengeByMemo;
+const getChallengeByDepositTxHashMock = mocks.getChallengeByDepositTxHash;
+const updateChallengeStatusMock = mocks.updateChallengeStatus;
+const findPayoutByTxHashMock = mocks.findPayoutByTxHash;
+const loggerInfoMock = mocks.loggerInfo;
+const loggerWarnMock = mocks.loggerWarn;
+const redisSetMock = mocks.redisSet;
 
 vi.mock("../db/queries/challenges", () => ({
-  getChallengeByMemo: getChallengeByMemoMock,
-  getChallengeByDepositTxHash: getChallengeByDepositTxHashMock,
-  updateChallengeStatus: updateChallengeStatusMock,
+  getChallengeByMemo: mocks.getChallengeByMemo,
+  getChallengeByDepositTxHash: mocks.getChallengeByDepositTxHash,
+  updateChallengeStatus: mocks.updateChallengeStatus,
 }));
 
 vi.mock("../db/queries/payouts", () => ({
-  findPayoutByTxHash: findPayoutByTxHashMock,
+  findPayoutByTxHash: mocks.findPayoutByTxHash,
 }));
 
 vi.mock("../middleware/rate-limit", () => ({
   apiLimiter: (_req: any, _res: any, next: any) => next(),
+  webhookLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../lib/config", () => ({
+  config: {
+    WEBHOOK_SECRET: "test-secret",
+  },
 }));
 
 vi.mock("../lib/logger", () => ({
   logger: {
-    info: loggerInfoMock,
-    warn: loggerWarnMock,
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
     error: vi.fn(),
   },
 }));
 
 vi.mock("../lib/redis", () => ({
-  redis: { call: vi.fn() },
+  redis: { call: vi.fn(), set: mocks.redisSet },
 }));
 
 // ── Test server helpers ────────────────────────────────────────────────────────
 
 async function startServer(): Promise<{ server: Server; baseUrl: string }> {
   const app = express();
-  app.use(express.json());
+  app.use(
+    express.json({
+      verify: (req, _res, buf) => {
+        (req as express.Request & { rawBody?: string }).rawBody = buf.toString("utf8");
+      },
+    })
+  );
   app.use("/webhooks", webhooksRouter);
   app.use(errorHandler);
 
@@ -61,6 +86,40 @@ async function startServer(): Promise<{ server: Server; baseUrl: string }> {
   };
 }
 
+function depositBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    memo: "550e8400-e29b-41d4-a716-446655440000",
+    txHash: "a".repeat(64),
+    amount: "10.0000000",
+    ...overrides,
+  };
+}
+
+function signedWebhookInit(
+  body: Record<string, unknown>,
+  options: {
+    webhookId?: string;
+    timestamp?: string;
+    secret?: string;
+    signature?: string;
+  } = {}
+): { headers: Record<string, string>; body: string } {
+  const rawBody = JSON.stringify(body);
+  const timestamp = options.timestamp ?? Date.now().toString();
+  const secret = options.secret ?? "test-secret";
+
+  return {
+    headers: {
+      "Content-Type": "application/json",
+      "X-Webhook-Secret": secret,
+      "X-Webhook-Id": options.webhookId ?? "webhook-test-id",
+      "X-Webhook-Timestamp": timestamp,
+      "X-Webhook-Signature": options.signature ?? signWebhookPayload(secret, timestamp, rawBody),
+    },
+    body: rawBody,
+  };
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe("Webhooks API", () => {
@@ -69,6 +128,7 @@ describe("Webhooks API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.WEBHOOK_SECRET = "test-secret";
+    redisSetMock.mockResolvedValue("OK");
 
     getChallengeByMemoMock.mockResolvedValue({
       id: "challenge-1",
@@ -94,18 +154,13 @@ describe("Webhooks API", () => {
     it("activates a challenge on a valid webhook", async () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
+      const body = depositBody();
+      const signed = signedWebhookInit(body);
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "test-secret",
-        },
-        body: JSON.stringify({
-          memo: "550e8400-e29b-41d4-a716-446655440000",
-          txHash: "a".repeat(64),
-          amount: "10.0000000",
-        }),
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(200);
@@ -118,18 +173,13 @@ describe("Webhooks API", () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
       getChallengeByMemoMock.mockResolvedValue({ id: "challenge-1", status: "active" });
+      const body = depositBody();
+      const signed = signedWebhookInit(body);
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "test-secret",
-        },
-        body: JSON.stringify({
-          memo: "550e8400-e29b-41d4-a716-446655440000",
-          txHash: "a".repeat(64),
-          amount: "10.0000000",
-        }),
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(200);
@@ -140,18 +190,13 @@ describe("Webhooks API", () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
       getChallengeByMemoMock.mockResolvedValue(null);
+      const body = depositBody();
+      const signed = signedWebhookInit(body);
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "test-secret",
-        },
-        body: JSON.stringify({
-          memo: "unknown-memo",
-          txHash: "a".repeat(64),
-          amount: "10.0000000",
-        }),
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(404);
@@ -162,18 +207,13 @@ describe("Webhooks API", () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
       getChallengeByDepositTxHashMock.mockResolvedValue({ id: "challenge-older" });
+      const body = depositBody({ txHash: "b".repeat(64) });
+      const signed = signedWebhookInit(body);
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "test-secret",
-        },
-        body: JSON.stringify({
-          memo: "550e8400-e29b-41d4-a716-446655440000",
-          txHash: "b".repeat(64),
-          amount: "10.0000000",
-        }),
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(200);
@@ -183,38 +223,93 @@ describe("Webhooks API", () => {
     it("rejects the wrong shared secret", async () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
+      const body = depositBody();
+      const signed = signedWebhookInit(body, { secret: "wrong-secret" });
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "wrong-secret",
-        },
-        body: JSON.stringify({
-          memo: "550e8400-e29b-41d4-a716-446655440000",
-          txHash: "a".repeat(64),
-          amount: "10.0000000",
-        }),
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(401);
       expect(updateChallengeStatusMock).not.toHaveBeenCalled();
     });
 
-    it("returns 400 for missing required fields", async () => {
+    it("rejects a wrong HMAC signature", async () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
+      const body = depositBody();
+      const signed = signedWebhookInit(body, {
+        signature: `sha256=${"0".repeat(64)}`,
+      });
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "test-secret",
-        },
-        body: JSON.stringify({
-          memo: "550e8400-e29b-41d4-a716-446655440000",
-          // txHash intentionally omitted
-        }),
+        headers: signed.headers,
+        body: signed.body,
+      });
+
+      expect(response.status).toBe(401);
+      expect(updateChallengeStatusMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects stale webhook timestamps", async () => {
+      const { server, baseUrl } = await startServer();
+      currentServer = server;
+      const body = depositBody();
+      const signed = signedWebhookInit(body, {
+        timestamp: String(Date.now() - 6 * 60 * 1000),
+      });
+
+      const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
+        method: "POST",
+        headers: signed.headers,
+        body: signed.body,
+      });
+
+      expect(response.status).toBe(401);
+      expect(updateChallengeStatusMock).not.toHaveBeenCalled();
+    });
+
+    it("returns a no-op for replayed webhook ids", async () => {
+      const { server, baseUrl } = await startServer();
+      currentServer = server;
+      redisSetMock.mockResolvedValue(null);
+      const body = depositBody();
+      const signed = signedWebhookInit(body, { webhookId: "already-seen" });
+
+      const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
+        method: "POST",
+        headers: signed.headers,
+        body: signed.body,
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        status: "duplicate_webhook_ignored",
+      });
+      expect(redisSetMock).toHaveBeenCalledWith(
+        "stellar-webhook:already-seen",
+        "1",
+        "EX",
+        WEBHOOK_REPLAY_TTL_SECONDS,
+        "NX"
+      );
+      expect(updateChallengeStatusMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for missing required fields", async () => {
+      const { server, baseUrl } = await startServer();
+      currentServer = server;
+      const body = depositBody();
+      delete body.txHash;
+      const signed = signedWebhookInit(body);
+
+      const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
+        method: "POST",
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(400);
@@ -224,18 +319,13 @@ describe("Webhooks API", () => {
     it("rejects an empty memo", async () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
+      const body = depositBody({ memo: "" });
+      const signed = signedWebhookInit(body);
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "test-secret",
-        },
-        body: JSON.stringify({
-          memo: "",
-          txHash: "a".repeat(64),
-          amount: "10.0000000",
-        }),
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(400);
@@ -245,18 +335,13 @@ describe("Webhooks API", () => {
     it("rejects an empty tx hash", async () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
+      const body = depositBody({ txHash: "" });
+      const signed = signedWebhookInit(body);
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "test-secret",
-        },
-        body: JSON.stringify({
-          memo: "550e8400-e29b-41d4-a716-446655440000",
-          txHash: "",
-          amount: "10.0000000",
-        }),
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(400);
@@ -266,19 +351,13 @@ describe("Webhooks API", () => {
     it("rejects unknown fields", async () => {
       const { server, baseUrl } = await startServer();
       currentServer = server;
+      const body = depositBody({ extra: "unexpected" });
+      const signed = signedWebhookInit(body);
 
       const response = await fetch(`${baseUrl}/webhooks/stellar/deposit`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Webhook-Secret": "test-secret",
-        },
-        body: JSON.stringify({
-          memo: "550e8400-e29b-41d4-a716-446655440000",
-          txHash: "a".repeat(64),
-          amount: "10.0000000",
-          extra: "unexpected",
-        }),
+        headers: signed.headers,
+        body: signed.body,
       });
 
       expect(response.status).toBe(400);

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -7,8 +7,8 @@ import {
 } from "../db/queries/challenges";
 import { findPayoutByTxHash } from "../db/queries/payouts";
 import { webhookLimiter } from "../middleware/rate-limit";
+import { verifyStellarWebhook } from "../middleware/verify-webhook";
 import { logger } from "../lib/logger";
-import { config } from "../lib/config";
 
 const router = Router();
 
@@ -16,7 +16,10 @@ const DepositWebhookSchema = z
   .object({
     memo: z.string().uuid("memo must be a valid UUID"),
     txHash: z.string().regex(/^[0-9a-fA-F]{64}$/, "txHash must be a 64-character hex string"),
-    amount: z.string().regex(/^\d+(\.\d{1,7})?$/, "amount must be a numeric string").optional(),
+    amount: z
+      .string()
+      .regex(/^\d+(\.\d{1,7})?$/, "amount must be a numeric string")
+      .optional(),
   })
   .strict();
 
@@ -25,13 +28,7 @@ const DepositWebhookSchema = z
  * Internal webhook: called by the deposit monitor when a matching USDC
  * payment is detected on-chain. Activates the challenge.
  */
-router.post("/stellar/deposit", webhookLimiter, async (req, res) => {
-  const secret = req.headers["x-webhook-secret"];
-  if (secret !== config.WEBHOOK_SECRET) {
-    res.status(401).json({ error: "Unauthorized" });
-    return;
-  }
-
+router.post("/stellar/deposit", webhookLimiter, verifyStellarWebhook, async (req, res) => {
   const body = DepositWebhookSchema.parse(req.body);
 
   const duplicateChallenge = await getChallengeByDepositTxHash(body.txHash);

--- a/docs/runbooks/rotate-webhook-secret.md
+++ b/docs/runbooks/rotate-webhook-secret.md
@@ -1,0 +1,31 @@
+# Rotate the Stellar Webhook Secret
+
+BrandBlitz deposit webhooks use the shared `WEBHOOK_SECRET` for both the legacy
+`X-Webhook-Secret` header and the HMAC signature in `X-Webhook-Signature`.
+
+## Headers
+
+Each webhook request must include:
+
+| Header                | Value                                                  |
+| --------------------- | ------------------------------------------------------ |
+| `X-Webhook-Secret`    | Current `WEBHOOK_SECRET`                               |
+| `X-Webhook-Id`        | Unique event id, stored for 10 minutes to block replay |
+| `X-Webhook-Timestamp` | Unix timestamp in seconds or milliseconds              |
+| `X-Webhook-Signature` | `sha256=<hex>` HMAC over `<timestamp>.<raw JSON body>` |
+
+Requests older than 5 minutes are rejected. Reused webhook ids return a 200
+no-op response so retries remain safe after the first accepted delivery.
+
+## Rotation
+
+1. Generate a new high-entropy `WEBHOOK_SECRET`.
+2. Update the deposit monitor secret first, but keep the API on the old secret.
+3. Pause webhook delivery briefly or let the queue drain.
+4. Update the API `WEBHOOK_SECRET` and restart the API workers.
+5. Resume the monitor and confirm a signed test webhook is accepted.
+6. Remove the old secret from secret stores and deployment history.
+
+If a zero-downtime rotation is required, run a temporary API deployment that
+accepts both the old and new secret, then remove the old secret after every
+monitor instance has rolled forward.


### PR DESCRIPTION
## Summary
- add timestamped HMAC validation for Stellar deposit webhooks
- reject stale deliveries and replayed webhook ids through Redis
- capture raw JSON bodies for signature checks and document webhook secret rotation

## Checks
- npx --yes pnpm@10.33.0 --filter @brandblitz/api exec vitest run src/routes/webhooks.test.ts
- npx --yes prettier@3.8.1 --check apps/api/src/middleware/verify-webhook.ts apps/api/src/routes/webhooks.ts apps/api/src/routes/webhooks.test.ts apps/api/src/index.ts docs/runbooks/rotate-webhook-secret.md
- git diff --check

Closes #115