### PR TITLE
security: parameterise updateBrand columns (#113) + a11y audit harness & fixes (#120)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,65 @@
+name: A11y
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - "apps/api/**"
+      - "e2e/**"
+      - "docker-compose.yml"
+      - ".github/workflows/a11y.yml"
+
+# Accessibility gate for issue #120: runs @axe-core/playwright against the real
+# pages and fails the build on any serious/critical WCAG 2.1 A/AA violation, so
+# future PRs can't regress a11y.
+jobs:
+  a11y:
+    name: Accessibility (axe-core)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Bring up the application stack
+        run: docker compose up -d --build
+
+      - name: Wait for web to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3000 >/dev/null; then
+              echo "web is up"; exit 0
+            fi
+            sleep 5
+          done
+          echo "web did not become ready in time" >&2
+          docker compose logs --no-color web | tail -n 100
+          exit 1
+
+      - name: Run accessibility suite
+        run: pnpm --filter @brandblitz/web a11y
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-playwright-report
+          path: e2e/artifacts/html-report
+          if-no-files-found: ignore
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/apps/api/src/db/queries/brands.security.test.ts
+++ b/apps/api/src/db/queries/brands.security.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Unit-level SQL-injection regression tests for the one query that builds a
+// dynamic SET clause (#113). The DB layer is mocked so these run without a
+// database — they assert how the SQL is *constructed*, not its execution.
+vi.mock("../index", () => ({ query: vi.fn() }));
+
+import { query } from "../index";
+import { updateBrand } from "./brands";
+
+const mockedQuery = vi.mocked(query);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("updateBrand SQL-injection hardening (#113)", () => {
+  it("rejects a non-allowlisted column key and never touches the DB", async () => {
+    await expect(
+      updateBrand("brand-1", "owner-1", {
+        // identifier-injection attempt smuggled in as an object key
+        ["name = '' , deleted_at = NOW() --"]: "x",
+      } as never)
+    ).rejects.toThrow(/disallowed column/i);
+    expect(mockedQuery).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a bad key is mixed with a valid one", async () => {
+    await expect(
+      updateBrand("brand-1", "owner-1", {
+        name: "ok",
+        ["x); DROP TABLE brands; --"]: 1,
+      } as never)
+    ).rejects.toThrow(/disallowed column/i);
+    expect(mockedQuery).not.toHaveBeenCalled();
+  });
+
+  it("treats a malicious VALUE as a bound parameter, never interpolated SQL", async () => {
+    mockedQuery.mockResolvedValue({ rows: [{ id: "brand-1" }], rowCount: 1 } as never);
+
+    const evil = "'; DROP TABLE brands; --";
+    await updateBrand("brand-1", "owner-1", { name: evil });
+
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockedQuery.mock.calls[0] as [string, unknown[]];
+    // The SET clause carries only a placeholder for the value …
+    expect(sql).toContain("SET name = $3");
+    // … and the attacker string is never spliced into the SQL text.
+    expect(sql).not.toContain(evil);
+    // It is passed as a bound parameter instead.
+    expect(params).toEqual(["brand-1", "owner-1", evil]);
+  });
+
+  it("builds a parameterised multi-column update for allowed columns", async () => {
+    mockedQuery.mockResolvedValue({ rows: [{ id: "brand-1" }], rowCount: 1 } as never);
+
+    await updateBrand("brand-1", "owner-1", {
+      name: "New",
+      tagline: "Tag",
+      primary_color: "#fff",
+    });
+
+    const [sql, params] = mockedQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("SET name = $3, tagline = $4, primary_color = $5");
+    expect(sql).toContain("WHERE id = $1 AND owner_user_id = $2");
+    expect(params).toEqual(["brand-1", "owner-1", "New", "Tag", "#fff"]);
+  });
+});

--- a/apps/api/src/db/queries/brands.ts
+++ b/apps/api/src/db/queries/brands.ts
@@ -94,16 +94,47 @@ export async function getActiveDistractorBrands(excludeBrandId: string): Promise
   return result.rows.slice(0, 20);
 }
 
+/**
+ * Columns `updateBrand` is permitted to write. The UPDATE statement interpolates
+ * column names into its SET clause, so these identifiers MUST come from this
+ * fixed allowlist — never from caller-supplied object keys — to keep the query
+ * injection-proof (the values are already parameterised; the identifiers are
+ * what an attacker could otherwise smuggle in via a crafted key). See #113.
+ */
+const UPDATABLE_BRAND_COLUMNS = [
+  "name",
+  "logo_url",
+  "primary_color",
+  "secondary_color",
+  "tagline",
+  "brand_story",
+  "usp",
+  "product_image_1_url",
+  "product_image_2_url",
+] as const;
+
+type UpdatableBrandColumn = (typeof UPDATABLE_BRAND_COLUMNS)[number];
+
 export async function updateBrand(
   id: string,
   ownerUserId: string,
-  updates: Partial<Omit<Brand, "id" | "owner_user_id" | "created_at">>
+  updates: Partial<Pick<Brand, UpdatableBrandColumn>>
 ): Promise<Brand | null> {
   const fields = Object.keys(updates);
   if (fields.length === 0) return getBrandById(id);
 
+  // Fail closed: reject any key that is not an explicitly allowed column before
+  // it can reach the dynamically-built SET clause. Without this, a crafted key
+  // (e.g. "name = '' , deleted_at = NOW() --") would be SQL injection even
+  // though the bound values below are parameterised.
+  const allowed = new Set<string>(UPDATABLE_BRAND_COLUMNS);
+  const invalid = fields.filter((f) => !allowed.has(f));
+  if (invalid.length > 0) {
+    throw new Error(`updateBrand: disallowed column(s): ${invalid.join(", ")}`);
+  }
+
   const setClause = fields.map((f, i) => `${f} = $${i + 3}`).join(", ");
-  const values = fields.map((f) => (updates as any)[f]);
+  const values = fields.map((f) => (updates as Record<string, unknown>)[f]);
 
   const result = await query<Brand>(
     `UPDATE brands SET ${setClause} WHERE id = $1 AND owner_user_id = $2 RETURNING *`,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "a11y": "playwright test -c ../../e2e/playwright.config.ts a11y",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "test": "corepack pnpm exec vitest run",

--- a/apps/web/src/components/brand/brand-kit-form.tsx
+++ b/apps/web/src/components/brand/brand-kit-form.tsx
@@ -194,11 +194,18 @@ const FormSchema = z.object({
                   className="font-mono"
                   pattern="^#[0-9a-f]{6}$"
                   aria-invalid={!HEX_COLOR_PATTERN.test(fields.primaryColor)}
+                  aria-describedby={
+                    !HEX_COLOR_PATTERN.test(fields.primaryColor)
+                      ? "primaryColorHexError"
+                      : undefined
+                  }
                   spellCheck={false}
                 />
               </div>
               {!HEX_COLOR_PATTERN.test(fields.primaryColor) ? (
-                <p className="text-xs text-red-500">Use format `#rrggbb` in lowercase.</p>
+                <p id="primaryColorHexError" className="text-xs text-red-500">
+                  Use format `#rrggbb` in lowercase.
+                </p>
               ) : null}
             </div>
             <div className="space-y-2">
@@ -220,11 +227,18 @@ const FormSchema = z.object({
                   className="font-mono"
                   pattern="^#[0-9a-f]{6}$"
                   aria-invalid={!HEX_COLOR_PATTERN.test(fields.secondaryColor)}
+                  aria-describedby={
+                    !HEX_COLOR_PATTERN.test(fields.secondaryColor)
+                      ? "secondaryColorHexError"
+                      : undefined
+                  }
                   spellCheck={false}
                 />
               </div>
               {!HEX_COLOR_PATTERN.test(fields.secondaryColor) ? (
-                <p className="text-xs text-red-500">Use format `#rrggbb` in lowercase.</p>
+                <p id="secondaryColorHexError" className="text-xs text-red-500">
+                  Use format `#rrggbb` in lowercase.
+                </p>
               ) : null}
             </div>
           </div>
@@ -308,7 +322,11 @@ const FormSchema = z.object({
       </Card>
 
       {error && (
-        <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg p-3">
+        <p
+          role="alert"
+          aria-live="assertive"
+          className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg p-3"
+        >
           {error}
         </p>
       )}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,70 @@
+# Security
+
+## SQL injection — parameterised queries (issue #113)
+
+### Policy
+
+All database access goes through `query(sql, params)` (`apps/api/src/db/index.ts`,
+a thin wrapper over `pg`). The rules:
+
+1. **Values are always bound parameters** — `$1`, `$2`, … — never string-concatenated
+   or template-interpolated into the SQL text.
+2. **Identifiers (table/column names) are never taken from caller input.** When a
+   statement must be built dynamically, the identifier must come from a **fixed
+   allowlist** defined in code, not from request data or object keys.
+
+### Audit (`apps/api/src/db/queries/*.ts`)
+
+Every production query file was reviewed. All values are passed as bound parameters;
+there is **no** string concatenation of values into SQL. Two files build SQL with a
+dynamic **identifier**, and both are constrained:
+
+| File | Query calls | Dynamic identifier? | Status |
+| --- | --- | --- | --- |
+| `brands.ts` | 7 | `updateBrand` SET clause column names | **Fixed** — see below |
+| `sessions.ts` | 11 | `recordRoundScore` `round_${round}_(score\|answer)` | Safe — `round` is validated to be `1 \| 2 \| 3` before the identifier is built |
+| `challenges.ts` | 11 | none | Safe |
+| `users.ts` | 8 | none | Safe |
+| `leagues.ts` | 6 | none | Safe |
+| `payouts.ts` | 5 | none | Safe |
+| `config.ts` | 4 | none | Safe |
+| `fraud-flags.ts` | 1 | none | Safe |
+
+### `updateBrand` hardening
+
+`updateBrand` builds its `SET` clause from the keys of an `updates` object. The
+**values** were already parameterised, but the **column names** were interpolated
+directly from `Object.keys(updates)`. Because TypeScript types are erased at runtime,
+a caller passing an unchecked object (e.g. a request body) could smuggle a crafted key
+such as `"name = '' , deleted_at = NOW() --"` straight into the SQL.
+
+Fix: an explicit `UPDATABLE_BRAND_COLUMNS` allowlist. `updateBrand` now rejects (throws)
+any key not in the allowlist **before** building the clause, so the interpolated
+identifiers can only ever be known-safe column names. Regression coverage lives in
+`apps/api/src/db/queries/brands.security.test.ts` (a non-allowlisted key is rejected
+without touching the DB; a malicious *value* is shown to travel as a bound parameter,
+never as interpolated SQL).
+
+### Recommended follow-up — lint enforcement
+
+To enforce rule (1)/(2) automatically, enable
+[`eslint-plugin-security`](https://github.com/eslint-community/eslint-plugin-security)
+on the API and add a project rule forbidding tagged/template-literal SQL that embeds
+values, e.g.:
+
+```jsonc
+// eslint config for apps/api
+{
+  "plugins": ["security"],
+  "extends": ["plugin:security/recommended"],
+  "rules": {
+    "security/detect-non-literal-fs-filename": "warn",
+    "security/detect-object-injection": "warn"
+  }
+}
+```
+
+This was **not** wired up in this change because `apps/api` currently has no ESLint
+configuration and CI runs no lint step; adding a from-scratch config (and triaging the
+pre-existing violations it would surface) is a larger, separate task. The runtime
+allowlist above is the actual control; the lint rule is defence-in-depth on top of it.

--- a/e2e/tests/a11y.spec.ts
+++ b/e2e/tests/a11y.spec.ts
@@ -1,0 +1,89 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+import { seedActiveChallenge, signInWithMockGoogle } from "./helpers";
+
+// Accessibility audit (WCAG 2.1 A/AA) for issue #120. Runs @axe-core/playwright
+// against every real page + the UI primitives they render, and fails on any
+// serious/critical violation so future PRs can't regress a11y.
+//
+// Requires the app stack to be running (same assumption as the other e2e specs:
+// web on http://localhost:3000, API reachable). Run via `pnpm --filter
+// @brandblitz/web a11y` or `pnpm e2e a11y`.
+
+const OWNER = { email: "a11y-owner@example.com", name: "A11y Owner" };
+
+// Only serious/critical impacts gate the build; minor/moderate are reported but
+// not failed, matching the issue's "zero serious/critical violations" bar.
+const BLOCKING_IMPACTS = new Set(["serious", "critical"]);
+
+async function expectNoSeriousA11yViolations(page: Page, label: string) {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+
+  const blocking = results.violations.filter((v) => BLOCKING_IMPACTS.has(v.impact ?? ""));
+  const summary = blocking
+    .map((v) => `  [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`)
+    .join("\n");
+
+  expect(blocking, `${label} has serious/critical a11y violations:\n${summary}`).toEqual([]);
+}
+
+test.describe("a11y: public pages", () => {
+  test("home", async ({ page }) => {
+    await page.goto("/");
+    await expectNoSeriousA11yViolations(page, "home (/)");
+  });
+
+  test("login", async ({ page }) => {
+    await page.goto("/login");
+    await expectNoSeriousA11yViolations(page, "login (/login)");
+  });
+
+  test("leaderboard", async ({ page }) => {
+    await page.goto("/leaderboard");
+    await expectNoSeriousA11yViolations(page, "leaderboard (/leaderboard)");
+  });
+});
+
+test.describe("a11y: authenticated pages", () => {
+  test("dashboard", async ({ page }) => {
+    await signInWithMockGoogle(page, OWNER, "/dashboard");
+    await page.waitForURL("**/dashboard");
+    await expectNoSeriousA11yViolations(page, "dashboard (/dashboard)");
+  });
+
+  test("brand/new (BrandKitForm)", async ({ page }) => {
+    await signInWithMockGoogle(page, OWNER, "/brand/new");
+    await page.waitForURL("**/brand/new");
+    await expectNoSeriousA11yViolations(page, "brand/new (/brand/new)");
+  });
+});
+
+test.describe("a11y: dynamic pages (seeded)", () => {
+  test("brand/[id] and challenge/[id]", async ({ page, request }) => {
+    const { brandId, challengeId } = await seedActiveChallenge(request, OWNER);
+    await signInWithMockGoogle(page, OWNER, `/brand/${brandId}`);
+
+    await page.goto(`/brand/${brandId}`);
+    await expectNoSeriousA11yViolations(page, `brand/[id] (/brand/${brandId})`);
+
+    await page.goto(`/challenge/${challengeId}`);
+    await expectNoSeriousA11yViolations(page, `challenge/[id] (/challenge/${challengeId})`);
+  });
+
+  test("profile/[username]", async ({ page }) => {
+    await signInWithMockGoogle(page, OWNER, "/dashboard");
+    await page.waitForURL("**/dashboard");
+    // Navigate to the signed-in user's own profile via the dashboard's profile
+    // link, so we land on a real /profile/[username] without guessing the slug.
+    const profileLink = page.getByRole("link", { name: /profile/i }).first();
+    if (await profileLink.count()) {
+      await profileLink.click();
+      await page.waitForURL("**/profile/**");
+      await expectNoSeriousA11yViolations(page, "profile/[username]");
+    } else {
+      test.skip(true, "No profile link surfaced from dashboard in this build");
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gitleaks:pre-commit": "git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.10.2",
     "@playwright/test": "1.51.1",
     "@vitest/coverage-v8": "4.1.2",
     "eslint": "10.1.0",


### PR DESCRIPTION
## Summary

Addresses two backlog items for BrandBlitz: a SQL-injection audit of the data layer (#113) and a WCAG 2.1 A/AA accessibility audit (#120).

closes #113
closes #120

## #113 — SQL-injection audit (`apps/api/src/db/queries/*.ts`)

**Audit result:** every production query uses bound parameters (`$1,$2…`); there is **no** string concatenation of values into SQL. Full per-file audit + policy is documented in the new [`docs/SECURITY.md`](docs/SECURITY.md). Two files build SQL with a dynamic **identifier**:
- `sessions.ts` `recordRoundScore` — `round_${round}_…`, but `round` is validated to `1|2|3` first → **safe**.
- `brands.ts` `updateBrand` — interpolated **column names** from `Object.keys(updates)`. Values were parameterised, but the keys were not validated, so a crafted key (e.g. `"name = '' , deleted_at = NOW() --"`) would be injection. **Fixed.**

**Fix:** an explicit `UPDATABLE_BRAND_COLUMNS` allowlist; `updateBrand` throws on any non-allowlisted key before building the `SET` clause (fails closed).

**Tests** (`brands.security.test.ts`, DB-less — mocks the query layer, runs anywhere):
- non-allowlisted key → rejected, DB never touched
- bad key mixed with a valid one → still rejected (fails closed)
- malicious **value** → travels as a bound parameter, never interpolated into SQL text
- valid multi-column update → correct `$3,$4,$5` parameterised statement

## #120 — accessibility audit (WCAG 2.1 A/AA)

- **Harness:** [`e2e/tests/a11y.spec.ts`](e2e/tests/a11y.spec.ts) runs `@axe-core/playwright` against home, login, leaderboard, dashboard, brand/new, seeded brand/[id] + challenge/[id], and profile/[username], **failing on any serious/critical** WCAG 2.1 A/AA violation.
- **Command + CI:** added `pnpm --filter @brandblitz/web a11y` and a dedicated `A11y` workflow ([`.github/workflows/a11y.yml`](.github/workflows/a11y.yml)) that brings up the stack and runs the suite, so future PRs fail on regressions. (Sibling to upstream's `e2e.yml` from #77 — kept separate so an a11y regression doesn't gate full-stack E2E runs and vice versa.)
- **Concrete fixes (`BrandKitForm`):** submit errors are now announced (`role="alert"` + `aria-live`); hex-colour validation messages are linked to their inputs via `aria-describedby`. All other form controls already had `<Label htmlFor>`/`aria-label`.
- **Dialog primitive:** already accessible — focus trap, focus-return, `aria-modal` and labelling are provided by Radix (`@radix-ui/react-dialog`); no change needed.

## Test plan
- `#113`: ran `brands.security.test.ts` → **4/4 passing** (vitest).
- `#120`: BrandKitForm changes are static JSX/ARIA additions verified by inspection.

## Caveats (please read for #120)
- **The axe harness was not executed in my environment.** The repo's workspace install is currently broken on `main` (`apps/web` pins `fast-check@3.25.0`, which does not exist on npm, and the lockfile is out of sync), so I could not `pnpm install`, build, or run the web app / Playwright here. The harness, `a11y` script, and CI workflow are provided so a maintainer (or CI, once the dependency is fixed) can confirm the **"zero serious/critical violations"** criterion. I did not blind-edit pages to chase violations I couldn't measure — only the BrandKitForm fixes (verifiable by inspection) and the already-correct Radix Dialog were touched.
- For `#113` I deliberately did **not** add `eslint-plugin-security`: `apps/api` has no ESLint config today and CI runs no lint step, so a from-scratch config (and triaging the violations it surfaces) is a separate task. The runtime allowlist is the actual control; `docs/SECURITY.md` records the recommended lint setup as a follow-up.

