### PR TITLE
ci: docker publish, contracts build, dependabot, PR meta workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,77 @@
+version: 2
+
+updates:
+  # ── npm (pnpm workspace) ──────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 10
+    groups:
+      stellar-packages:
+        patterns:
+          - "@stellar/*"
+          - "@stellar-base/*"
+          - "@stellar/stellar-sdk"
+      soroban-packages:
+        patterns:
+          - "@soroban-*"
+          - "soroban-*"
+      sentry:
+        patterns:
+          - "@sentry/*"
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "playwright"
+          - "@playwright/*"
+    ignore:
+      # Major bumps always need human review — dependabot-automerge.yml skips them.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ── Docker (api image) ───────────────────────────────────────────────────
+  - package-ecosystem: docker
+    directory: "/apps/api"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+
+  # ── Docker (web image) ───────────────────────────────────────────────────
+  - package-ecosystem: docker
+    directory: "/apps/web"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+
+  # ── GitHub Actions ───────────────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    groups:
+      actions-core:
+        patterns:
+          - "actions/*"
+      docker-actions:
+        patterns:
+          - "docker/*"
+
+  # ── Rust / Cargo ─────────────────────────────────────────────────────────
+  - package-ecosystem: cargo
+    directory: "/contracts"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    groups:
+      soroban:
+        patterns:
+          - "soroban-*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,44 @@
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/api/**"
+          - "packages/storage/**"
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "apps/web/**"
+
+stellar:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "contracts/**"
+          - "packages/stellar/**"
+
+infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "docker-compose*.yml"
+          - "nginx/**"
+          - "scripts/**"
+          - "Makefile"
+          - "*.dockerfile"
+          - "**/*.dockerfile"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "*.md"
+          - "**/*.md"
+
+testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "e2e/**"
+          - "tests/**"
+          - "**/*.test.ts"
+          - "**/*.spec.ts"
+          - "**/*.test.tsx"
+          - "**/*.spec.tsx"

--- a/.github/pr-title-lint.json
+++ b/.github/pr-title-lint.json
@@ -1,0 +1,20 @@
+{
+  "types": [
+    "feat",
+    "fix",
+    "chore",
+    "docs",
+    "refactor",
+    "test",
+    "ci",
+    "perf",
+    "style",
+    "revert",
+    "build"
+  ],
+  "requireScope": false,
+  "subjectMinLength": 3,
+  "subjectMaxLength": 80,
+  "subjectPattern": ".+",
+  "subjectPatternError": "PR title subject must not be empty"
+}

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,66 @@
+name: Contracts CI
+
+on:
+  push:
+    branches: ["main", "develop"]
+    paths:
+      - "contracts/**"
+  pull_request:
+    paths:
+      - "contracts/**"
+
+concurrency:
+  group: contracts-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned versions — update these when the workspace Cargo.toml bumps soroban-sdk.
+  RUST_VERSION: "1.85.0"
+  STELLAR_CLI_VERSION: "22.8.0"
+
+jobs:
+  build-test:
+    name: Build & test escrow contract
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust ${{ env.RUST_VERSION }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32v1-none
+
+      - name: Cache Rust build artefacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contracts
+          key: contracts-${{ env.RUST_VERSION }}-${{ env.STELLAR_CLI_VERSION }}
+
+      - name: Install stellar-cli ${{ env.STELLAR_CLI_VERSION }}
+        run: cargo install stellar-cli --version ${{ env.STELLAR_CLI_VERSION }} --locked
+        # stellar-cli binary lands in ~/.cargo/bin which Swatinem/rust-cache persists,
+        # so this step is skipped on cache hits.
+
+      - name: Build escrow contract (WASM)
+        working-directory: contracts
+        run: stellar contract build
+        # stellar contract build targets wasm32v1-none (soroban-sdk >= 21).
+        # Artefact: contracts/target/wasm32v1-none/release/escrow.wasm
+
+      - name: Verify WASM artefact exists
+        working-directory: contracts
+        run: ls -lh target/wasm32v1-none/release/*.wasm
+
+      - name: Run contract tests
+        working-directory: contracts
+        run: cargo test
+
+      - name: Upload WASM artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: escrow-wasm-${{ github.sha }}
+          path: contracts/target/wasm32v1-none/release/*.wasm
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,42 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch/minor Dependabot PRs
+    runs-on: ubuntu-latest
+    # Only run for Dependabot PRs.
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve the PR
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash) for patch and minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Auto-merge only activates once all required status checks pass
+        # (branch protection must require CI to pass before merge).
+        # Major updates are deliberately excluded — they always require human review.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,81 @@
+name: Docker publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  ORG: privexlabs
+
+jobs:
+  build-push:
+    name: Build & push ${{ matrix.app }} image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # required for cosign OIDC keyless signing
+
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [api, web]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract OCI metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORG }}/brandblitz-${{ matrix.app }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=raw,value=latest
+          labels: |
+            org.opencontainers.image.title=BrandBlitz ${{ matrix.app }}
+            org.opencontainers.image.description=BrandBlitz ${{ matrix.app }} service
+            org.opencontainers.image.vendor=privexlabs
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+
+      - name: Build and push ${{ matrix.app }}
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/${{ matrix.app }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.ORG }}/brandblitz-${{ matrix.app }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.ORG }}/brandblitz-${{ matrix.app }}:buildcache,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign (keyless OIDC)
+        run: |
+          cosign sign --yes \
+            "${{ env.REGISTRY }}/${{ env.ORG }}/brandblitz-${{ matrix.app }}@${{ steps.push.outputs.digest }}"

--- a/.github/workflows/pr-meta.yml
+++ b/.github/workflows/pr-meta.yml
@@ -1,0 +1,119 @@
+name: PR meta
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  # ── Path-based auto-labeling ──────────────────────────────────────────────
+  label:
+    name: Auto-label by path
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true
+
+  # ── PR size guard ─────────────────────────────────────────────────────────
+  size-check:
+    name: PR size guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flag oversized PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const total = pr.additions + pr.deletions;
+            const LIMIT = 600;
+
+            if (total > LIMIT) {
+              // Add the size: XL label (create it if it doesn't exist yet)
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  labels: ['size: XL'],
+                });
+              } catch {
+                // Label may not exist in the repo yet — create it first
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'size: XL',
+                  color: 'e4e669',
+                  description: 'PR diff exceeds 600 lines — consider splitting',
+                }).catch(() => {});
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  labels: ['size: XL'],
+                });
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `⚠️ **Large PR detected** — this PR changes **${total} lines** `,
+                  `(${pr.additions} additions + ${pr.deletions} deletions), `,
+                  `which exceeds the ${LIMIT}-line guideline.`,
+                  '',
+                  'Large PRs are harder to review and more likely to introduce merge conflicts. ',
+                  'Please consider splitting this into smaller, focused pull requests.',
+                ].join(''),
+              });
+            }
+
+  # ── PR title lint (conventional commits) ─────────────────────────────────
+  title-lint:
+    name: PR title lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint PR title against conventional commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const config = JSON.parse(
+              fs.readFileSync('.github/pr-title-lint.json', 'utf8')
+            );
+
+            const title = context.payload.pull_request.title;
+            const types = config.types.join('|');
+            // Pattern: <type>[optional scope][optional !]: <subject>
+            const pattern = new RegExp(`^(${types})(\\([^)]+\\))?!?:\\s.{${config.subjectMinLength},${config.subjectMaxLength}}$`);
+
+            if (!pattern.test(title)) {
+              core.setFailed(
+                `PR title "${title}" does not follow the conventional commits format.\n` +
+                `Expected: <type>[scope]: <subject>\n` +
+                `Allowed types: ${config.types.join(', ')}\n` +
+                `Example: feat(api): add Stellar escrow deposit endpoint`
+              );
+            } else {
+              core.info(`✅ PR title "${title}" matches conventional commits format.`);
+            }


### PR DESCRIPTION
Fixes #75
Fixes #76
Fixes #78
Fixes #79

## What changed
- **`docker.yml`** (#75): Triggered on `v*` tags; matrix builds `api` and `web` images using `docker/build-push-action@v6` with Buildx + GHCR registry cache; pushes `:vX.Y.Z`, `:vX.Y`, `:vX`, `:latest` tags; OCI `org.opencontainers.image.*` labels; SBOM + provenance attestation; cosign keyless OIDC signing
- **`contracts.yml`** (#76): Triggered on any change to `contracts/**`; installs Rust `1.85.0` + `stellar-cli 22.8.0` (both pinned); builds WASM via `stellar contract build`; runs `cargo test`; uploads `.wasm` artefact with 30-day retention; `Swatinem/rust-cache` keeps build cache under 8 min on warm runs
- **`dependabot.yml`** (#78): Covers npm (pnpm workspace), Docker (api + web), GitHub Actions, and Cargo — all weekly Monday; groups `@stellar/*`, `soroban-*`, `@sentry/*`, testing packages into single PRs
- **`dependabot-automerge.yml`** (#78): Auto-approves and squash-merges Dependabot PRs with `semver-patch` or `semver-minor` update type after CI passes; major bumps are explicitly excluded and require human review
- **`pr-meta.yml`** (#79): Runs `actions/labeler@v5` with `labeler.yml` mapping `apps/api/`, `apps/web/`, `contracts/`, `.github/`, `docs/`, `e2e/` to labels; size guard adds `size: XL` label + comment for PRs > 600 lines; title lint reads `pr-title-lint.json` and enforces conventional commit format (`feat`, `fix`, `chore`, `ci`, etc.)

## Why
- Images were manually built and pushed with no SemVer tags, OCI metadata, or provenance
- Soroban contract changes had zero CI coverage — a broken WASM could ship undetected
- No automated dependency updates meant transitive CVEs accumulated silently
- PRs had no size or title quality gates, leading to inconsistent review standards

## How to test
- `docker.yml`: push a tag matching `v*` (e.g. `v0.1.0`) — both api and web jobs run
- `contracts.yml`: open a PR that touches any file under `contracts/` — WASM artefact appears in the Actions run summary
- Dependabot: check Insights → Dependency graph → Dependabot after merge
- Auto-merge: merge a patch Dependabot PR — it should be approved and queued automatically
- `pr-meta.yml`: open a PR with title `bad title` — title-lint job fails; open with `fix: something` — it passes