### PR TITLE
fix: unify countdown, stable onExpire ref, drop root overflow-x, add …

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -81,11 +81,16 @@ html.dark {
 
 html,
 body {
-  max-width: 100vw;
-  overflow-x: hidden;
   font-family: system-ui, -apple-system, sans-serif;
   background: var(--background);
   color: var(--foreground);
+}
+
+/* Clip horizontal overflow at the page content level without creating a scroll
+   container (overflow-x: clip, unlike hidden, does not establish a new BFC),
+   so position:sticky in the header continues to work on all browsers. */
+main {
+  overflow-x: clip;
 }
 
 a {

--- a/apps/web/src/components/brand/upload-field.test.tsx
+++ b/apps/web/src/components/brand/upload-field.test.tsx
@@ -296,6 +296,32 @@ describe("UploadField", () => {
     });
   });
 
+  // ── Drag and drop ─────────────────────────────────────────────────────────────
+
+  it("drag and drop: dropping a file triggers handleFile and calls the API", async () => {
+    defaultPresignResolve();
+
+    render(
+      <UploadField
+        label="Brand Logo"
+        uploadType="brand-logo"
+        apiToken="tok"
+        onUploaded={mocks.onUploaded}
+      />
+    );
+
+    const dropZone = screen.getByRole("button", { name: /brand logo/i });
+    const file = makeFile("logo.png", "image/png", 512);
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith("/upload/presign", expect.anything());
+    });
+  });
+
   it("MIME error does not show a Retry button (no file to retry with)", async () => {
     render(
       <UploadField

--- a/apps/web/src/components/brand/upload-field.tsx
+++ b/apps/web/src/components/brand/upload-field.tsx
@@ -42,6 +42,7 @@ export function UploadField({
   const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
 
   const handleFile = async (file: File) => {
     setError(null);
@@ -140,19 +141,37 @@ export function UploadField({
       ) : (
         <button
           type="button"
+          aria-label={label}
           onClick={() => inputRef.current?.click()}
+          onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setIsDragging(false);
+            const file = e.dataTransfer.files[0];
+            if (file) handleFile(file);
+          }}
+          onPaste={(e) => {
+            const file = e.clipboardData.files[0];
+            if (file) handleFile(file);
+          }}
           disabled={uploading}
           className={cn(
-            "w-full border-2 border-dashed border-[var(--border)] rounded-xl p-8 text-center transition-colors hover:border-[var(--primary)] hover:bg-[var(--muted)]/50 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+            "w-full border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
+            isDragging
+              ? "border-[var(--primary)] bg-[var(--muted)]/50"
+              : "border-[var(--border)] hover:border-[var(--primary)] hover:bg-[var(--muted)]/50"
           )}
         >
-          {uploading ? (
+          {isDragging ? (
+            <p className="text-sm font-medium text-[var(--primary)]">Drop here</p>
+          ) : uploading ? (
             <p className="text-sm text-[var(--muted-foreground)]">Uploading...</p>
           ) : (
             <>
               <p className="text-sm font-medium">{label}</p>
               <p className="text-xs text-[var(--muted-foreground)] mt-1">
-                Click to upload · {accept}
+                Click or drag &amp; drop · {accept}
               </p>
             </>
           )}

--- a/apps/web/src/components/game/countdown-timer.test.tsx
+++ b/apps/web/src/components/game/countdown-timer.test.tsx
@@ -98,11 +98,33 @@ describe('CountdownTimer', () => {
 
   it('does not leak intervals on unmount', () => {
     const { unmount } = render(<CountdownTimer durationSeconds={10} />);
-    
+
     expect(vi.getTimerCount()).toBe(1);
 
     unmount();
-    
+
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('parent re-renders with new onExpire identity do not restart the timer', () => {
+    const onExpire = vi.fn();
+
+    function Parent({ tick }: { tick: number }) {
+      // New arrow function every render — old bug would restart timer each time
+      return <CountdownTimer durationSeconds={5} onExpire={() => { onExpire(); void tick; }} />;
+    }
+
+    const { rerender } = render(<Parent tick={0} />);
+
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(screen.getByText('4')).not.toBeNull();
+
+    for (let i = 1; i <= 10; i++) {
+      rerender(<Parent tick={i} />);
+    }
+
+    // Timer should have continued from 4s left, not restarted
+    act(() => { vi.advanceTimersByTime(4000); });
+    expect(onExpire).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/game/countdown-timer.tsx
+++ b/apps/web/src/components/game/countdown-timer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCountdown } from "@/hooks/use-countdown";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 
@@ -11,26 +11,7 @@ interface CountdownTimerProps {
 }
 
 export function CountdownTimer({ durationSeconds, onExpire, className }: CountdownTimerProps) {
-  const [timeLeftMs, setTimeLeftMs] = useState(durationSeconds * 1000);
-
-  useEffect(() => {
-    const totalMs = durationSeconds * 1000;
-    setTimeLeftMs(totalMs);
-    const startTime = Date.now();
-    
-    const interval = setInterval(() => {
-      const elapsed = Date.now() - startTime;
-      const remaining = Math.max(0, totalMs - elapsed);
-      setTimeLeftMs(remaining);
-
-      if (remaining === 0) {
-        clearInterval(interval);
-        onExpire?.();
-      }
-    }, 100);
-
-    return () => clearInterval(interval);
-  }, [durationSeconds, onExpire]);
+  const { timeLeftMs } = useCountdown({ durationSeconds, onExpire });
 
   const seconds = Math.ceil(timeLeftMs / 1000);
   const progress = (timeLeftMs / (durationSeconds * 1000)) * 100;

--- a/apps/web/src/hooks/use-countdown.ts
+++ b/apps/web/src/hooks/use-countdown.ts
@@ -1,44 +1,34 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 
 interface UseCountdownOptions {
-  seconds: number;
+  durationSeconds: number;
   onExpire?: () => void;
-  autoStart?: boolean;
 }
 
-export function useCountdown({ seconds, onExpire, autoStart = true }: UseCountdownOptions) {
-  const [timeLeft, setTimeLeft] = useState(seconds);
-  const [running, setRunning] = useState(autoStart);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+export function useCountdown({ durationSeconds, onExpire }: UseCountdownOptions) {
+  const [timeLeftMs, setTimeLeftMs] = useState(durationSeconds * 1000);
   const onExpireRef = useRef(onExpire);
   onExpireRef.current = onExpire;
 
   useEffect(() => {
-    if (!running) return;
+    const totalMs = durationSeconds * 1000;
+    setTimeLeftMs(totalMs);
+    const startTime = Date.now();
 
-    intervalRef.current = setInterval(() => {
-      setTimeLeft((t) => {
-        if (t <= 1) {
-          clearInterval(intervalRef.current!);
-          setRunning(false);
-          onExpireRef.current?.();
-          return 0;
-        }
-        return t - 1;
-      });
-    }, 1000);
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - startTime;
+      const remaining = Math.max(0, totalMs - elapsed);
+      setTimeLeftMs(remaining);
+      if (remaining === 0) {
+        clearInterval(interval);
+        onExpireRef.current?.();
+      }
+    }, 100);
 
-    return () => clearInterval(intervalRef.current!);
-  }, [running]);
+    return () => clearInterval(interval);
+  }, [durationSeconds]);
 
-  const start = useCallback(() => setRunning(true), []);
-  const pause = useCallback(() => setRunning(false), []);
-  const reset = useCallback(() => {
-    setRunning(false);
-    setTimeLeft(seconds);
-  }, [seconds]);
-
-  return { timeLeft, running, start, pause, reset };
+  return { timeLeftMs };
 }


### PR DESCRIPTION
…upload DnD

- Closes #169: rewrites use-countdown.ts with Date.now/100ms approach; countdown-timer.tsx now consumes the hook, removing the duplicate implementation.
- Closes #170: onExpire stashed in a ref inside useCountdown so inline arrow callbacks passed by callers never restart the interval; only durationSeconds is in effect deps.
- Closes #177: removes max-width/overflow-x:hidden from html/body (was breaking position:sticky header); applies overflow-x:clip on main instead, which clips without creating a scroll container.
- Closes #162: UploadField handles onDragOver/onDragLeave/onDrop and onPaste, all routed through the existing handleFile; drag visual state shows "Drop here"; aria-label and focus-visible ring added for accessibility.
- Adds Vitest coverage: parent-rerender stability test for CountdownTimer; DataTransfer drop test for UploadField.