### PR TITLE
Resolves #103, #107, #116, #142

### DIFF
--- a/apps/api/src/db/constraints.test.ts
+++ b/apps/api/src/db/constraints.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Integration tests for issue #107: DB-level CHECK constraints (migration 013).
+ * Each test inserts a row that violates a constraint and asserts PostgreSQL rejects it.
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const schemaName = `constraints_test_${Date.now()}_${randomUUID().replace(/-/g, "")}`;
+
+function withSearchPath(connectionString: string, schema: string): string {
+  const url = new URL(connectionString);
+  const existing = url.searchParams.get("options");
+  const opt = `-c search_path=${schema}`;
+  url.searchParams.set("options", existing ? `${existing} ${opt}` : opt);
+  return url.toString();
+}
+
+if (originalDatabaseUrl) {
+  process.env.DATABASE_URL = withSearchPath(originalDatabaseUrl, schemaName);
+}
+
+const describeIntegration = originalDatabaseUrl ? describe : describe.skip;
+
+describeIntegration("CHECK constraint regressions (migration 013)", () => {
+  let query: typeof import("./index").query;
+  let closeDb: typeof import("./index").closeDb;
+
+  async function insertUser(): Promise<string> {
+    const r = await query<{ id: string }>(
+      `INSERT INTO users (email, display_name) VALUES ($1, 'Test') RETURNING id`,
+      [`cu-${randomUUID()}@test.invalid`]
+    );
+    return r.rows[0].id;
+  }
+
+  async function insertBrand(ownerId: string): Promise<string> {
+    const r = await query<{ id: string }>(
+      `INSERT INTO brands (owner_user_id, name) VALUES ($1, 'B') RETURNING id`,
+      [ownerId]
+    );
+    return r.rows[0].id;
+  }
+
+  async function insertChallenge(brandId: string): Promise<string> {
+    const r = await query<{ id: string }>(
+      `INSERT INTO challenges (brand_id, challenge_id, pool_amount_stroops)
+       VALUES ($1, $2, 0) RETURNING id`,
+      [brandId, `ch-${randomUUID()}`]
+    );
+    return r.rows[0].id;
+  }
+
+  beforeAll(async () => {
+    const db = await import("./index");
+    query = db.query;
+    closeDb = db.closeDb;
+
+    await query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
+    await query(`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`);
+
+    await query(`
+      CREATE TABLE users (
+        id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        email        TEXT NOT NULL UNIQUE,
+        display_name TEXT NOT NULL,
+        role         TEXT NOT NULL DEFAULT 'player' CHECK (role IN ('player', 'brand', 'admin'))
+      )
+    `);
+
+    await query(`
+      CREATE TABLE brands (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        name          TEXT NOT NULL
+      )
+    `);
+
+    // challenges with pool_amount constraint (migration 013)
+    await query(`
+      CREATE TABLE challenges (
+        id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        brand_id            UUID NOT NULL REFERENCES brands(id) ON DELETE CASCADE,
+        challenge_id        TEXT NOT NULL UNIQUE,
+        pool_amount_stroops BIGINT NOT NULL DEFAULT 0,
+        status              TEXT NOT NULL DEFAULT 'pending_deposit'
+          CHECK (status IN ('pending_deposit','active','ended','settled','payout_failed','cancelled','refunded')),
+        CONSTRAINT challenges_pool_amount_positive
+          CHECK (
+            status IN ('pending_deposit', 'cancelled')
+            OR pool_amount_stroops > 0
+          )
+      )
+    `);
+
+    // game_sessions with score range constraint (migration 013)
+    await query(`
+      CREATE TABLE game_sessions (
+        id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id      UUID REFERENCES users(id) ON DELETE SET NULL,
+        challenge_id UUID NOT NULL REFERENCES challenges(id) ON DELETE CASCADE,
+        total_score  INTEGER NOT NULL DEFAULT 0,
+        CONSTRAINT game_sessions_score_range
+          CHECK (total_score >= 0 AND total_score <= 450)
+      )
+    `);
+
+    // payouts with amount_stroops > 0 constraint (migration 013)
+    await query(`
+      CREATE TABLE payouts (
+        id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        challenge_id   UUID NOT NULL REFERENCES challenges(id) ON DELETE CASCADE,
+        user_id        UUID REFERENCES users(id) ON DELETE SET NULL,
+        amount_stroops BIGINT NOT NULL DEFAULT 1,
+        CONSTRAINT payouts_amount_positive
+          CHECK (amount_stroops > 0)
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (query) await query(`DROP SCHEMA IF EXISTS ${schemaName} CASCADE`);
+    if (closeDb) await closeDb();
+    process.env.DATABASE_URL = originalDatabaseUrl;
+  });
+
+  // ── challenges ─────────────────────────────────────────────────────────────
+
+  it("challenges: pool_amount_stroops = 0 is allowed when status = pending_deposit", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    await expect(
+      query(
+        `INSERT INTO challenges (brand_id, challenge_id, pool_amount_stroops, status)
+         VALUES ($1, $2, 0, 'pending_deposit')`,
+        [bid, `ch-${randomUUID()}`]
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it("challenges: pool_amount_stroops = 0 with status = active violates constraint", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    await expect(
+      query(
+        `INSERT INTO challenges (brand_id, challenge_id, pool_amount_stroops, status)
+         VALUES ($1, $2, 0, 'active')`,
+        [bid, `ch-${randomUUID()}`]
+      )
+    ).rejects.toThrow();
+  });
+
+  it("challenges: pool_amount_stroops > 0 with status = active is accepted", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    await expect(
+      query(
+        `INSERT INTO challenges (brand_id, challenge_id, pool_amount_stroops, status)
+         VALUES ($1, $2, 1000000, 'active')`,
+        [bid, `ch-${randomUUID()}`]
+      )
+    ).resolves.toBeDefined();
+  });
+
+  // ── game_sessions ──────────────────────────────────────────────────────────
+
+  it("game_sessions: total_score = 0 is valid", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    const cid = await insertChallenge(bid);
+    await expect(
+      query(
+        `INSERT INTO game_sessions (user_id, challenge_id, total_score) VALUES ($1, $2, 0)`,
+        [uid, cid]
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it("game_sessions: total_score = 450 is valid", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    const cid = await insertChallenge(bid);
+    await expect(
+      query(
+        `INSERT INTO game_sessions (user_id, challenge_id, total_score) VALUES ($1, $2, 450)`,
+        [uid, cid]
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it("game_sessions: total_score = 451 violates constraint", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    const cid = await insertChallenge(bid);
+    await expect(
+      query(
+        `INSERT INTO game_sessions (user_id, challenge_id, total_score) VALUES ($1, $2, 451)`,
+        [uid, cid]
+      )
+    ).rejects.toThrow();
+  });
+
+  it("game_sessions: total_score = -1 violates constraint", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    const cid = await insertChallenge(bid);
+    await expect(
+      query(
+        `INSERT INTO game_sessions (user_id, challenge_id, total_score) VALUES ($1, $2, -1)`,
+        [uid, cid]
+      )
+    ).rejects.toThrow();
+  });
+
+  // ── payouts ────────────────────────────────────────────────────────────────
+
+  it("payouts: amount_stroops = 0 violates constraint", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    const cid = await insertChallenge(bid);
+    await expect(
+      query(
+        `INSERT INTO payouts (challenge_id, user_id, amount_stroops) VALUES ($1, $2, 0)`,
+        [cid, uid]
+      )
+    ).rejects.toThrow();
+  });
+
+  it("payouts: amount_stroops > 0 is accepted", async () => {
+    const uid = await insertUser();
+    const bid = await insertBrand(uid);
+    const cid = await insertChallenge(bid);
+    await expect(
+      query(
+        `INSERT INTO payouts (challenge_id, user_id, amount_stroops) VALUES ($1, $2, 5000000)`,
+        [cid, uid]
+      )
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/api/src/db/queries/gdpr.ts
+++ b/apps/api/src/db/queries/gdpr.ts
@@ -44,11 +44,37 @@ export async function findPendingErasureRequest(
   return result.rows[0] ?? null;
 }
 
+/**
+ * Find a pending erasure request that was self-initiated (admin_id IS NULL).
+ * Used by the self-serve cancel endpoint so users cannot see or interact with
+ * admin-initiated legal erasure requests.
+ */
+export async function findPendingSelfErasureRequest(
+  userId: string
+): Promise<GdprErasureRequest | null> {
+  const result = await query<GdprErasureRequest>(
+    `SELECT * FROM gdpr_erasure_requests
+     WHERE user_id = $1
+       AND admin_id IS NULL
+       AND cancelled_at IS NULL
+       AND executed_at IS NULL
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [userId]
+  );
+  return result.rows[0] ?? null;
+}
+
+/**
+ * Cancel a self-initiated erasure request (admin_id IS NULL).
+ * Admin-initiated requests may only be cancelled through an admin endpoint.
+ */
 export async function cancelErasureRequest(userId: string): Promise<void> {
   await query(
     `UPDATE gdpr_erasure_requests
      SET cancelled_at = NOW(), updated_at = NOW()
      WHERE user_id = $1
+       AND admin_id IS NULL
        AND cancelled_at IS NULL
        AND executed_at IS NULL`,
     [userId]

--- a/apps/api/src/db/queries/gdpr.ts
+++ b/apps/api/src/db/queries/gdpr.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "crypto";
+import { query } from "../index";
+
+export interface GdprErasureRequest {
+  id: string;
+  user_id: string;
+  requested_at: string;
+  execute_at: string;
+  cancelled_at: string | null;
+  executed_at: string | null;
+  admin_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const GRACE_PERIOD_DAYS = 30;
+
+export async function createErasureRequest(
+  userId: string,
+  adminId?: string
+): Promise<GdprErasureRequest> {
+  const executeAt = new Date(Date.now() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000);
+  const result = await query<GdprErasureRequest>(
+    `INSERT INTO gdpr_erasure_requests (user_id, execute_at, admin_id)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [userId, executeAt.toISOString(), adminId ?? null]
+  );
+  return result.rows[0];
+}
+
+export async function findPendingErasureRequest(
+  userId: string
+): Promise<GdprErasureRequest | null> {
+  const result = await query<GdprErasureRequest>(
+    `SELECT * FROM gdpr_erasure_requests
+     WHERE user_id = $1
+       AND cancelled_at IS NULL
+       AND executed_at IS NULL
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [userId]
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function cancelErasureRequest(userId: string): Promise<void> {
+  await query(
+    `UPDATE gdpr_erasure_requests
+     SET cancelled_at = NOW(), updated_at = NOW()
+     WHERE user_id = $1
+       AND cancelled_at IS NULL
+       AND executed_at IS NULL`,
+    [userId]
+  );
+}
+
+export async function markErasureExecuted(requestId: string): Promise<void> {
+  await query(
+    `UPDATE gdpr_erasure_requests
+     SET executed_at = NOW(), updated_at = NOW()
+     WHERE id = $1`,
+    [requestId]
+  );
+}
+
+/**
+ * Anonymise all PII in the users row.
+ * The row is retained (not deleted) so FK references from game_sessions and
+ * payouts remain valid and financial records are preserved for compliance.
+ */
+export async function anonymizeUser(userId: string): Promise<void> {
+  const token = randomUUID();
+  await query(
+    `UPDATE users SET
+       email                   = $2,
+       google_id               = NULL,
+       display_name            = 'Deleted User',
+       username                = $3,
+       avatar_url              = NULL,
+       phone_hash              = NULL,
+       phone_verified          = FALSE,
+       phone_verified_at       = NULL,
+       stellar_address         = NULL,
+       embedded_wallet_address = NULL,
+       muxed_id                = NULL,
+       updated_at              = NOW()
+     WHERE id = $1`,
+    [userId, `deleted_${token}@gdpr.invalid`, `deleted_${token}`]
+  );
+}

--- a/apps/api/src/db/queries/users.ts
+++ b/apps/api/src/db/queries/users.ts
@@ -111,3 +111,13 @@ export async function markPhoneVerified(userId: string, phoneHash: string): Prom
     [phoneHash, userId]
   );
 }
+
+/**
+ * Permanently remove a user row.
+ * WARNING: DBA-only operation. Use GDPR anonymisation (anonymizeUser) for
+ * right-to-erasure requests. Hard-delete is blocked while fraud_flags rows
+ * reference this user (ON DELETE RESTRICT).
+ */
+export async function hardDeleteUser(userId: string): Promise<void> {
+  await query("DELETE FROM users WHERE id = $1", [userId]);
+}

--- a/apps/api/src/db/queries/users_fk_on_delete.test.ts
+++ b/apps/api/src/db/queries/users_fk_on_delete.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Integration tests for issue #103: FK ON DELETE behaviour after migration 012.
+ * Verifies:
+ *  - hard-deleting a user sets game_sessions.user_id and payouts.user_id to NULL
+ *  - hard-deleting a user with open fraud_flags is rejected (RESTRICT)
+ */
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const schemaName = `users_fk_test_${Date.now()}_${randomUUID().replace(/-/g, "")}`;
+
+function withSearchPath(connectionString: string, schema: string): string {
+  const url = new URL(connectionString);
+  const existing = url.searchParams.get("options");
+  const opt = `-c search_path=${schema}`;
+  url.searchParams.set("options", existing ? `${existing} ${opt}` : opt);
+  return url.toString();
+}
+
+if (originalDatabaseUrl) {
+  process.env.DATABASE_URL = withSearchPath(originalDatabaseUrl, schemaName);
+}
+
+const describeIntegration = originalDatabaseUrl ? describe : describe.skip;
+
+describeIntegration("FK ON DELETE behaviour (migration 012)", () => {
+  let query: typeof import("../index").query;
+  let closeDb: typeof import("../index").closeDb;
+
+  async function insertUser(): Promise<string> {
+    const r = await query<{ id: string }>(
+      `INSERT INTO users (email, display_name) VALUES ($1, 'Test') RETURNING id`,
+      [`u-${randomUUID()}@test.invalid`]
+    );
+    return r.rows[0].id;
+  }
+
+  async function insertChallenge(brandId: string): Promise<string> {
+    const r = await query<{ id: string }>(
+      `INSERT INTO challenges (brand_id, challenge_id) VALUES ($1, $2) RETURNING id`,
+      [brandId, `ch-${randomUUID()}`]
+    );
+    return r.rows[0].id;
+  }
+
+  async function insertBrand(ownerId: string): Promise<string> {
+    const r = await query<{ id: string }>(
+      `INSERT INTO brands (owner_user_id, name) VALUES ($1, 'B') RETURNING id`,
+      [ownerId]
+    );
+    return r.rows[0].id;
+  }
+
+  beforeAll(async () => {
+    const db = await import("../index");
+    query = db.query;
+    closeDb = db.closeDb;
+
+    await query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
+    await query(`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`);
+
+    // Minimal schema matching init.sql + migration 012 FK changes
+    await query(`
+      CREATE TABLE users (
+        id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        email        TEXT NOT NULL UNIQUE,
+        display_name TEXT NOT NULL
+      )
+    `);
+
+    await query(`
+      CREATE TABLE brands (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        name          TEXT NOT NULL
+      )
+    `);
+
+    await query(`
+      CREATE TABLE challenges (
+        id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        brand_id         UUID NOT NULL REFERENCES brands(id) ON DELETE CASCADE,
+        challenge_id     TEXT NOT NULL UNIQUE,
+        pool_amount_stroops BIGINT NOT NULL DEFAULT 0,
+        status           TEXT NOT NULL DEFAULT 'pending_deposit'
+      )
+    `);
+
+    // game_sessions: user_id nullable + SET NULL (migration 012)
+    await query(`
+      CREATE TABLE game_sessions (
+        id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id      UUID REFERENCES users(id) ON DELETE SET NULL,
+        challenge_id UUID NOT NULL REFERENCES challenges(id) ON DELETE CASCADE,
+        total_score  INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+
+    // payouts: user_id nullable + SET NULL (migration 012)
+    await query(`
+      CREATE TABLE payouts (
+        id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        challenge_id UUID NOT NULL REFERENCES challenges(id) ON DELETE CASCADE,
+        user_id      UUID REFERENCES users(id) ON DELETE SET NULL,
+        amount_stroops BIGINT NOT NULL DEFAULT 100
+      )
+    `);
+
+    // fraud_flags: user_id NOT NULL + RESTRICT (migration 012)
+    await query(`
+      CREATE TABLE fraud_flags (
+        id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id    UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+        flag_type  TEXT NOT NULL
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (query) await query(`DROP SCHEMA IF EXISTS ${schemaName} CASCADE`);
+    if (closeDb) await closeDb();
+    process.env.DATABASE_URL = originalDatabaseUrl;
+  });
+
+  it("hard-delete user sets game_sessions.user_id to NULL", async () => {
+    const userId = await insertUser();
+    const brandId = await insertBrand(userId);
+    const challengeId = await insertChallenge(brandId);
+
+    const { rows: [session] } = await query<{ id: string }>(
+      `INSERT INTO game_sessions (user_id, challenge_id) VALUES ($1, $2) RETURNING id`,
+      [userId, challengeId]
+    );
+
+    await query("DELETE FROM users WHERE id = $1", [userId]);
+
+    const { rows: [row] } = await query<{ user_id: string | null }>(
+      "SELECT user_id FROM game_sessions WHERE id = $1",
+      [session.id]
+    );
+    expect(row.user_id).toBeNull();
+  });
+
+  it("hard-delete user sets payouts.user_id to NULL", async () => {
+    const userId = await insertUser();
+    const brandId = await insertBrand(userId);
+    const challengeId = await insertChallenge(brandId);
+
+    const { rows: [payout] } = await query<{ id: string }>(
+      `INSERT INTO payouts (challenge_id, user_id) VALUES ($1, $2) RETURNING id`,
+      [challengeId, userId]
+    );
+
+    await query("DELETE FROM users WHERE id = $1", [userId]);
+
+    const { rows: [row] } = await query<{ user_id: string | null }>(
+      "SELECT user_id FROM payouts WHERE id = $1",
+      [payout.id]
+    );
+    expect(row.user_id).toBeNull();
+  });
+
+  it("hard-delete user with fraud_flags is rejected (RESTRICT)", async () => {
+    const userId = await insertUser();
+
+    await query(
+      `INSERT INTO fraud_flags (user_id, flag_type) VALUES ($1, 'test_flag')`,
+      [userId]
+    );
+
+    await expect(
+      query("DELETE FROM users WHERE id = $1", [userId])
+    ).rejects.toThrow();
+  });
+});

--- a/apps/api/src/queues/gdpr-erasure.queue.ts
+++ b/apps/api/src/queues/gdpr-erasure.queue.ts
@@ -1,0 +1,35 @@
+import { Queue, type JobsOptions } from "bullmq";
+import { redis } from "../lib/redis";
+
+export interface GdprErasureJobData {
+  userId: string;
+  requestId: string;
+}
+
+export const gdprErasureJobOptions = {
+  attempts: 3,
+  backoff: { type: "exponential", delay: 5_000 },
+  removeOnComplete: { count: 100 },
+  removeOnFail: { count: 100 },
+} satisfies JobsOptions;
+
+export const gdprErasureQueue = new Queue("gdpr-erasure", {
+  connection: redis,
+  defaultJobOptions: gdprErasureJobOptions,
+});
+
+const GRACE_PERIOD_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Enqueue an erasure job to fire after the 30-day grace period. */
+export async function enqueueGdprErasure(data: GdprErasureJobData): Promise<void> {
+  await gdprErasureQueue.add("erase", data, {
+    jobId: `gdpr:${data.userId}`,
+    delay: GRACE_PERIOD_MS,
+  });
+}
+
+/** Remove the pending erasure job (cancel within grace period). */
+export async function cancelGdprErasure(userId: string): Promise<void> {
+  const job = await gdprErasureQueue.getJob(`gdpr:${userId}`);
+  if (job) await job.remove();
+}

--- a/apps/api/src/queues/processors/gdpr-erasure.processor.test.ts
+++ b/apps/api/src/queues/processors/gdpr-erasure.processor.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ── mocks ────────────────────────────────────────────────────────────────────
+
+const mockFindPendingErasureRequest = vi.fn();
+const mockAnonymizeUser = vi.fn();
+const mockMarkErasureExecuted = vi.fn();
+const mockRevokeAllUserRefreshTokens = vi.fn();
+
+vi.mock("../../db/queries/gdpr", () => ({
+  findPendingErasureRequest: mockFindPendingErasureRequest,
+  anonymizeUser: mockAnonymizeUser,
+  markErasureExecuted: mockMarkErasureExecuted,
+}));
+
+vi.mock("../../lib/tokens", () => ({
+  revokeAllUserRefreshTokens: mockRevokeAllUserRefreshTokens,
+}));
+
+vi.mock("../../lib/redis", () => ({
+  redis: {},
+}));
+
+vi.mock("../../lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import { processGdprErasureJob } from "./gdpr-erasure.processor";
+
+function makeJob(data: { userId: string; requestId: string }) {
+  return { id: "job-1", data } as any;
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("processGdprErasureJob", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("anonymises user, revokes tokens and marks request executed when request is pending", async () => {
+    const userId = "user-abc";
+    const requestId = "req-abc";
+    mockFindPendingErasureRequest.mockResolvedValueOnce({ id: requestId, user_id: userId });
+    mockAnonymizeUser.mockResolvedValueOnce(undefined);
+    mockRevokeAllUserRefreshTokens.mockResolvedValueOnce(undefined);
+    mockMarkErasureExecuted.mockResolvedValueOnce(undefined);
+
+    await processGdprErasureJob(makeJob({ userId, requestId }));
+
+    expect(mockAnonymizeUser).toHaveBeenCalledWith(userId);
+    expect(mockRevokeAllUserRefreshTokens).toHaveBeenCalledWith(userId);
+    expect(mockMarkErasureExecuted).toHaveBeenCalledWith(requestId);
+  });
+
+  it("skips anonymisation when request is cancelled (no pending request found)", async () => {
+    mockFindPendingErasureRequest.mockResolvedValueOnce(null);
+
+    await processGdprErasureJob(makeJob({ userId: "user-xyz", requestId: "req-xyz" }));
+
+    expect(mockAnonymizeUser).not.toHaveBeenCalled();
+    expect(mockRevokeAllUserRefreshTokens).not.toHaveBeenCalled();
+    expect(mockMarkErasureExecuted).not.toHaveBeenCalled();
+  });
+
+  it("skips when a newer request supersedes the job's requestId", async () => {
+    mockFindPendingErasureRequest.mockResolvedValueOnce({
+      id: "req-newer",
+      user_id: "user-abc",
+    });
+
+    await processGdprErasureJob(makeJob({ userId: "user-abc", requestId: "req-old" }));
+
+    expect(mockAnonymizeUser).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: skips when no pending request exists (already executed)", async () => {
+    mockFindPendingErasureRequest.mockResolvedValueOnce(null);
+
+    await processGdprErasureJob(makeJob({ userId: "user-done", requestId: "req-done" }));
+
+    expect(mockAnonymizeUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/queues/processors/gdpr-erasure.processor.ts
+++ b/apps/api/src/queues/processors/gdpr-erasure.processor.ts
@@ -1,0 +1,64 @@
+import { Worker, type Job, type WorkerOptions } from "bullmq";
+import { redis } from "../../lib/redis";
+import { logger } from "../../lib/logger";
+import {
+  findPendingErasureRequest,
+  anonymizeUser,
+  markErasureExecuted,
+} from "../../db/queries/gdpr";
+import { revokeAllUserRefreshTokens } from "../../lib/tokens";
+import type { GdprErasureJobData } from "../gdpr-erasure.queue";
+
+export const gdprErasureWorkerOptions = {
+  connection: redis,
+  concurrency: 1,
+} satisfies WorkerOptions;
+
+export async function processGdprErasureJob(
+  job: Job<GdprErasureJobData>
+): Promise<void> {
+  const { userId, requestId } = job.data;
+  logger.info("Processing GDPR erasure job", { jobId: job.id, userId });
+
+  const request = await findPendingErasureRequest(userId);
+
+  if (!request) {
+    // Request was cancelled or already executed — skip silently
+    logger.info("GDPR erasure skipped (cancelled or already executed)", { userId });
+    return;
+  }
+
+  if (request.id !== requestId) {
+    // A newer request supersedes this job — let the newer job handle it
+    logger.info("GDPR erasure skipped (superseded by newer request)", { userId });
+    return;
+  }
+
+  await anonymizeUser(userId);
+  await revokeAllUserRefreshTokens(userId);
+  await markErasureExecuted(requestId);
+
+  logger.info("GDPR erasure completed", { userId });
+}
+
+export function createGdprErasureWorker(WorkerImpl: typeof Worker = Worker): Worker {
+  const worker = new WorkerImpl(
+    "gdpr-erasure",
+    processGdprErasureJob,
+    gdprErasureWorkerOptions
+  );
+
+  worker.on("completed", (job) => {
+    logger.info("GDPR erasure job completed", { jobId: job.id });
+  });
+
+  worker.on("failed", (job, err) => {
+    logger.error("GDPR erasure job failed", {
+      jobId: job?.id,
+      error: err.message,
+      attempts: job?.attemptsMade,
+    });
+  });
+
+  return worker;
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,11 +1,20 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/authenticate";
 import { getArchivedChallengeById } from "../db/queries/challenges";
+import { findUserById } from "../db/queries/users";
 import { createError } from "../middleware/error";
 
 const router = Router();
 
-router.get("/archive/challenges/:id", authenticate, async (req, res) => {
+router.use(authenticate);
+
+router.use(async (req, _res, next) => {
+  const user = await findUserById(req.user!.sub);
+  if (!user || user.role !== "admin") throw createError("Forbidden", 403, "FORBIDDEN");
+  next();
+});
+
+router.get("/archive/challenges/:id", async (req, res) => {
   const challenge = await getArchivedChallengeById(req.params.id);
   if (!challenge) throw createError("Archived challenge not found", 404);
   res.json({ challenge });

--- a/apps/api/src/routes/admin/users.ts
+++ b/apps/api/src/routes/admin/users.ts
@@ -1,0 +1,58 @@
+import { Router } from "express";
+import { z } from "zod";
+import { authenticate } from "../../middleware/authenticate";
+import { createError } from "../../middleware/error";
+import { findUserById } from "../../db/queries/users";
+import {
+  createErasureRequest,
+  findPendingErasureRequest,
+} from "../../db/queries/gdpr";
+import { enqueueGdprErasure } from "../../queues/gdpr-erasure.queue";
+import { query } from "../../db/index";
+
+const router = Router();
+
+router.use(authenticate);
+
+router.use(async (req, _res, next) => {
+  const user = await findUserById(req.user!.sub);
+  if (!user || user.role !== "admin") throw createError("Forbidden", 403, "FORBIDDEN");
+  next();
+});
+
+/**
+ * POST /admin/users/:userId/erase
+ * Trigger a GDPR right-to-erasure for a specific user on behalf of legal/compliance.
+ * Subject to the same 30-day grace period as a self-serve request.
+ * Every invocation is audit-logged.
+ */
+router.post("/:userId/erase", async (req, res) => {
+  const { userId } = z.object({ userId: z.string().uuid() }).parse(req.params);
+
+  const target = await findUserById(userId);
+  if (!target) throw createError("User not found", 404);
+
+  const existing = await findPendingErasureRequest(userId);
+  if (existing) throw createError("A deletion request is already pending for this user", 409);
+
+  const erasureRequest = await createErasureRequest(userId, req.user!.sub);
+  await enqueueGdprErasure({ userId, requestId: erasureRequest.id });
+
+  await query(
+    `INSERT INTO audit_log (actor_id, action, entity, entity_key, after)
+     VALUES ($1, 'gdpr_erasure_request', 'user', $2, $3)`,
+    [
+      req.user!.sub,
+      userId,
+      JSON.stringify({ requestId: erasureRequest.id, executeAt: erasureRequest.execute_at }),
+    ]
+  );
+
+  res.status(202).json({
+    message: "GDPR erasure request created. Data will be anonymised after 30 days.",
+    requestId: erasureRequest.id,
+    executeAt: erasureRequest.execute_at,
+  });
+});
+
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -9,6 +9,8 @@ import leaderboardRoutes from "./leaderboard";
 import webhooksRoutes from "./webhooks";
 import leaguesRoutes from "./leagues";
 import adminConfigRoutes from "./admin/config";
+import adminUsersRoutes from "./admin/users";
+import deleteAccountRoutes from "./me/delete-account";
 
 export function registerRoutes(app: Express): void {
   app.use("/auth", authRoutes);
@@ -21,4 +23,6 @@ export function registerRoutes(app: Express): void {
   app.use("/webhooks", webhooksRoutes);
   app.use("/leagues", leaguesRoutes);
   app.use("/admin/config", adminConfigRoutes);
+  app.use("/admin/users", adminUsersRoutes);
+  app.use("/me/delete-account", deleteAccountRoutes);
 }

--- a/apps/api/src/routes/me/delete-account.test.ts
+++ b/apps/api/src/routes/me/delete-account.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// ── mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("../../middleware/authenticate", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.user = { sub: "user-123", email: "alice@example.com" };
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/rate-limit", () => ({
+  apiLimiter: (_req: any, _res: any, next: any) => next(),
+}));
+
+const mockFindUserById = vi.fn();
+const mockFindPendingErasureRequest = vi.fn();
+const mockCreateErasureRequest = vi.fn();
+const mockCancelErasureRequest = vi.fn();
+const mockEnqueueGdprErasure = vi.fn();
+const mockCancelGdprErasure = vi.fn();
+
+vi.mock("../../db/queries/users", () => ({
+  findUserById: mockFindUserById,
+}));
+
+vi.mock("../../db/queries/gdpr", () => ({
+  findPendingErasureRequest: mockFindPendingErasureRequest,
+  createErasureRequest: mockCreateErasureRequest,
+  cancelErasureRequest: mockCancelErasureRequest,
+}));
+
+vi.mock("../../queues/gdpr-erasure.queue", () => ({
+  enqueueGdprErasure: mockEnqueueGdprErasure,
+  cancelGdprErasure: mockCancelGdprErasure,
+}));
+
+vi.mock("../../lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+// ── app setup ────────────────────────────────────────────────────────────────
+
+import deleteAccountRoutes from "./delete-account";
+import { errorHandler } from "../../middleware/error";
+
+let app: express.Express;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.use("/me/delete-account", deleteAccountRoutes);
+  app.use(errorHandler);
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("POST /me/delete-account", () => {
+  it("returns 403 when email does not match the user's account email", async () => {
+    mockFindUserById.mockResolvedValueOnce({
+      id: "user-123",
+      email: "alice@example.com",
+    });
+
+    const res = await request(app)
+      .post("/me/delete-account")
+      .send({ email: "wrong@example.com" })
+      .expect(403);
+
+    expect(res.body.error).toBe("Email confirmation does not match your account email");
+    expect(mockCreateErasureRequest).not.toHaveBeenCalled();
+    expect(mockEnqueueGdprErasure).not.toHaveBeenCalled();
+  });
+
+  it("returns 202 and enqueues job when email matches", async () => {
+    mockFindUserById.mockResolvedValueOnce({
+      id: "user-123",
+      email: "alice@example.com",
+    });
+    mockFindPendingErasureRequest.mockResolvedValueOnce(null);
+    const fakeRequest = {
+      id: "req-abc",
+      user_id: "user-123",
+      execute_at: new Date(Date.now() + 30 * 86400000).toISOString(),
+    };
+    mockCreateErasureRequest.mockResolvedValueOnce(fakeRequest);
+    mockEnqueueGdprErasure.mockResolvedValueOnce(undefined);
+
+    const res = await request(app)
+      .post("/me/delete-account")
+      .send({ email: "alice@example.com" })
+      .expect(202);
+
+    expect(res.body.executeAt).toBe(fakeRequest.execute_at);
+    expect(mockCreateErasureRequest).toHaveBeenCalledWith("user-123", undefined);
+    expect(mockEnqueueGdprErasure).toHaveBeenCalledWith({
+      userId: "user-123",
+      requestId: "req-abc",
+    });
+  });
+
+  it("returns 202 with case-insensitive email match", async () => {
+    mockFindUserById.mockResolvedValueOnce({
+      id: "user-123",
+      email: "Alice@Example.COM",
+    });
+    mockFindPendingErasureRequest.mockResolvedValueOnce(null);
+    mockCreateErasureRequest.mockResolvedValueOnce({
+      id: "req-xyz",
+      user_id: "user-123",
+      execute_at: new Date().toISOString(),
+    });
+
+    await request(app)
+      .post("/me/delete-account")
+      .send({ email: "alice@example.com" })
+      .expect(202);
+  });
+
+  it("returns 409 when a deletion request is already pending", async () => {
+    mockFindUserById.mockResolvedValueOnce({
+      id: "user-123",
+      email: "alice@example.com",
+    });
+    mockFindPendingErasureRequest.mockResolvedValueOnce({ id: "existing-req" });
+
+    const res = await request(app)
+      .post("/me/delete-account")
+      .send({ email: "alice@example.com" })
+      .expect(409);
+
+    expect(res.body.error).toMatch(/already pending/);
+    expect(mockEnqueueGdprErasure).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when user is not found", async () => {
+    mockFindUserById.mockResolvedValueOnce(null);
+
+    await request(app)
+      .post("/me/delete-account")
+      .send({ email: "alice@example.com" })
+      .expect(404);
+  });
+
+  it("returns 400 for invalid email body", async () => {
+    await request(app)
+      .post("/me/delete-account")
+      .send({ email: "not-an-email" })
+      .expect(400);
+  });
+});
+
+describe("DELETE /me/delete-account", () => {
+  it("returns 200 and cancels request when one exists", async () => {
+    mockFindPendingErasureRequest.mockResolvedValueOnce({ id: "req-abc" });
+    mockCancelErasureRequest.mockResolvedValueOnce(undefined);
+    mockCancelGdprErasure.mockResolvedValueOnce(undefined);
+
+    const res = await request(app)
+      .delete("/me/delete-account")
+      .expect(200);
+
+    expect(res.body.message).toMatch(/cancelled/);
+    expect(mockCancelErasureRequest).toHaveBeenCalledWith("user-123");
+    expect(mockCancelGdprErasure).toHaveBeenCalledWith("user-123");
+  });
+
+  it("returns 404 when no pending request exists", async () => {
+    mockFindPendingErasureRequest.mockResolvedValueOnce(null);
+
+    await request(app)
+      .delete("/me/delete-account")
+      .expect(404);
+
+    expect(mockCancelErasureRequest).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/me/delete-account.test.ts
+++ b/apps/api/src/routes/me/delete-account.test.ts
@@ -26,8 +26,11 @@ vi.mock("../../db/queries/users", () => ({
   findUserById: mockFindUserById,
 }));
 
+const mockFindPendingSelfErasureRequest = vi.fn();
+
 vi.mock("../../db/queries/gdpr", () => ({
   findPendingErasureRequest: mockFindPendingErasureRequest,
+  findPendingSelfErasureRequest: mockFindPendingSelfErasureRequest,
   createErasureRequest: mockCreateErasureRequest,
   cancelErasureRequest: mockCancelErasureRequest,
 }));
@@ -161,8 +164,8 @@ describe("POST /me/delete-account", () => {
 });
 
 describe("DELETE /me/delete-account", () => {
-  it("returns 200 and cancels request when one exists", async () => {
-    mockFindPendingErasureRequest.mockResolvedValueOnce({ id: "req-abc" });
+  it("returns 200 and cancels a self-initiated request", async () => {
+    mockFindPendingSelfErasureRequest.mockResolvedValueOnce({ id: "req-abc", admin_id: null });
     mockCancelErasureRequest.mockResolvedValueOnce(undefined);
     mockCancelGdprErasure.mockResolvedValueOnce(undefined);
 
@@ -175,8 +178,19 @@ describe("DELETE /me/delete-account", () => {
     expect(mockCancelGdprErasure).toHaveBeenCalledWith("user-123");
   });
 
-  it("returns 404 when no pending request exists", async () => {
-    mockFindPendingErasureRequest.mockResolvedValueOnce(null);
+  it("returns 404 when no self-initiated pending request exists", async () => {
+    mockFindPendingSelfErasureRequest.mockResolvedValueOnce(null);
+
+    await request(app)
+      .delete("/me/delete-account")
+      .expect(404);
+
+    expect(mockCancelErasureRequest).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when only an admin-initiated request exists (not cancellable by user)", async () => {
+    // findPendingSelfErasureRequest excludes admin_id IS NOT NULL rows
+    mockFindPendingSelfErasureRequest.mockResolvedValueOnce(null);
 
     await request(app)
       .delete("/me/delete-account")

--- a/apps/api/src/routes/me/delete-account.ts
+++ b/apps/api/src/routes/me/delete-account.ts
@@ -1,0 +1,60 @@
+import { Router } from "express";
+import { z } from "zod";
+import { authenticate } from "../../middleware/authenticate";
+import { createError } from "../../middleware/error";
+import { findUserById } from "../../db/queries/users";
+import {
+  createErasureRequest,
+  findPendingErasureRequest,
+  cancelErasureRequest,
+} from "../../db/queries/gdpr";
+import {
+  enqueueGdprErasure,
+  cancelGdprErasure,
+} from "../../queues/gdpr-erasure.queue";
+
+const router = Router();
+
+/**
+ * POST /me/delete-account
+ * Self-serve GDPR right-to-erasure request.
+ * Requires the user to confirm their email address in the request body.
+ * Starts a 30-day grace period; the account is anonymised after the window elapses.
+ */
+router.post("/", authenticate, async (req, res) => {
+  const { email } = z.object({ email: z.string().email() }).parse(req.body);
+
+  const user = await findUserById(req.user!.sub);
+  if (!user) throw createError("User not found", 404);
+
+  if (user.email.toLowerCase() !== email.toLowerCase()) {
+    throw createError("Email confirmation does not match your account email", 403);
+  }
+
+  const existing = await findPendingErasureRequest(user.id);
+  if (existing) throw createError("A deletion request is already pending for this account", 409);
+
+  const erasureRequest = await createErasureRequest(user.id);
+  await enqueueGdprErasure({ userId: user.id, requestId: erasureRequest.id });
+
+  res.status(202).json({
+    message: "Your account deletion request has been received. Your data will be anonymised after a 30-day grace period.",
+    executeAt: erasureRequest.execute_at,
+  });
+});
+
+/**
+ * DELETE /me/delete-account
+ * Cancel a pending account deletion within the 30-day grace period.
+ */
+router.delete("/", authenticate, async (req, res) => {
+  const pending = await findPendingErasureRequest(req.user!.sub);
+  if (!pending) throw createError("No pending deletion request found", 404);
+
+  await cancelErasureRequest(req.user!.sub);
+  await cancelGdprErasure(req.user!.sub);
+
+  res.json({ message: "Your account deletion request has been cancelled." });
+});
+
+export default router;

--- a/apps/api/src/routes/me/delete-account.ts
+++ b/apps/api/src/routes/me/delete-account.ts
@@ -6,6 +6,7 @@ import { findUserById } from "../../db/queries/users";
 import {
   createErasureRequest,
   findPendingErasureRequest,
+  findPendingSelfErasureRequest,
   cancelErasureRequest,
 } from "../../db/queries/gdpr";
 import {
@@ -45,10 +46,12 @@ router.post("/", authenticate, async (req, res) => {
 
 /**
  * DELETE /me/delete-account
- * Cancel a pending account deletion within the 30-day grace period.
+ * Cancel a self-initiated account deletion within the 30-day grace period.
+ * Admin-initiated legal erasures are not visible here and must be cancelled
+ * through the admin endpoint.
  */
 router.delete("/", authenticate, async (req, res) => {
-  const pending = await findPendingErasureRequest(req.user!.sub);
+  const pending = await findPendingSelfErasureRequest(req.user!.sub);
   if (!pending) throw createError("No pending deletion request found", 404);
 
   await cancelErasureRequest(req.user!.sub);

--- a/apps/api/src/routes/upload.test.ts
+++ b/apps/api/src/routes/upload.test.ts
@@ -253,6 +253,35 @@ describe("upload routes integration", () => {
     expect(response.body.error).toBe("SVG contains disallowed content");
   });
 
+  it("POST /upload/verify returns 400 for SVG with entity-encoded javascript: URI", async () => {
+    // &#106;avascript: decodes to javascript: — must be caught after entity decoding
+    mockSend.mockResolvedValueOnce({ ContentType: "image/svg+xml" });
+    const svgContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><a href="&#106;avascript:alert(1)"><text>x</text></a></svg>');
+    mockSend.mockResolvedValueOnce({ Body: { transformToByteArray: async () => svgContent } });
+    mockSend.mockResolvedValueOnce({});
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/encoded.svg" })
+      .expect(400);
+
+    expect(response.body.error).toBe("SVG contains disallowed content");
+  });
+
+  it("POST /upload/verify returns 400 for SVG with data: href", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "image/svg+xml" });
+    const svgContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/svg+xml,<svg onload=alert(1)/>"/></svg>');
+    mockSend.mockResolvedValueOnce({ Body: { transformToByteArray: async () => svgContent } });
+    mockSend.mockResolvedValueOnce({});
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/datauri.svg" })
+      .expect(400);
+
+    expect(response.body.error).toBe("SVG contains disallowed content");
+  });
+
   it("POST /upload/verify returns 200 for a valid SVG without dangerous content", async () => {
     mockSend.mockResolvedValueOnce({ ContentType: "image/svg+xml" });
     const svgContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" fill="#6366f1"/></svg>');

--- a/apps/api/src/routes/upload.test.ts
+++ b/apps/api/src/routes/upload.test.ts
@@ -121,8 +121,14 @@ describe("upload routes integration", () => {
     );
   });
 
-  it("POST /upload/verify returns 200 when the object exists", async () => {
-    mockSend.mockResolvedValueOnce({});
+  it("POST /upload/verify returns 200 when the object exists and MIME matches", async () => {
+    // HeadObject → ContentType: image/png
+    mockSend.mockResolvedValueOnce({ ContentType: "image/png" });
+    // GetObject Range → PNG magic bytes
+    const pngMagic = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    mockSend.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => pngMagic },
+    });
 
     const response = await request(app)
       .post("/upload/verify")
@@ -133,7 +139,6 @@ describe("upload routes integration", () => {
       exists: true,
       publicUrl: "https://public/brand-assets/logos/test-key",
     });
-    expect(mockSend).toHaveBeenCalledTimes(1);
     expect(mockSend.mock.calls[0][0]?.input).toMatchObject({
       Bucket: "brand-assets",
       Key: "logos/test-key",
@@ -149,5 +154,144 @@ describe("upload routes integration", () => {
       .expect(404);
 
     expect(response.body.error).toBe("File not found in storage");
+  });
+
+  // ── MIME magic-byte validation (issue #116) ────────────────────────────────
+
+  it("POST /upload/verify returns 200 for a valid PNG (magic bytes match)", async () => {
+    // HeadObject → ContentType: image/png
+    mockSend.mockResolvedValueOnce({ ContentType: "image/png" });
+    // GetObject Range → PNG magic bytes
+    const pngMagic = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    mockSend.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => pngMagic },
+    });
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/valid.png" })
+      .expect(200);
+
+    expect(response.body.exists).toBe(true);
+  });
+
+  it("POST /upload/verify returns 400 and deletes when magic bytes mismatch declared MIME", async () => {
+    // HeadObject → ContentType: image/png
+    mockSend.mockResolvedValueOnce({ ContentType: "image/png" });
+    // GetObject Range → JPEG magic bytes (mismatch!)
+    const jpegMagic = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    mockSend.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => jpegMagic },
+    });
+    // DeleteObject call
+    mockSend.mockResolvedValueOnce({});
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/bad.png" })
+      .expect(400);
+
+    expect(response.body.error).toBe("File content does not match declared content type");
+    // Verify DeleteObjectCommand was called (3rd mockSend call)
+    expect(mockSend).toHaveBeenCalledTimes(3);
+  });
+
+  it("POST /upload/verify returns 400 and deletes SVG containing <script>", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "image/svg+xml" });
+    const svgContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+    mockSend.mockResolvedValueOnce({ Body: { transformToByteArray: async () => svgContent } });
+    mockSend.mockResolvedValueOnce({});
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/evil.svg" })
+      .expect(400);
+
+    expect(response.body.error).toBe("SVG contains disallowed content");
+    expect(mockSend).toHaveBeenCalledTimes(3);
+  });
+
+  it("POST /upload/verify returns 400 for SVG with event handler (onload=)", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "image/svg+xml" });
+    const svgContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"></svg>');
+    mockSend.mockResolvedValueOnce({ Body: { transformToByteArray: async () => svgContent } });
+    mockSend.mockResolvedValueOnce({});
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/onload.svg" })
+      .expect(400);
+
+    expect(response.body.error).toBe("SVG contains disallowed content");
+  });
+
+  it("POST /upload/verify returns 400 for SVG with javascript: URI", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "image/svg+xml" });
+    const svgContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><text>click</text></a></svg>');
+    mockSend.mockResolvedValueOnce({ Body: { transformToByteArray: async () => svgContent } });
+    mockSend.mockResolvedValueOnce({});
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/jsuri.svg" })
+      .expect(400);
+
+    expect(response.body.error).toBe("SVG contains disallowed content");
+  });
+
+  it("POST /upload/verify returns 400 for SVG with <foreignObject>", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "image/svg+xml" });
+    const svgContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><body onload="alert(1)"/></foreignObject></svg>');
+    mockSend.mockResolvedValueOnce({ Body: { transformToByteArray: async () => svgContent } });
+    mockSend.mockResolvedValueOnce({});
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/foreign.svg" })
+      .expect(400);
+
+    expect(response.body.error).toBe("SVG contains disallowed content");
+  });
+
+  it("POST /upload/verify returns 200 for a valid SVG without dangerous content", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "image/svg+xml" });
+    const svgContent = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" fill="#6366f1"/></svg>');
+    mockSend.mockResolvedValueOnce({ Body: { transformToByteArray: async () => svgContent } });
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/clean.svg" })
+      .expect(200);
+
+    expect(response.body.exists).toBe(true);
+  });
+
+  it("POST /upload/verify returns 200 for a valid JPEG", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "image/jpeg" });
+    const jpegMagic = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+    mockSend.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => jpegMagic },
+    });
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "avatars/photo.jpg" })
+      .expect(200);
+
+    expect(response.body.exists).toBe(true);
+  });
+
+  it("POST /upload/verify returns 400 and deletes when declared MIME is not in the allow-list", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "application/pdf" });
+    mockSend.mockResolvedValueOnce({});
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/document.pdf" })
+      .expect(400);
+
+    expect(response.body.error).toBe("Declared content type is not allowed");
+    // DeleteObject was called
+    expect(mockSend).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -1,7 +1,12 @@
 import { Router } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
-import { PutObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
+import {
+  PutObjectCommand,
+  HeadObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+} from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { s3, BUCKETS, getPublicUrl } from "@brandblitz/storage";
 import { authenticate } from "../middleware/authenticate";
@@ -21,13 +26,74 @@ const ALLOWED_CONTENT_TYPES = [
   "image/jpeg",
   "image/webp",
   "image/svg+xml",
-];
+] as const;
+
+type AllowedMime = typeof ALLOWED_CONTENT_TYPES[number];
 
 const PresignSchema = z.object({
   type: z.enum(["brand-logo", "product-image", "user-avatar"]),
   contentType: z.enum(["image/png", "image/jpeg", "image/webp", "image/svg+xml"]),
   contentLength: z.number().int().positive(),
 });
+
+/**
+ * Detect MIME type from the first bytes of a buffer using magic numbers.
+ * Returns one of the four allowed MIME strings, or null if unrecognised.
+ */
+function detectMime(buf: Buffer): AllowedMime | null {
+  if (buf.length < 3) return null;
+
+  // PNG: 89 50 4E 47
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) {
+    return "image/png";
+  }
+  // JPEG: FF D8 FF
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return "image/jpeg";
+  }
+  // WebP: "RIFF" at 0-3 and "WEBP" at 8-11
+  if (
+    buf.length >= 12 &&
+    buf.toString("ascii", 0, 4) === "RIFF" &&
+    buf.toString("ascii", 8, 12) === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  // SVG: XML or SVG text (after optional BOM / whitespace)
+  const text = buf.toString("utf8", 0, Math.min(buf.length, 128)).trimStart();
+  if (text.startsWith("<svg") || text.startsWith("<?xml") || text.startsWith("<!DOCTYPE svg")) {
+    return "image/svg+xml";
+  }
+
+  return null;
+}
+
+/**
+ * SVG XSS patterns — any match causes the file to be rejected.
+ * A single regex is not sufficient; SVGs support many execution vectors:
+ *   - event handlers on any element (onload, onerror, onclick, …)
+ *   - javascript: / vbscript: URIs in href/src/action/xlink:href
+ *   - <foreignObject> embeds an HTML namespace (and its event model)
+ *   - <use xlink:href="http://…"> pulls in external SVG fragments
+ *   - data:text/html and data:text/xml URIs can carry executable HTML
+ *   - <script> elements
+ *
+ * The full SVG content is scanned (not just the first 8 KiB) because
+ * payloads can appear anywhere in the file.
+ */
+const SVG_DANGEROUS_PATTERNS: RegExp[] = [
+  /<script/i,
+  /\bon\w+\s*=/i,                         // onload=, onclick=, onerror=, …
+  /javascript\s*:/i,                       // javascript: URIs
+  /vbscript\s*:/i,                         // vbscript: URIs (IE legacy)
+  /<foreignObject/i,                       // HTML namespace embedding
+  /data\s*:\s*text\/(html|xml)/i,          // data:text/html and data:text/xml
+  /<use[^>]+(?:xlink:)?href\s*=\s*["']https?:/i, // external <use> references
+];
+
+function isSvgSafe(content: string): boolean {
+  return !SVG_DANGEROUS_PATTERNS.some((pattern) => pattern.test(content));
+}
 
 /**
  * POST /upload/presign
@@ -66,22 +132,73 @@ router.post("/presign", authenticate, uploadLimiter, async (req, res) => {
 
 /**
  * POST /upload/verify
- * Verify a file was actually uploaded before accepting it in a form.
+ * Verify a file was actually uploaded and its content matches the declared MIME type.
+ *
+ * For binary formats (PNG/JPEG/WebP): reads the first 16 bytes via a Range
+ * request and validates magic bytes against the declared ContentType.
+ *
+ * For SVG: fetches the complete file content (bounded by the 2 MB presign limit)
+ * and applies a comprehensive block-list of XSS execution vectors. A partial
+ * read is not sufficient because payloads can appear anywhere in the document.
+ *
+ * Deletes the object and returns 400 on any validation failure.
  */
 router.post("/verify", authenticate, async (req, res) => {
   const { key } = z.object({ key: z.string() }).parse(req.body);
 
-  // Determine bucket from key prefix
   const bucket = key.startsWith("logos/") || key.startsWith("products/") || key.startsWith("avatars/")
     ? BUCKETS.BRAND_ASSETS
     : BUCKETS.SHARE_CARDS;
 
+  // Step 1: confirm object exists and get its declared ContentType
+  let declaredMime: string;
   try {
-    await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
-    res.json({ exists: true, publicUrl: getPublicUrl(bucket, key) });
+    const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    declaredMime = head.ContentType ?? "";
   } catch {
     throw createError("File not found in storage", 404);
   }
+
+  // Only validate MIME for the four explicitly allowed types
+  if (!(ALLOWED_CONTENT_TYPES as readonly string[]).includes(declaredMime)) {
+    await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    throw createError("Declared content type is not allowed", 400);
+  }
+
+  async function deleteAndReject(message: string): Promise<never> {
+    await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    throw createError(message, 400);
+  }
+
+  // Step 2: fetch file content for inspection
+  //   - Binary formats: first 16 bytes is sufficient for magic number detection
+  //   - SVG: full file required for complete XSS scanning
+  const isSvg = declaredMime === "image/svg+xml";
+  const rangeHeader = isSvg ? undefined : "bytes=0-15";
+
+  let buf: Buffer;
+  try {
+    const obj = await s3.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key, Range: rangeHeader })
+    );
+    const bytes = await (obj.Body as { transformToByteArray(): Promise<Uint8Array> }).transformToByteArray();
+    buf = Buffer.from(bytes);
+  } catch {
+    throw createError("Failed to read file from storage", 500);
+  }
+
+  // Step 3: validate detected MIME against declared MIME
+  const detected = detectMime(buf);
+  if (detected !== declaredMime) {
+    return deleteAndReject("File content does not match declared content type");
+  }
+
+  // Step 4: comprehensive SVG XSS scan across the full file content
+  if (isSvg && !isSvgSafe(buf.toString("utf8"))) {
+    return deleteAndReject("SVG contains disallowed content");
+  }
+
+  res.json({ exists: true, publicUrl: getPublicUrl(bucket, key) });
 });
 
 export default router;

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -69,29 +69,44 @@ function detectMime(buf: Buffer): AllowedMime | null {
 }
 
 /**
- * SVG XSS patterns — any match causes the file to be rejected.
- * A single regex is not sufficient; SVGs support many execution vectors:
- *   - event handlers on any element (onload, onerror, onclick, …)
- *   - javascript: / vbscript: URIs in href/src/action/xlink:href
- *   - <foreignObject> embeds an HTML namespace (and its event model)
- *   - <use xlink:href="http://…"> pulls in external SVG fragments
- *   - data:text/html and data:text/xml URIs can carry executable HTML
- *   - <script> elements
+ * Decode common XML/HTML character references so encoded payloads like
+ * `&#106;avascript:` or `&#x6A;avascript:` are normalised before scanning.
+ * Only decodes numeric references; named references (&amp; etc.) that
+ * are safe in SVG attribute values are left intact.
+ */
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
+      String.fromCodePoint(parseInt(hex, 16))
+    )
+    .replace(/&#([0-9]+);/g, (_, dec) =>
+      String.fromCodePoint(parseInt(dec, 10))
+    );
+}
+
+/**
+ * SVG XSS patterns applied after entity decoding.
  *
- * The full SVG content is scanned (not just the first 8 KiB) because
- * payloads can appear anywhere in the file.
+ * Blocklist limitations are acknowledged: XML namespace tricks,
+ * CSS-based attacks in <style>, and novel parser differentials are not
+ * covered here. For full mitigation, serve user-uploaded SVGs from a
+ * separate cookieless origin with `Content-Disposition: attachment` and
+ * `Content-Security-Policy: default-src 'none'; sandbox`.
  */
 const SVG_DANGEROUS_PATTERNS: RegExp[] = [
   /<script/i,
-  /\bon\w+\s*=/i,                         // onload=, onclick=, onerror=, …
-  /javascript\s*:/i,                       // javascript: URIs
-  /vbscript\s*:/i,                         // vbscript: URIs (IE legacy)
-  /<foreignObject/i,                       // HTML namespace embedding
-  /data\s*:\s*text\/(html|xml)/i,          // data:text/html and data:text/xml
+  /\bon\w+\s*=/i,                               // event handlers (onload=, onerror=, …)
+  /javascript\s*:/i,                             // javascript: URIs
+  /vbscript\s*:/i,                               // vbscript: URIs (IE legacy)
+  /<foreignObject/i,                             // HTML namespace embedding
+  /\bhref\s*=\s*["']?\s*data\s*:/i,             // data: URIs in any href
+  /\bsrc\s*=\s*["']?\s*data\s*:/i,              // data: URIs in any src
+  /\baction\s*=\s*["']?\s*data\s*:/i,           // data: URIs in form action
   /<use[^>]+(?:xlink:)?href\s*=\s*["']https?:/i, // external <use> references
 ];
 
-function isSvgSafe(content: string): boolean {
+function isSvgSafe(rawContent: string): boolean {
+  const content = decodeXmlEntities(rawContent);
   return !SVG_DANGEROUS_PATTERNS.some((pattern) => pattern.test(content));
 }
 

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -5,6 +5,9 @@ import { connectDb, closeDb } from "./db";
 import { connectRedis, redis, startRedisEvictionMonitor } from "./lib/redis";
 import { createPayoutWorker } from "./queues/processors/payout.processor";
 import { createArchiveWorker, scheduleArchiveJob } from "./queues/archive.queue";
+import { createLeagueWorker } from "./queues/processors/league.processor";
+import { createGdprErasureWorker } from "./queues/processors/gdpr-erasure.processor";
+import { ensureLeagueRepeatableJobs } from "./queues/league.queue";
 import { logger } from "./lib/logger";
 
 async function startWorker(): Promise<void> {
@@ -13,15 +16,20 @@ async function startWorker(): Promise<void> {
 
   const payoutWorker = createPayoutWorker();
   const archiveWorker = createArchiveWorker();
+  const leagueWorker = createLeagueWorker();
+  const gdprErasureWorker = createGdprErasureWorker();
   await scheduleArchiveJob();
-
-  logger.info("BullMQ worker started — processing payout and archive jobs");
+  await ensureLeagueRepeatableJobs();
+  const evictionMonitor = startRedisEvictionMonitor();
+  logger.info("BullMQ worker started — processing payout + archive + league + gdpr-erasure jobs");
 
   const shutdown = async (signal: string) => {
     logger.info(`${signal} received — closing worker`);
     clearInterval(evictionMonitor);
     await payoutWorker.close();
     await archiveWorker.close();
+    await leagueWorker.close();
+    await gdprErasureWorker.close();
     await closeDb();
     await redis.disconnect();
     logger.info("Worker shutdown complete");

--- a/docs/runbooks/gdpr-erasure.md
+++ b/docs/runbooks/gdpr-erasure.md
@@ -1,0 +1,147 @@
+# Runbook: GDPR Right-to-Erasure
+
+## Overview
+
+BrandBlitz supports the GDPR right to erasure (Article 17) via a two-step pseudonymisation process. User identity (PII) is wiped, while financial and fraud records are retained for regulatory compliance (Article 17(3)(b)).
+
+---
+
+## How Erasure Works
+
+### Step 1 — Request
+
+The user (or an admin acting on a legal request) initiates deletion:
+
+- **Self-serve:** `POST /me/delete-account` with `{ "email": "<confirmed email>" }`
+- **Admin/legal:** `POST /admin/users/:userId/erase` (requires admin role; audit-logged)
+
+Both endpoints return `202 Accepted` with an `executeAt` timestamp 30 days in the future.
+
+A row is inserted into `gdpr_erasure_requests` and a BullMQ job is enqueued with a 30-day delay (`jobId: gdpr:<userId>`).
+
+### Step 2 — Grace period (30 days)
+
+During the grace window the user can cancel:
+
+```
+DELETE /me/delete-account
+```
+
+This sets `cancelled_at` on the request row and removes the pending BullMQ job.
+
+### Step 3 — Anonymisation
+
+After 30 days the `gdpr-erasure` BullMQ worker fires and:
+
+1. Confirms the request is still pending (not cancelled, not already executed).
+2. Calls `anonymizeUser(userId)` which nulls / randomises all PII columns:
+   - `email` → `deleted_<uuid>@gdpr.invalid`
+   - `display_name` → `Deleted User`
+   - `username` → `deleted_<uuid>`
+   - `phone_hash`, `avatar_url`, `google_id`, `stellar_address`, `embedded_wallet_address`, `muxed_id` → `NULL`
+3. Calls `revokeAllUserRefreshTokens(userId)` to invalidate all active sessions.
+4. Sets `executed_at` on the request row.
+
+**The user row is NOT deleted.** It acts as an anonymised shell so that `game_sessions` and `payouts` retain their foreign-key linkage for financial/regulatory record-keeping.
+
+---
+
+## Hard-Deleting a User (DBA-only)
+
+If a full row deletion is required (e.g., test data cleanup or a court order):
+
+1. **Delete fraud flags first** — `fraud_flags.user_id` has `ON DELETE RESTRICT`. Deleting a user with open fraud flags will fail until they are removed:
+
+   ```sql
+   DELETE FROM fraud_flags WHERE user_id = '<userId>';
+   ```
+
+2. **Delete the user row:**
+
+   ```sql
+   DELETE FROM users WHERE id = '<userId>';
+   ```
+
+3. After deletion:
+   - `game_sessions.user_id` → `NULL` (SET NULL)
+   - `payouts.user_id` → `NULL` (SET NULL)
+   - Brands, league assignments, badges, referrals → cascade-deleted
+
+---
+
+## Relevant Database Objects
+
+| Object | Purpose |
+|---|---|
+| `gdpr_erasure_requests` | Tracks pending / cancelled / executed erasure requests |
+| `gdpr_erasure_requests.execute_at` | Timestamp when anonymisation fires |
+| `gdpr_erasure_requests.cancelled_at` | Set when user cancels within grace window |
+| `gdpr_erasure_requests.executed_at` | Set after successful anonymisation |
+| `gdpr_erasure_requests.admin_id` | Non-null for admin-initiated requests |
+| BullMQ queue `gdpr-erasure` | Delayed jobs (`gdpr:<userId>`) fired after 30 days |
+
+---
+
+## Monitoring
+
+Check pending requests:
+
+```sql
+SELECT id, user_id, execute_at, cancelled_at, executed_at
+FROM gdpr_erasure_requests
+WHERE cancelled_at IS NULL
+ORDER BY execute_at;
+```
+
+Check failed BullMQ jobs in the `gdpr-erasure` queue via the Bull dashboard or Redis:
+
+```
+KEYS gdpr:*
+```
+
+---
+
+## Failure Recovery
+
+If a BullMQ job fails after all retries (3 attempts with exponential backoff):
+
+1. Identify the `requestId` from the `gdpr_erasure_requests` row.
+2. Manually re-run anonymisation:
+
+   ```sql
+   -- Verify the request is still pending
+   SELECT * FROM gdpr_erasure_requests WHERE id = '<requestId>';
+   ```
+
+3. Run the anonymisation SQL directly if the worker cannot be restarted:
+
+   ```sql
+   UPDATE users SET
+     email                   = 'deleted_' || gen_random_uuid()::text || '@gdpr.invalid',
+     google_id               = NULL,
+     display_name            = 'Deleted User',
+     username                = 'deleted_' || gen_random_uuid()::text,
+     avatar_url              = NULL,
+     phone_hash              = NULL,
+     phone_verified          = FALSE,
+     phone_verified_at       = NULL,
+     stellar_address         = NULL,
+     embedded_wallet_address = NULL,
+     muxed_id                = NULL,
+     updated_at              = NOW()
+   WHERE id = '<userId>';
+
+   UPDATE gdpr_erasure_requests
+   SET executed_at = NOW(), updated_at = NOW()
+   WHERE id = '<requestId>';
+   ```
+
+---
+
+## See Also
+
+- Issue #142 — GDPR right-to-erasure implementation
+- Issue #103 — FK ON DELETE audit (ensures financial records survive user deletion)
+- `apps/api/src/db/queries/gdpr.ts` — DB query layer
+- `apps/api/src/queues/gdpr-erasure.queue.ts` — BullMQ queue
+- `apps/api/src/queues/processors/gdpr-erasure.processor.ts` — Worker logic

--- a/init.sql
+++ b/init.sql
@@ -85,7 +85,10 @@ CREATE TABLE challenges (
   payout_tx_hashes    TEXT[],
   created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  CONSTRAINT challenges_ends_after_starts CHECK (ends_at IS NULL OR ends_at > starts_at)
+  CONSTRAINT challenges_ends_after_starts CHECK (ends_at IS NULL OR ends_at > starts_at),
+  CONSTRAINT challenges_pool_amount_positive CHECK (
+    status IN ('pending_deposit', 'cancelled') OR pool_amount_stroops > 0
+  )
 );
 
 CREATE INDEX idx_challenges_brand_id      ON challenges (brand_id);
@@ -122,7 +125,7 @@ CREATE INDEX idx_challenge_questions_challenge ON challenge_questions (challenge
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE game_sessions (
   id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id               UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  user_id               UUID REFERENCES users(id) ON DELETE SET NULL,
   challenge_id          UUID NOT NULL REFERENCES challenges(id) ON DELETE CASCADE,
   device_id             TEXT,
   ip_address            INET,
@@ -149,7 +152,8 @@ CREATE TABLE game_sessions (
   fraud_flags           TEXT[]  NOT NULL DEFAULT '{}',
   created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE (user_id, challenge_id)
+  UNIQUE (user_id, challenge_id),
+  CONSTRAINT game_sessions_score_range CHECK (total_score >= 0 AND total_score <= 450)
 );
 
 CREATE INDEX idx_game_sessions_challenge_id ON game_sessions (challenge_id);
@@ -177,7 +181,7 @@ CREATE INDEX idx_round_scores_session ON session_round_scores (session_id);
 CREATE TABLE payouts (
   id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   challenge_id     UUID NOT NULL REFERENCES challenges(id) ON DELETE CASCADE,
-  user_id          UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  user_id          UUID REFERENCES users(id) ON DELETE SET NULL,
   session_id       UUID NOT NULL REFERENCES game_sessions(id) ON DELETE CASCADE,
   amount_stroops   BIGINT NOT NULL DEFAULT 0,
   status           TEXT NOT NULL DEFAULT 'pending'
@@ -188,7 +192,8 @@ CREATE TABLE payouts (
   updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE (challenge_id, user_id),
   CONSTRAINT payouts_failed_requires_message
-    CHECK ((status = 'failed') = (LENGTH(error_message) > 0))
+    CHECK ((status = 'failed') = (LENGTH(error_message) > 0)),
+  CONSTRAINT payouts_amount_positive CHECK (amount_stroops > 0)
 );
 
 CREATE INDEX idx_payouts_challenge_id ON payouts (challenge_id);
@@ -201,7 +206,7 @@ CREATE INDEX idx_payouts_status       ON payouts (status);
 CREATE TABLE fraud_flags (
   id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   session_id   UUID NOT NULL REFERENCES game_sessions(id) ON DELETE CASCADE,
-  user_id      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  user_id      UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
   flag_type    TEXT NOT NULL,
   details      JSONB,
   created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -315,3 +320,24 @@ CREATE TABLE audit_log (
 CREATE INDEX idx_audit_log_actor_id   ON audit_log (actor_id);
 CREATE INDEX idx_audit_log_entity     ON audit_log (entity, entity_key);
 CREATE INDEX idx_audit_log_created_at ON audit_log (created_at DESC);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- GDPR ERASURE REQUESTS (tracks 30-day grace period before anonymisation)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE gdpr_erasure_requests (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  execute_at   TIMESTAMPTZ NOT NULL,
+  cancelled_at TIMESTAMPTZ,
+  executed_at  TIMESTAMPTZ,
+  admin_id     UUID        REFERENCES users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_gdpr_erasure_user_id ON gdpr_erasure_requests (user_id);
+
+CREATE TRIGGER gdpr_erasure_requests_updated_at
+  BEFORE UPDATE ON gdpr_erasure_requests
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/migrations/012_fk_on_delete.sql
+++ b/migrations/012_fk_on_delete.sql
@@ -1,0 +1,34 @@
+-- Migration 012: Fix ON DELETE behaviour for financial / fraud records
+-- game_sessions.user_id  → SET NULL  (keep session history when user deleted)
+-- payouts.user_id        → SET NULL  (keep payout records for regulatory compliance)
+-- fraud_flags.user_id    → RESTRICT  (block hard-delete while fraud investigation open)
+
+-- ── game_sessions ────────────────────────────────────────────────────────────
+ALTER TABLE game_sessions
+  ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE game_sessions
+  DROP CONSTRAINT game_sessions_user_id_fkey;
+
+ALTER TABLE game_sessions
+  ADD CONSTRAINT game_sessions_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL;
+
+-- ── payouts ──────────────────────────────────────────────────────────────────
+ALTER TABLE payouts
+  ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE payouts
+  DROP CONSTRAINT payouts_user_id_fkey;
+
+ALTER TABLE payouts
+  ADD CONSTRAINT payouts_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL;
+
+-- ── fraud_flags ───────────────────────────────────────────────────────────────
+ALTER TABLE fraud_flags
+  DROP CONSTRAINT fraud_flags_user_id_fkey;
+
+ALTER TABLE fraud_flags
+  ADD CONSTRAINT fraud_flags_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT;

--- a/migrations/013_check_constraints.sql
+++ b/migrations/013_check_constraints.sql
@@ -1,0 +1,21 @@
+-- Migration 013: DB-level CHECK constraints for core numeric invariants
+-- Complements Zod edge validation; rejects garbage if Zod is bypassed.
+
+-- challenges: pool must be positive once the challenge is active
+--   (pending_deposit and cancelled/refunded may still hold 0)
+ALTER TABLE challenges
+  ADD CONSTRAINT challenges_pool_amount_positive
+    CHECK (
+      status IN ('pending_deposit', 'cancelled')
+      OR pool_amount_stroops > 0
+    );
+
+-- game_sessions: total score must be in [0, 450] (3 rounds × 150 max)
+ALTER TABLE game_sessions
+  ADD CONSTRAINT game_sessions_score_range
+    CHECK (total_score >= 0 AND total_score <= 450);
+
+-- payouts: payout amounts must always be positive
+ALTER TABLE payouts
+  ADD CONSTRAINT payouts_amount_positive
+    CHECK (amount_stroops > 0);

--- a/migrations/014_gdpr_erasure.sql
+++ b/migrations/014_gdpr_erasure.sql
@@ -1,0 +1,22 @@
+-- Migration 014: GDPR right-to-erasure request tracking table
+-- Records pending / executed / cancelled erasure requests.
+-- The actual anonymisation is performed by the gdpr-erasure BullMQ worker
+-- after the 30-day grace period elapses.
+
+CREATE TABLE gdpr_erasure_requests (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  execute_at   TIMESTAMPTZ NOT NULL,
+  cancelled_at TIMESTAMPTZ,
+  executed_at  TIMESTAMPTZ,
+  admin_id     UUID        REFERENCES users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_gdpr_erasure_user_id ON gdpr_erasure_requests (user_id);
+
+CREATE TRIGGER gdpr_erasure_requests_updated_at
+  BEFORE UPDATE ON gdpr_erasure_requests
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
## Summary

  Resolves #103, #107, #116, #142

  ### #103 — FK ON DELETE Audit

  | Table | Column | Before | After | Reason |
  |---|---|---|---|---|
  | game_sessions | user_id | NOT NULL CASCADE | NULL SET NULL | Preserve historical session records |
  | payouts | user_id | NOT NULL CASCADE | NULL SET NULL | Preserve financial records for compliance |
  | fraud_flags | user_id | NOT NULL CASCADE | NOT NULL RESTRICT | Block user deletion while fraud investigation open |
  | audit_log | actor_id | NULL SET NULL | NULL SET NULL | No change (already correct) |
  | All others | — | CASCADE | CASCADE | Ephemeral/owned data, cascade is appropriate |

  ### #107 — CHECK Constraints

  Added DB-level constraints (complements existing Zod edge validation):
  - `challenges.pool_amount_stroops > 0` when status not in `('pending_deposit','cancelled')`
  - `game_sessions.total_score BETWEEN 0 AND 450` (3 rounds × 150 max)
  - `payouts.amount_stroops > 0` (no zero-value payouts)

  ### #116 — MIME Magic Bytes Validation

  `POST /upload/verify` now fetches first 8 KiB via `GetObjectCommand` Range request and validates magic bytes against
  the declared `ContentType` from S3 metadata. SVG files are additionally scanned for `<script>` tags. Mismatches delete
  the object and return 400.

  ### #142 — GDPR Right-to-Erasure

  - `POST /me/delete-account` — self-serve; requires email confirmation; 202 + 30-day grace
  - `DELETE /me/delete-account` — cancel within grace period
  - `POST /admin/users/:userId/erase` — admin-triggered (audit-logged)
  - BullMQ `gdpr-erasure` queue: 30-day delayed job per user (`jobId: gdpr:<userId>`)
  - Anonymisation: email→placeholder, name→"Deleted User", phone/avatar/wallet→NULL. User row retained (preserves FK
  linkage in game_sessions/payouts)
  - Runbook: `docs/runbooks/gdpr-erasure.md`

  ## Migrations

  Apply in order on existing DBs:
  1. `migrations/012_fk_on_delete.sql`
  2. `migrations/013_check_constraints.sql`
  3. `migrations/014_gdpr_erasure.sql`

  Fresh DBs: run `init.sql` (already updated).

  ## Test plan

  - [ ] `pnpm -F api test` passes
  - [ ] SQL: `INSERT INTO game_sessions (..., total_score) VALUES (..., 451)` → constraint violation
  - [ ] SQL: `INSERT INTO payouts (..., amount_stroops) VALUES (..., 0)` → constraint violation
  - [ ] SQL: delete user with fraud_flag → FK error
  - [ ] SQL: delete user without fraud_flag → game_sessions.user_id and payouts.user_id → NULL
  - [ ] `POST /upload/verify` with PNG magic but declared `image/jpeg` → 400 + file deleted
  - [ ] `POST /me/delete-account` with correct email → 202 with executeAt ~30 days out
  - [ ] `DELETE /me/delete-account` → 200 cancels request

  Closes #103
  Closes #107
  Closes #116
  Closes #142