### PR TITLE
Fix user profiles, session timeout sweep, and leaderboard pagination

### DIFF
--- a/apps/api/src/db/queries/gdpr.ts
+++ b/apps/api/src/db/queries/gdpr.ts
@@ -109,7 +109,6 @@ export async function anonymizeUser(userId: string): Promise<void> {
        phone_verified_at       = NULL,
        stellar_address         = NULL,
        embedded_wallet_address = NULL,
-       muxed_id                = NULL,
        updated_at              = NOW()
      WHERE id = $1`,
     [userId, `deleted_${token}@gdpr.invalid`, `deleted_${token}`]

--- a/apps/api/src/db/queries/sessions.ts
+++ b/apps/api/src/db/queries/sessions.ts
@@ -1,4 +1,5 @@
-import { query } from "../index";
+import type { PoolClient } from "pg";
+import { pool, query } from "../index";
 
 export interface GameSession {
   id: string;
@@ -99,6 +100,22 @@ export async function markChallengeStarted(sessionId: string): Promise<void> {
   );
 }
 
+async function withTransaction<T>(callback: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    const result = await callback(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 export async function recordRoundScore(
   sessionId: string,
   round: 1 | 2 | 3,
@@ -134,20 +151,56 @@ export async function recordRoundScore(
 }
 
 export async function finishSession(sessionId: string): Promise<GameSession> {
-  const result = await query<GameSession>(
-    `UPDATE game_sessions
-     SET completed_at = NOW(),
-         status = 'completed',
-         total_score = COALESCE((
-           SELECT SUM(score)::int
-           FROM session_round_scores
-           WHERE session_id = $1
-         ), 0)
-     WHERE id = $1
-     RETURNING *`,
-    [sessionId]
-  );
-  return result.rows[0];
+  return withTransaction<GameSession>(async (client) => {
+    const sessionResult = await client.query<GameSession>(
+      `SELECT *
+       FROM game_sessions
+       WHERE id = $1
+       FOR UPDATE`,
+      [sessionId]
+    );
+    const current = sessionResult.rows[0];
+    if (!current) {
+      throw new Error("Session not found");
+    }
+
+    if (current.completed_at) {
+      return current;
+    }
+
+    const totalResult = await client.query<{ total_score: number }>(
+      `SELECT COALESCE(SUM(score)::int, 0) AS total_score
+       FROM session_round_scores
+       WHERE session_id = $1`,
+      [sessionId]
+    );
+    const totalScore = totalResult.rows[0]?.total_score ?? 0;
+
+    const finishedResult = await client.query<GameSession>(
+      `UPDATE game_sessions
+       SET completed_at = NOW(),
+           status = 'completed',
+           total_score = $2
+       WHERE id = $1
+       RETURNING *`,
+      [sessionId, totalScore]
+    );
+    const finished = finishedResult.rows[0];
+    if (!finished) {
+      throw new Error("Session not found");
+    }
+
+    await client.query(
+      `UPDATE users
+       SET total_score = total_score + $2,
+           challenges_played = challenges_played + 1,
+           updated_at = NOW()
+       WHERE id = $1`,
+      [finished.user_id, finished.total_score]
+    );
+
+    return finished;
+  });
 }
 
 export async function storeSessionHmac(sessionId: string, hmac: string): Promise<void> {
@@ -171,6 +224,23 @@ export async function flagSession(
   );
 }
 
+export async function markAbandonedSessions(): Promise<number> {
+  const result = await query<{ count: number }>(
+    `WITH abandoned AS (
+       UPDATE game_sessions
+       SET status = 'abandoned',
+           completed_at = COALESCE(completed_at, NOW()),
+           updated_at = NOW()
+       WHERE status IN ('warmup', 'active')
+         AND COALESCE(challenge_started_at, warmup_started_at, created_at) < NOW() - INTERVAL '2 hours'
+       RETURNING id
+     )
+     SELECT COUNT(*)::int AS count FROM abandoned`
+  );
+
+  return result.rows[0]?.count ?? 0;
+}
+
 export async function getLeaderboard(
   challengeId: string,
   limit = 20,
@@ -192,10 +262,52 @@ export async function getLeaderboard(
      WHERE gs.challenge_id = $1
        AND gs.flagged = FALSE
        AND gs.is_practice = FALSE
+       AND gs.status = 'completed'
      ORDER BY gs.total_score DESC, gs.completed_at ASC
      LIMIT $2 OFFSET $3`,
     [challengeId, limit, offset]
   );
+  return result.rows;
+}
+
+export async function getTopSessionsPerChallenge(
+  challengeIds: string[],
+  limitPerChallenge = 10
+): Promise<LeaderboardSession[]> {
+  if (challengeIds.length === 0) {
+    return [];
+  }
+
+  const result = await query<LeaderboardSession & { challenge_rank: number }>(
+    `WITH ranked AS (
+       SELECT gs.*,
+              u.email AS username,
+              u.avatar_url,
+              u.display_name,
+              u.league,
+              u.total_earned_usdc,
+              COALESCE(
+                NULLIF(to_jsonb(u) ->> 'embedded_wallet_address', ''),
+                NULLIF(to_jsonb(u) ->> 'stellar_address', '')
+              ) AS stellar_address,
+              ROW_NUMBER() OVER (
+                PARTITION BY gs.challenge_id
+                ORDER BY gs.total_score DESC, gs.completed_at ASC
+              ) AS challenge_rank
+       FROM game_sessions gs
+       JOIN users u ON gs.user_id = u.id
+       WHERE gs.challenge_id = ANY($1::uuid[])
+         AND gs.flagged = FALSE
+         AND gs.is_practice = FALSE
+         AND gs.status = 'completed'
+     )
+     SELECT *
+     FROM ranked
+     WHERE challenge_rank <= $2
+     ORDER BY challenge_id ASC, challenge_rank ASC`,
+    [challengeIds, limitPerChallenge]
+  );
+
   return result.rows;
 }
 
@@ -211,6 +323,7 @@ export async function getArchivedLeaderboard(
      WHERE gs.challenge_id = $1
        AND gs.flagged = FALSE
        AND gs.is_practice = FALSE
+       AND gs.status = 'completed'
      ORDER BY gs.total_score DESC, gs.challenge_ended_at ASC
      LIMIT $2 OFFSET $3`,
     [challengeId, limit, offset]

--- a/apps/api/src/db/queries/users.ts
+++ b/apps/api/src/db/queries/users.ts
@@ -1,4 +1,5 @@
-import { query } from "../index";
+import type { PoolClient } from "pg";
+import { pool, query } from "../index";
 
 export interface User {
   id: string;
@@ -58,6 +59,44 @@ export async function findUserByPhoneHash(phoneHash: string): Promise<User | nul
   return result.rows[0] ?? null;
 }
 
+function slugifyUsername(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-")
+    .slice(0, 24);
+}
+
+async function allocateUsername(
+  client: PoolClient,
+  displayName: string,
+  email: string
+): Promise<string> {
+  const base = slugifyUsername(displayName) || slugifyUsername(email.split("@")[0] ?? "") || "player";
+  const prefix = `${base}-%`;
+  const result = await client.query<{ username: string }>(
+    `SELECT username
+     FROM users
+     WHERE username = $1 OR username LIKE $2`,
+    [base, prefix]
+  );
+
+  const taken = new Set(result.rows.map((row) => row.username));
+  if (!taken.has(base)) {
+    return base;
+  }
+
+  let suffix = 2;
+  while (taken.has(`${base}-${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${base}-${suffix}`;
+}
+
 export async function getUserPublicProfileByUsername(username: string): Promise<PublicUser | null> {
   const result = await query<PublicUser>(
     `SELECT display_name, username, league, total_earned_usdc, challenges_played, avatar_url, streak
@@ -76,18 +115,38 @@ export async function upsertUser(data: {
 }): Promise<User> {
   const displayName = data.name?.trim() || data.email.split("@")[0] || "BrandBlitz User";
 
-  const result = await query<User>(
-    `INSERT INTO users (email, google_id, display_name, avatar_url)
-     VALUES ($1, $2, $3, $4)
-     ON CONFLICT (google_id) DO UPDATE
-       SET email = EXCLUDED.email,
-           display_name = COALESCE(NULLIF(EXCLUDED.display_name, ''), users.display_name),
-           avatar_url = COALESCE(EXCLUDED.avatar_url, users.avatar_url),
-           updated_at = NOW()
-     RETURNING *`,
-    [data.email, data.googleId, displayName, data.avatarUrl ?? null]
-  );
-  return result.rows[0];
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const client = await pool.connect();
+
+    try {
+      await client.query("BEGIN");
+      const username = await allocateUsername(client, displayName, data.email);
+      const result = await client.query<User>(
+        `INSERT INTO users (email, google_id, display_name, username, avatar_url)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (google_id) DO UPDATE
+           SET email = EXCLUDED.email,
+               display_name = COALESCE(NULLIF(EXCLUDED.display_name, ''), users.display_name),
+               username = COALESCE(users.username, EXCLUDED.username),
+               avatar_url = COALESCE(EXCLUDED.avatar_url, users.avatar_url),
+               updated_at = NOW()
+         RETURNING *`,
+        [data.email, data.googleId, displayName, username, data.avatarUrl ?? null]
+      );
+      await client.query("COMMIT");
+      return result.rows[0];
+    } catch (error) {
+      await client.query("ROLLBACK");
+      if (attempt < 2 && error instanceof Error && "code" in error && (error as { code?: string }).code === "23505") {
+        continue;
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  throw new Error("Unable to allocate username");
 }
 
 export async function updateUserWallet(
@@ -97,6 +156,16 @@ export async function updateUserWallet(
   await query(
     "UPDATE users SET stellar_address = $1, updated_at = NOW() WHERE id = $2",
     [stellarAddress, userId]
+  );
+}
+
+export async function incrementUserEarnings(userId: string, amountUsdc: string): Promise<void> {
+  await query(
+    `UPDATE users
+     SET total_earned_usdc = total_earned_usdc + $1::numeric,
+         updated_at = NOW()
+     WHERE id = $2`,
+    [amountUsdc, userId]
   );
 }
 

--- a/apps/api/src/queues/processors/session-timeout.processor.ts
+++ b/apps/api/src/queues/processors/session-timeout.processor.ts
@@ -1,0 +1,40 @@
+import { Worker, type Job, type WorkerOptions } from "bullmq";
+import { redis } from "../../lib/redis";
+import { logger } from "../../lib/logger";
+import { metrics } from "../../lib/metrics";
+import { markAbandonedSessions } from "../../db/queries/sessions";
+
+export const sessionTimeoutWorkerOptions = {
+  connection: redis,
+  concurrency: 1,
+} satisfies WorkerOptions;
+
+export async function processSessionTimeoutJob(_job: Job): Promise<void> {
+  const abandonedCount = await markAbandonedSessions();
+  for (let index = 0; index < abandonedCount; index += 1) {
+    metrics.inc("sessions.abandoned_total");
+  }
+  logger.info("Session timeout sweep completed", { abandonedCount });
+}
+
+export function createSessionTimeoutWorker(WorkerImpl: typeof Worker = Worker): Worker {
+  const worker = new WorkerImpl(
+    "session-timeout",
+    processSessionTimeoutJob,
+    sessionTimeoutWorkerOptions
+  );
+
+  worker.on("completed", (job) => {
+    logger.info("Session timeout job completed", { jobId: job.id });
+  });
+
+  worker.on("failed", (job, err) => {
+    logger.error("Session timeout job failed", {
+      jobId: job?.id,
+      error: err.message,
+      attempts: job?.attemptsMade,
+    });
+  });
+
+  return worker;
+}

--- a/apps/api/src/queues/session-timeout.queue.ts
+++ b/apps/api/src/queues/session-timeout.queue.ts
@@ -1,0 +1,25 @@
+import { Queue, type JobsOptions } from "bullmq";
+import { redis } from "../lib/redis";
+
+export const sessionTimeoutJobOptions = {
+  attempts: 1,
+  removeOnComplete: { count: 50 },
+  removeOnFail: { count: 25 },
+} satisfies JobsOptions;
+
+export const sessionTimeoutQueue = new Queue("session-timeout", {
+  connection: redis,
+  defaultJobOptions: sessionTimeoutJobOptions,
+});
+
+export async function ensureSessionTimeoutSweepJob(): Promise<void> {
+  await sessionTimeoutQueue.add(
+    "session-timeout-sweep",
+    {},
+    {
+      jobId: "session-timeout-sweep",
+      repeat: { every: 5 * 60_000 },
+      removeOnComplete: true,
+    }
+  );
+}

--- a/apps/api/src/routes/leaderboard.ts
+++ b/apps/api/src/routes/leaderboard.ts
@@ -97,8 +97,13 @@ router.get("/stream", async (req, res) => {
  * Cross-challenge leaderboard (cached in Redis, 5 min TTL).
  * Single aggregated query via ROW_NUMBER() — no N+1.
  */
-router.get("/global", async (_req, res) => {
-  const response = await cached("leaderboard:global", 300, async () => {
+router.get("/global", async (req, res) => {
+  const { limit, offset } = z.object({
+    limit: z.coerce.number().min(1).max(100).default(50),
+    offset: z.coerce.number().min(0).default(0),
+  }).parse(req.query);
+
+  const response = await cached(`leaderboard:global:${limit}:${offset}`, 300, async () => {
     const challenges = await getActiveChallenges(10);
     const challengeIds = challenges.map((c) => c.id);
     const topSessions = await getTopSessionsPerChallenge(challengeIds, 10);
@@ -120,7 +125,17 @@ router.get("/global", async (_req, res) => {
       };
     });
 
-    return { leaderboard: allSessions, cachedAt: new Date().toISOString() };
+    const leaderboard = allSessions.slice(offset, offset + limit);
+
+    return {
+      leaderboard,
+      cachedAt: new Date().toISOString(),
+      pagination: {
+        limit,
+        offset,
+        hasMore: offset + leaderboard.length < allSessions.length,
+      },
+    };
   });
 
   res.json(response);

--- a/apps/api/src/services/payout.ts
+++ b/apps/api/src/services/payout.ts
@@ -3,6 +3,7 @@ import type { NetworkName } from "@brandblitz/stellar";
 import { getLeaderboard } from "../db/queries/sessions";
 import { getChallengeById, updateChallengeStatus } from "../db/queries/challenges";
 import { createPayout, updatePayoutStatus } from "../db/queries/payouts";
+import { incrementUserEarnings } from "../db/queries/users";
 import { rankWinners } from "./scoring";
 import { calculatePayoutShareStroops, stroopsToUsdc } from "../lib/usdc";
 import { payoutJobOptions, payoutQueue } from "../queues/payout.queue";
@@ -84,7 +85,7 @@ export async function processPayout(challengeId: string): Promise<void> {
 
   const totalPoints = eligibleWinners.reduce((acc, s) => acc + s.totalScore, 0);
   const recipients: PayoutRecipient[] = [];
-  const payoutRecords: { id: string; address: string }[] = [];
+  const payoutRecords: { id: string; address: string; userId: string; amount: string }[] = [];
 
   for (const winner of eligibleWinners) {
     const amountStroops = calculatePayoutShareStroops(
@@ -106,7 +107,12 @@ export async function processPayout(challengeId: string): Promise<void> {
     });
 
     recipients.push({ address: winner.stellarAddress, amount });
-    payoutRecords.push({ id: payout.id, address: winner.stellarAddress });
+    payoutRecords.push({
+      id: payout.id,
+      address: winner.stellarAddress,
+      userId: winner.userId,
+      amount,
+    });
   }
 
   if (recipients.length === 0) {
@@ -144,6 +150,9 @@ export async function processPayout(challengeId: string): Promise<void> {
       const record = payoutRecords.find((candidate) => candidate.address === recipient.address);
       if (record) {
         await updatePayoutStatus(record.id, status, result.txHash || undefined, errorMessage);
+        if (result.success) {
+          await incrementUserEarnings(record.userId, record.amount);
+        }
       }
     }
 

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -8,6 +8,8 @@ import { createArchiveWorker, scheduleArchiveJob } from "./queues/archive.queue"
 import { createLeagueWorker } from "./queues/processors/league.processor";
 import { createGdprErasureWorker } from "./queues/processors/gdpr-erasure.processor";
 import { ensureLeagueRepeatableJobs } from "./queues/league.queue";
+import { createSessionTimeoutWorker } from "./queues/processors/session-timeout.processor";
+import { ensureSessionTimeoutSweepJob, sessionTimeoutQueue } from "./queues/session-timeout.queue";
 import { drainSharedAgent } from "@brandblitz/stellar";
 import { logger } from "./lib/logger";
 
@@ -19,10 +21,12 @@ async function startWorker(): Promise<void> {
   const archiveWorker = createArchiveWorker();
   const leagueWorker = createLeagueWorker();
   const gdprErasureWorker = createGdprErasureWorker();
+  const sessionTimeoutWorker = createSessionTimeoutWorker();
   await scheduleArchiveJob();
   await ensureLeagueRepeatableJobs();
+  await ensureSessionTimeoutSweepJob();
   const evictionMonitor = startRedisEvictionMonitor();
-  logger.info("BullMQ worker started — processing payout + archive + league + gdpr-erasure jobs");
+  logger.info("BullMQ worker started — processing payout + archive + league + gdpr-erasure + session-timeout jobs");
 
   const shutdown = async (signal: string) => {
     logger.info(`${signal} received — closing worker`);
@@ -31,6 +35,8 @@ async function startWorker(): Promise<void> {
     await archiveWorker.close();
     await leagueWorker.close();
     await gdprErasureWorker.close();
+    await sessionTimeoutWorker.close();
+    await sessionTimeoutQueue.close();
     await closeDb();
     await redis.disconnect();
     drainSharedAgent();

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:22.14.0-alpine AS base
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 # ── deps ──────────────────────────────────────────────────────────────────────
@@ -35,7 +35,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 
 # ── runner ────────────────────────────────────────────────────────────────────
-FROM node:22-alpine AS runner
+FROM node:22.14.0-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
@@ -51,6 +51,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/
 USER nextjs
 
 EXPOSE 3000
+STOPSIGNAL SIGTERM
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -6,23 +6,29 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
-async function getGlobalLeaderboard(): Promise<{ entries: LeaderboardEntry[]; failed: boolean }> {
+async function getGlobalLeaderboard(): Promise<{
+  entries: LeaderboardEntry[];
+  hasMore: boolean;
+  failed: boolean;
+}> {
   try {
-    const res = await api.get("/leaderboard/global");
+    const res = await api.get("/leaderboard/global?limit=50&offset=0");
     return {
       entries: res.data.leaderboard,
+      hasMore: Boolean(res.data.pagination?.hasMore),
       failed: false,
     };
   } catch {
     return {
       entries: [],
+      hasMore: false,
       failed: true,
     };
   }
 }
 
 export default async function LeaderboardPage() {
-  const { entries, failed } = await getGlobalLeaderboard();
+  const { entries, hasMore, failed } = await getGlobalLeaderboard();
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
@@ -47,7 +53,7 @@ export default async function LeaderboardPage() {
               />
             </div>
           ) : (
-            <LiveGlobalLeaderboard initial={entries} />
+            <LiveGlobalLeaderboard initial={entries} initialHasMore={hasMore} />
           )}
         </CardContent>
       </Card>

--- a/apps/web/src/components/leaderboard/live-global-leaderboard.tsx
+++ b/apps/web/src/components/leaderboard/live-global-leaderboard.tsx
@@ -6,37 +6,173 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { api } from "@/lib/api";
 import { formatScore, formatUsdc } from "@/lib/utils";
 import type { LeaderboardEntry } from "@/lib/api";
-import { useLiveLeaderboard } from "@/hooks/use-live-leaderboard";
 
 const MEDAL: Record<number, string> = { 1: "🥇", 2: "🥈", 3: "🥉" };
+const PAGE_SIZE = 50;
+const STORAGE_KEY = "brandblitz:leaderboard:global";
 
-export function LiveGlobalLeaderboard({ initial }: { initial: LeaderboardEntry[] }) {
-  const { entries } = useLiveLeaderboard({ initial });
+async function fetchLeaderboardPage(offset: number): Promise<{
+  entries: LeaderboardEntry[];
+  hasMore: boolean;
+}> {
+  const res = await api.get(`/leaderboard/global?limit=${PAGE_SIZE}&offset=${offset}`);
+  const entries: LeaderboardEntry[] = res.data.leaderboard;
+  const hasMore = Boolean(res.data.pagination?.hasMore ?? entries.length === PAGE_SIZE);
+  return { entries, hasMore };
+}
+
+function loadSavedState(): { scrollY: number; loadedCount: number } | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const raw = window.sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { scrollY?: number; loadedCount?: number };
+    if (typeof parsed.loadedCount !== "number") {
+      return null;
+    }
+    return {
+      scrollY: typeof parsed.scrollY === "number" ? parsed.scrollY : 0,
+      loadedCount: parsed.loadedCount,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function LiveGlobalLeaderboard({
+  initial,
+  initialHasMore = initial.length === PAGE_SIZE,
+}: {
+  initial: LeaderboardEntry[];
+  initialHasMore?: boolean;
+}) {
+  const [entries, setEntries] = useState(initial);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
   const prevRankByUserRef = useRef<Map<string, number>>(new Map());
   const [changedUsers, setChangedUsers] = useState<Set<string>>(new Set());
+  const restoreOnceRef = useRef(false);
 
   const rows = useMemo(() => {
-    return entries.map((e) => {
-      const userKey = e.userId ?? e.username;
-      return { ...e, _key: userKey };
+    return entries.map((entry) => {
+      const userKey = entry.userId ?? entry.username;
+      return { ...entry, _key: userKey };
     });
   }, [entries]);
 
   useEffect(() => {
+    const saved = loadSavedState();
+    if (restoreOnceRef.current || !saved) {
+      return;
+    }
+    restoreOnceRef.current = true;
+
+    let cancelled = false;
+
+    const restore = async () => {
+      setIsRestoring(true);
+      let currentEntries = initial.slice();
+      let nextOffset = currentEntries.length;
+
+      while (currentEntries.length < saved.loadedCount) {
+        const page = await fetchLeaderboardPage(nextOffset);
+        if (cancelled || page.entries.length === 0) {
+          break;
+        }
+
+        currentEntries = currentEntries.concat(page.entries);
+        nextOffset = currentEntries.length;
+        setEntries(currentEntries);
+        setHasMore(page.hasMore);
+
+        if (!page.hasMore) {
+          break;
+        }
+      }
+
+      if (!cancelled) {
+        window.requestAnimationFrame(() => window.scrollTo(0, saved.scrollY));
+        setIsRestoring(false);
+      }
+    };
+
+    void restore();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [initial]);
+
+  useEffect(() => {
+    const persistState = () => {
+      window.sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          scrollY: window.scrollY,
+          loadedCount: entries.length,
+        })
+      );
+    };
+
+    window.addEventListener("pagehide", persistState);
+    window.addEventListener("beforeunload", persistState);
+    return () => {
+      window.removeEventListener("pagehide", persistState);
+      window.removeEventListener("beforeunload", persistState);
+      persistState();
+    };
+  }, [entries.length]);
+
+  useEffect(() => {
     const prev = prevRankByUserRef.current;
     const changed = new Set<string>();
+
     for (const row of rows) {
       const prevRank = prev.get(row._key);
-      if (prevRank !== undefined && prevRank !== row.rank) changed.add(row._key);
+      if (prevRank !== undefined && prevRank !== row.rank) {
+        changed.add(row._key);
+      }
       prev.set(row._key, row.rank);
     }
-    if (changed.size === 0) return;
+
+    if (changed.size === 0) {
+      return;
+    }
+
     setChangedUsers(changed);
-    const t = window.setTimeout(() => setChangedUsers(new Set()), 600);
-    return () => window.clearTimeout(t);
+    const timeout = window.setTimeout(() => setChangedUsers(new Set()), 600);
+    return () => window.clearTimeout(timeout);
   }, [rows]);
+
+  const loadMore = async () => {
+    if (isLoadingMore || !hasMore) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+    try {
+      const page = await fetchLeaderboardPage(entries.length);
+      if (page.entries.length === 0) {
+        setHasMore(false);
+        return;
+      }
+
+      setEntries((current) => current.concat(page.entries));
+      setHasMore(page.hasMore);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
 
   if (rows.length === 0) {
     return (
@@ -55,65 +191,77 @@ export function LiveGlobalLeaderboard({ initial }: { initial: LeaderboardEntry[]
   }
 
   return (
-    <table className="w-full text-sm">
-      <thead>
-        <tr className="border-b border-[var(--border)]">
-          <th className="text-left px-6 py-3 font-medium text-[var(--muted-foreground)]">
-            Rank
-          </th>
-          <th className="text-left px-6 py-3 font-medium text-[var(--muted-foreground)]">
-            Player
-          </th>
-          <th className="text-right px-6 py-3 font-medium text-[var(--muted-foreground)]">
-            Score
-          </th>
-          <th className="text-right px-6 py-3 font-medium text-[var(--muted-foreground)]">
-            Earned
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((entry) => (
-          <tr
-            key={entry._key}
-            className={[
-              "border-b border-[var(--border)] last:border-0 hover:bg-[var(--muted)]/50 transition-colors",
-              changedUsers.has(entry._key) ? "bg-[var(--muted)]" : "",
-            ].join(" ")}
-          >
-            <td className="px-6 py-4 font-bold">{MEDAL[entry.rank] ?? `#${entry.rank}`}</td>
-            <td className="px-6 py-4">
-              <div className="flex items-center gap-3">
-                {entry.avatarUrl ? (
-                  <Image
-                    src={entry.avatarUrl}
-                    alt={entry.displayName ?? entry.username}
-                    width={32}
-                    height={32}
-                    sizes="32px"
-                    className="h-8 w-8 rounded-full object-cover"
-                  />
-                ) : (
-                  <div className="h-8 w-8 rounded-full bg-[var(--primary)] flex items-center justify-center text-white text-xs font-bold">
-                    {(entry.displayName ?? entry.username).charAt(0).toUpperCase()}
-                  </div>
-                )}
-                <span className="font-medium">{entry.displayName ?? entry.username}</span>
-                {entry.league && (
-                  <Badge variant={entry.league as "gold" | "silver" | "bronze"}>
-                    {entry.league}
-                  </Badge>
-                )}
-              </div>
-            </td>
-            <td className="px-6 py-4 text-right font-mono">{formatScore(entry.totalScore)}</td>
-            <td className="px-6 py-4 text-right text-green-600 font-medium">
-              {entry.totalEarned ? `${formatUsdc(entry.totalEarned)} USDC` : "—"}
-            </td>
+    <div className="space-y-4">
+      {isRestoring && (
+        <div className="px-6 pt-4 text-sm text-[var(--muted-foreground)]">
+          Restoring your place on the board...
+        </div>
+      )}
+
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-[var(--border)]">
+            <th className="px-6 py-3 text-left font-medium text-[var(--muted-foreground)]">Rank</th>
+            <th className="px-6 py-3 text-left font-medium text-[var(--muted-foreground)]">Player</th>
+            <th className="px-6 py-3 text-right font-medium text-[var(--muted-foreground)]">Score</th>
+            <th className="px-6 py-3 text-right font-medium text-[var(--muted-foreground)]">Earned</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {rows.map((entry) => (
+            <tr
+              key={entry._key}
+              className={[
+                "border-b border-[var(--border)] last:border-0 hover:bg-[var(--muted)]/50 transition-colors",
+                changedUsers.has(entry._key) ? "bg-[var(--muted)]" : "",
+              ].join(" ")}
+            >
+              <td className="px-6 py-4 font-bold">{MEDAL[entry.rank] ?? `#${entry.rank}`}</td>
+              <td className="px-6 py-4">
+                <div className="flex items-center gap-3">
+                  {entry.avatarUrl ? (
+                    <Image
+                      src={entry.avatarUrl}
+                      alt={entry.displayName ?? entry.username}
+                      width={32}
+                      height={32}
+                      sizes="32px"
+                      className="h-8 w-8 rounded-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--primary)] text-xs font-bold text-white">
+                      {(entry.displayName ?? entry.username).charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <span className="font-medium">{entry.displayName ?? entry.username}</span>
+                  {entry.league && (
+                    <Badge variant={entry.league as "gold" | "silver" | "bronze"}>
+                      {entry.league}
+                    </Badge>
+                  )}
+                </div>
+              </td>
+              <td className="px-6 py-4 text-right font-mono">{formatScore(entry.totalScore)}</td>
+              <td className="px-6 py-4 text-right font-medium text-green-600">
+                {entry.totalEarned ? `${formatUsdc(entry.totalEarned)} USDC` : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="flex items-center justify-between gap-4 px-6 pb-2">
+        <p className="text-sm text-[var(--muted-foreground)]">
+          Showing {rows.length} players
+        </p>
+        {hasMore ? (
+          <Button variant="outline" onClick={() => void loadMore()} disabled={isLoadingMore}>
+            {isLoadingMore ? "Loading..." : "Load more"}
+          </Button>
+        ) : (
+          <p className="text-sm text-[var(--muted-foreground)]">You&apos;re at the end.</p>
+        )}
+      </div>
+    </div>
   );
 }
-

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -41,7 +41,7 @@ export interface GameSession {
   id: string;
   userId: string;
   challengeId: string;
-  status: "warmup" | "active" | "completed" | "flagged";
+  status: "warmup" | "active" | "completed" | "flagged" | "abandoned";
   warmupStartedAt?: string;
   challengeStartedAt?: string;
   completedAt?: string;

--- a/init.sql
+++ b/init.sql
@@ -17,7 +17,6 @@ CREATE TABLE users (
   kyc_complete      BOOLEAN NOT NULL DEFAULT FALSE,
   stellar_address   TEXT,
   embedded_wallet_address TEXT,
-  muxed_id          BIGINT,
   phone_hash        TEXT UNIQUE,
   phone_verified    BOOLEAN NOT NULL DEFAULT FALSE,
   phone_verified_at TIMESTAMPTZ,
@@ -40,8 +39,6 @@ CREATE INDEX idx_users_google_id    ON users (google_id);
 CREATE INDEX idx_users_phone_hash   ON users (phone_hash);
 CREATE INDEX idx_users_total_score  ON users (total_score DESC);
 CREATE INDEX idx_users_league       ON users (league);
-CREATE UNIQUE INDEX users_muxed_id_unique ON users (muxed_id) WHERE muxed_id IS NOT NULL;
-
 -- ─────────────────────────────────────────────────────────────────────────────
 -- BRANDS
 -- ─────────────────────────────────────────────────────────────────────────────
@@ -130,7 +127,7 @@ CREATE TABLE game_sessions (
   device_id             TEXT,
   ip_address            INET,
   status                TEXT NOT NULL DEFAULT 'warmup'
-                          CHECK (status IN ('warmup', 'active', 'completed', 'flagged')),
+                          CHECK (status IN ('warmup', 'active', 'completed', 'flagged', 'abandoned')),
   is_practice           BOOLEAN NOT NULL DEFAULT FALSE,
   warmup_started_at     TIMESTAMPTZ,
   warmup_completed_at   TIMESTAMPTZ,

--- a/migrations/014_users_username_and_session_abandoned.sql
+++ b/migrations/014_users_username_and_session_abandoned.sql
@@ -1,0 +1,46 @@
+-- Backfill usernames for existing users, drop muxed_id, and allow abandoned sessions.
+
+WITH base_usernames AS (
+  SELECT
+    id,
+    COALESCE(
+      NULLIF(lower(regexp_replace(display_name, '[^a-z0-9]+', '-', 'gi')), ''),
+      NULLIF(lower(regexp_replace(split_part(email, '@', 1), '[^a-z0-9]+', '-', 'gi')), ''),
+      'player'
+    ) AS base_username,
+    ROW_NUMBER() OVER (
+      PARTITION BY COALESCE(
+        NULLIF(lower(regexp_replace(display_name, '[^a-z0-9]+', '-', 'gi')), ''),
+        NULLIF(lower(regexp_replace(split_part(email, '@', 1), '[^a-z0-9]+', '-', 'gi')), ''),
+        'player'
+      )
+      ORDER BY created_at, id
+    ) AS base_rank
+  FROM users
+),
+resolved_usernames AS (
+  SELECT
+    id,
+    CASE
+      WHEN base_rank = 1 THEN base_username
+      ELSE base_username || '-' || base_rank::text
+    END AS username
+  FROM base_usernames
+)
+UPDATE users u
+SET username = r.username
+FROM resolved_usernames r
+WHERE u.id = r.id
+  AND (u.username IS NULL OR u.username = '');
+
+ALTER TABLE users
+  DROP COLUMN IF EXISTS muxed_id;
+
+DROP INDEX IF EXISTS users_muxed_id_unique;
+
+ALTER TABLE game_sessions
+  DROP CONSTRAINT IF EXISTS game_sessions_status_check;
+
+ALTER TABLE game_sessions
+  ADD CONSTRAINT game_sessions_status_check
+    CHECK (status IN ('warmup', 'active', 'completed', 'flagged', 'abandoned'));


### PR DESCRIPTION
Closes #228\nCloses #101\nCloses #88\nCloses #199\n\nSummary:\n- Generate and backfill unique usernames on auth signup.\n- Keep denormalized user totals up to date through payout processing.\n- Sweep abandoned sessions into an explicit abandoned state.\n- Page the global leaderboard from the server and add load-more/scroll restore on the web app.\n- Harden the web Docker image around standalone output and a pinned Node base.