### PR TITLE
fix: resolve issues #192, #125, #149, #167

### DIFF
--- a/apps/web/src/app/(auth)/login/login-page.test.tsx
+++ b/apps/web/src/app/(auth)/login/login-page.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import LoginPage from "./page";
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "unauthenticated", data: null }),
+  signIn: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+  usePathname: () => "/login",
+}));
+
+describe("LoginPage", () => {
+  it("renders without throwing and shows the BrandBlitz heading", () => {
+    render(<LoginPage />);
+    expect(screen.getByText("Welcome to BrandBlitz")).toBeTruthy();
+  });
+
+  it("renders the terms paragraph", () => {
+    render(<LoginPage />);
+    expect(screen.getByText(/by signing in you agree/i)).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,37 +1,9 @@
-"use client";
-
-import { useEffect, useMemo } from "react";
-import { signIn, useSession } from "next-auth/react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { Button } from "@/components/ui/button";
+import { Suspense } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import LoginLoading from "./loading";
+import { Skeleton } from "@/components/ui/skeleton";
+import { LoginButton } from "@/components/auth/login-button";
 
 export default function LoginPage() {
-  const { status } = useSession();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") ?? "/";
-  const providerId = process.env.NEXT_PUBLIC_E2E_MOCK_GOOGLE_OAUTH === "true" ? "google-mock" : "google";
-  const mockSignInOptions = useMemo(
-    () => ({
-      callbackUrl,
-      email: searchParams.get("mockEmail") ?? "e2e-player@example.com",
-      name: searchParams.get("mockName") ?? "E2E Player",
-    }),
-    [callbackUrl, searchParams]
-  );
-
-  useEffect(() => {
-    if (status === "authenticated") {
-      router.replace(callbackUrl);
-    }
-  }, [status, router, callbackUrl]);
-
-  if (status === "loading") {
-    return <LoginLoading />;
-  }
-
   return (
     <Card className="w-full max-w-sm">
       <CardHeader className="text-center">
@@ -39,33 +11,9 @@ export default function LoginPage() {
         <CardDescription>Sign in to compete and earn USDC rewards</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <Button
-          className="w-full"
-          size="lg"
-          onClick={() =>
-            signIn(providerId, providerId === "google-mock" ? mockSignInOptions : { callbackUrl })
-          }
-        >
-          <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-              fill="#4285F4"
-            />
-            <path
-              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-              fill="#34A853"
-            />
-            <path
-              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-              fill="#FBBC05"
-            />
-            <path
-              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-              fill="#EA4335"
-            />
-          </svg>
-          Continue with Google
-        </Button>
+        <Suspense fallback={<Skeleton className="h-11 w-full" />}>
+          <LoginButton />
+        </Suspense>
         <p className="text-xs text-center text-[var(--muted-foreground)]">
           By signing in you agree to our Terms of Service and Privacy Policy.
         </p>

--- a/apps/web/src/app/(brand)/not-found.tsx
+++ b/apps/web/src/app/(brand)/not-found.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+export default function BrandNotFound() {
+  return (
+    <main
+      role="main"
+      className="flex flex-col items-center justify-center px-6 py-20 text-center min-h-[60vh]"
+    >
+      <p className="text-6xl font-extrabold text-[var(--primary)] mb-4" aria-hidden="true">
+        404
+      </p>
+      <h1 className="text-2xl font-bold mb-3">This brand doesn&apos;t exist</h1>
+      <p className="text-[var(--muted-foreground)] mb-8 max-w-sm">
+        The brand you&apos;re looking for doesn&apos;t exist — create your own and launch a
+        challenge.
+      </p>
+      <div className="flex flex-wrap gap-3 justify-center">
+        <Link
+          href="/brand/new"
+          className="inline-flex items-center justify-center rounded-md bg-[var(--primary)] px-5 py-2.5 text-sm font-medium text-white hover:opacity-90 transition-opacity min-h-[44px]"
+        >
+          Create a brand
+        </Link>
+        <Link
+          href="/"
+          className="inline-flex items-center justify-center rounded-md border border-[var(--border)] bg-[var(--background)] px-5 py-2.5 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors min-h-[44px]"
+        >
+          Go home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)] flex flex-col">
+      <header className="border-b border-[var(--border)] px-6 h-16 flex items-center">
+        <Link
+          href="/"
+          className="font-extrabold text-xl text-[var(--primary)]"
+          aria-label="BrandBlitz home"
+        >
+          BrandBlitz
+        </Link>
+      </header>
+
+      <main
+        role="main"
+        className="flex flex-1 flex-col items-center justify-center px-6 py-20 text-center"
+      >
+        <p className="text-6xl font-extrabold text-[var(--primary)] mb-4" aria-hidden="true">
+          404
+        </p>
+        <h1 className="text-2xl font-bold mb-3">This page doesn&apos;t exist</h1>
+        <p className="text-[var(--muted-foreground)] mb-8 max-w-sm">
+          This challenge doesn&apos;t exist — try a live one from the home page.
+        </p>
+        <div className="flex flex-wrap gap-3 justify-center">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-md bg-[var(--primary)] px-5 py-2.5 text-sm font-medium text-white hover:opacity-90 transition-opacity min-h-[44px]"
+          >
+            Play a live challenge
+          </Link>
+          <Link
+            href="/leaderboard"
+            className="inline-flex items-center justify-center rounded-md border border-[var(--border)] bg-[var(--background)] px-5 py-2.5 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors min-h-[44px]"
+          >
+            View leaderboard
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/login-button.tsx
+++ b/apps/web/src/components/auth/login-button.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { signIn, useSession } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function LoginButton() {
+  const { status } = useSession();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") ?? "/";
+  const providerId =
+    process.env.NEXT_PUBLIC_E2E_MOCK_GOOGLE_OAUTH === "true" ? "google-mock" : "google";
+  const mockSignInOptions = useMemo(
+    () => ({
+      callbackUrl,
+      email: searchParams.get("mockEmail") ?? "e2e-player@example.com",
+      name: searchParams.get("mockName") ?? "E2E Player",
+    }),
+    [callbackUrl, searchParams]
+  );
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      router.replace(callbackUrl);
+    }
+  }, [status, router, callbackUrl]);
+
+  if (status === "loading") return <Skeleton className="h-11 w-full" />;
+
+  return (
+    <Button
+      className="w-full"
+      size="lg"
+      onClick={() =>
+        signIn(providerId, providerId === "google-mock" ? mockSignInOptions : { callbackUrl })
+      }
+    >
+      <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+          fill="#FBBC05"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          fill="#EA4335"
+        />
+      </svg>
+      Continue with Google
+    </Button>
+  );
+}

--- a/apps/web/src/components/brand/brand-kit-form.tsx
+++ b/apps/web/src/components/brand/brand-kit-form.tsx
@@ -174,7 +174,7 @@ const FormSchema = z.object({
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="primaryColor">Primary Color</Label>
               <div className="flex items-center gap-2">

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -4,16 +4,23 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useSession, signOut } from "next-auth/react";
+import { usePathname } from "next/navigation";
 import { createApiClient } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "./theme-toggle";
 
 export function Header() {
   const { data: session, status } = useSession();
+  const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
   const [streak, setStreak] = useState<number | null>(null);
   const [toastMessage, setToastMessage] = useState<string>("");
 
   const apiToken = useMemo(() => (session as any)?.apiToken as string | undefined, [session]);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
 
   useEffect(() => {
     if (!apiToken) {
@@ -31,6 +38,34 @@ export function Header() {
     });
   }, [apiToken]);
 
+  const navLinks = (
+    <>
+      <Link
+        href="/challenge"
+        className="block py-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+        onClick={() => setMenuOpen(false)}
+      >
+        Challenges
+      </Link>
+      <Link
+        href="/leaderboard"
+        className="block py-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+        onClick={() => setMenuOpen(false)}
+      >
+        Leaderboard
+      </Link>
+      {session && (
+        <Link
+          href="/dashboard"
+          className="block py-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+          onClick={() => setMenuOpen(false)}
+        >
+          Dashboard
+        </Link>
+      )}
+    </>
+  );
+
   return (
     <header className="border-b border-[var(--border)] bg-[var(--background)]/95 backdrop-blur-sm sticky top-0 z-50">
       <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
@@ -38,33 +73,26 @@ export function Header() {
           BrandBlitz
         </Link>
 
-        <nav className="hidden md:flex items-center gap-6 text-sm">
-          <Link
-            href="/challenge"
-            className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
-          >
-            Challenges
-          </Link>
-          <Link
-            href="/leaderboard"
-            className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
-          >
-            Leaderboard
-          </Link>
-          {session && (
-            <Link
-              href="/dashboard"
-              className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
-            >
-              Dashboard
-            </Link>
-          )}
-        </nav>
+        {/* Desktop nav */}
+        <nav className="hidden md:flex items-center gap-6 text-sm">{navLinks}</nav>
 
         <div className="flex items-center gap-3">
           <ThemeToggle />
+
+          {/* Hamburger — mobile only */}
+          <button
+            className="md:hidden flex flex-col justify-center items-center w-10 h-10 gap-1.5 rounded-md hover:bg-[var(--muted)] transition-colors"
+            aria-label="Open menu"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen((prev) => !prev)}
+          >
+            <span className="block h-0.5 w-5 bg-[var(--foreground)] transition-transform" />
+            <span className="block h-0.5 w-5 bg-[var(--foreground)]" />
+            <span className="block h-0.5 w-5 bg-[var(--foreground)] transition-transform" />
+          </button>
+
           {status === "loading" ? null : session ? (
-            <div className="flex items-center gap-3">
+            <div className="hidden md:flex items-center gap-3">
               {session.user?.image ? (
                 <Image
                   src={session.user.image}
@@ -84,17 +112,55 @@ export function Header() {
               </Button>
             </div>
           ) : (
-            <Link href="/login">
+            <Link href="/login" className="hidden md:block">
               <Button size="sm">Sign In</Button>
             </Link>
           )}
         </div>
       </div>
+
       {toastMessage ? (
         <div className="fixed right-4 top-20 z-50 rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm shadow-lg">
           {toastMessage}
         </div>
       ) : null}
+
+      {/* Mobile menu */}
+      {menuOpen && (
+        <div className="md:hidden border-t border-[var(--border)] bg-[var(--background)] px-6 pb-4">
+          <nav className="flex flex-col text-sm pt-3">{navLinks}</nav>
+          <div className="mt-4 pt-4 border-t border-[var(--border)]">
+            {session ? (
+              <div className="flex items-center gap-3">
+                {session.user?.image ? (
+                  <Image
+                    src={session.user.image}
+                    alt={session.user.name ?? "User"}
+                    width={32}
+                    height={32}
+                    sizes="32px"
+                    className="h-8 w-8 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="h-8 w-8 rounded-full bg-[var(--primary)] flex items-center justify-center text-white text-sm font-bold">
+                    {session.user?.name?.charAt(0).toUpperCase() ?? "U"}
+                  </div>
+                )}
+                <span className="text-sm text-[var(--foreground)]">{session.user?.name}</span>
+                <Button variant="ghost" size="sm" onClick={() => signOut()} className="ml-auto">
+                  Sign Out
+                </Button>
+              </div>
+            ) : (
+              <Link href="/login" onClick={() => setMenuOpen(false)}>
+                <Button size="sm" className="w-full min-h-[44px]">
+                  Sign In
+                </Button>
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
     </header>
   );
 }

--- a/apps/web/src/hooks/use-challenge.test.ts
+++ b/apps/web/src/hooks/use-challenge.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChallenge } from "./use-challenge";
+
+const getMock = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  createApiClient: () => ({ get: getMock }),
+}));
+
+describe("useChallenge", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it("returns challenge data on success", async () => {
+    getMock.mockResolvedValue({
+      data: { challenge: { id: "c1" }, questions: [{ id: "q1" }] },
+    });
+
+    const { result } = renderHook(() => useChallenge("c1", "token"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.challenge).toEqual({ id: "c1" });
+    expect(result.current.questions).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces message and code from a 400 server error", async () => {
+    getMock.mockRejectedValue({
+      response: {
+        status: 400,
+        data: { error: { message: "Challenge has ended", code: "CHALLENGE_ENDED" } },
+      },
+    });
+
+    const { result } = renderHook(() => useChallenge("c1", "token"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error?.message).toBe("Challenge has ended");
+    expect(result.current.error?.code).toBe("CHALLENGE_ENDED");
+    expect(result.current.challenge).toBeNull();
+  });
+
+  it("surfaces message from a 404 server error without a code", async () => {
+    getMock.mockRejectedValue({
+      response: {
+        status: 404,
+        data: { error: { message: "Challenge not found" } },
+      },
+    });
+
+    const { result } = renderHook(() => useChallenge("c1", "token"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error?.message).toBe("Challenge not found");
+    expect(result.current.error?.code).toBeUndefined();
+  });
+
+  it("falls back to generic message on a 503 with no error body", async () => {
+    getMock.mockRejectedValue({
+      response: { status: 503, data: {} },
+    });
+
+    const { result } = renderHook(() => useChallenge("c1", "token"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error?.message).toBe("Failed to load challenge");
+    expect(result.current.error?.code).toBeUndefined();
+  });
+
+  it("returns 'Couldn’t reach the server' when there is no response (network down)", async () => {
+    getMock.mockRejectedValue({ message: "Network Error" });
+
+    const { result } = renderHook(() => useChallenge("c1", "token"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error?.message).toBe("Couldn't reach the server");
+    expect(result.current.error?.code).toBeUndefined();
+  });
+});

--- a/apps/web/src/hooks/use-challenge.ts
+++ b/apps/web/src/hooks/use-challenge.ts
@@ -3,18 +3,23 @@
 import { useState, useEffect } from "react";
 import { createApiClient, type Challenge, type ChallengeQuestion } from "@/lib/api";
 
+export interface ChallengeError {
+  message: string;
+  code?: string;
+}
+
 interface UseChallengeResult {
   challenge: Challenge | null;
   questions: ChallengeQuestion[];
   loading: boolean;
-  error: string | null;
+  error: ChallengeError | null;
 }
 
 export function useChallenge(challengeId: string, apiToken?: string): UseChallengeResult {
   const [challenge, setChallenge] = useState<Challenge | null>(null);
   const [questions, setQuestions] = useState<ChallengeQuestion[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ChallengeError | null>(null);
 
   useEffect(() => {
     if (!challengeId) return;
@@ -28,7 +33,14 @@ export function useChallenge(challengeId: string, apiToken?: string): UseChallen
         setQuestions(res.data.questions ?? []);
       })
       .catch((err) => {
-        setError(err?.response?.data?.message ?? "Failed to load challenge");
+        if (!err.response) {
+          setError({ message: "Couldn't reach the server" });
+        } else {
+          setError({
+            message: err.response.data?.error?.message ?? "Failed to load challenge",
+            code: err.response.data?.error?.code,
+          });
+        }
       })
       .finally(() => setLoading(false));
   }, [challengeId, apiToken]);

--- a/e2e/tests/not-found.spec.ts
+++ b/e2e/tests/not-found.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("root 404 renders branded page with correct CTAs", async ({ page }) => {
+  const response = await page.goto("/nonexistent-page-xyz-12345");
+  expect(response?.status()).toBe(404);
+
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await expect(page.getByRole("link", { name: /play a live challenge/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /view leaderboard/i })).toBeVisible();
+});
+
+test("root 404 links back to home and leaderboard", async ({ page }) => {
+  await page.goto("/nonexistent-page-xyz-12345");
+
+  const homeLink = page.getByRole("link", { name: /play a live challenge/i });
+  await expect(homeLink).toHaveAttribute("href", "/");
+
+  const leaderboardLink = page.getByRole("link", { name: /view leaderboard/i });
+  await expect(leaderboardLink).toHaveAttribute("href", "/leaderboard");
+});

--- a/e2e/tests/responsive.spec.ts
+++ b/e2e/tests/responsive.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+const VIEWPORTS = [
+  { width: 375, height: 812, label: "mobile-375" },
+  { width: 768, height: 1024, label: "tablet-768" },
+  { width: 1024, height: 768, label: "laptop-1024" },
+  { width: 1280, height: 900, label: "desktop-1280" },
+];
+
+const PUBLIC_ROUTES = ["/", "/login", "/leaderboard"];
+
+for (const viewport of VIEWPORTS) {
+  for (const route of PUBLIC_ROUTES) {
+    test(`no horizontal scroll at ${viewport.width}px on ${route}`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto(route);
+
+      const hasOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > window.innerWidth
+      );
+      expect(hasOverflow).toBe(false);
+    });
+  }
+}
+
+test("hamburger button visible at 375px on home page", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto("/");
+
+  await expect(page.getByRole("button", { name: /open menu/i })).toBeVisible();
+});
+
+test("desktop nav links visible at 1280px on home page", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/");
+
+  await expect(page.getByRole("link", { name: "Challenges" }).first()).toBeVisible();
+  await expect(page.getByRole("link", { name: "Leaderboard" }).first()).toBeVisible();
+});
+
+test("hamburger opens and closes mobile nav at 375px", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto("/");
+
+  const hamburger = page.getByRole("button", { name: /open menu/i });
+  await hamburger.click();
+
+  await expect(page.getByRole("link", { name: "Challenges" })).toBeVisible();
+
+  await hamburger.click();
+  // Desktop nav links are in the DOM but display:none on mobile; mobile nav links are removed
+  await expect(page.getByRole("link", { name: "Challenges" }).first()).not.toBeVisible();
+});


### PR DESCRIPTION
 ## Summary

  - **#192**: `useChallenge` now surfaces server error messages and codes; network errors show "Couldn't reach the
  server"
  - **#125**: Header collapses to hamburger menu below `md`; brand-kit form color grid stacks on 375 px; Playwright
  responsive tests added
  - **#149**: `useSearchParams()` moved into `LoginButton` client component wrapped in Suspense; `login/page.tsx` is now
  a server component — `next build` emits no `useSearchParams` warnings
  - **#167**: Branded root `not-found.tsx` and `(brand)/not-found.tsx` added; Playwright 404 tests added

  Closes #192
  Closes #125
  Closes #149
  Closes #167

  ## Changes by issue

  ### #192 — useChallenge error details
  - `UseChallengeResult.error` type: `string | null` → `ChallengeError { message, code? } | null`
  - Network errors → `"Couldn't reach the server"`, server errors → `data.error.message ?? fallback`
  - New: `src/hooks/use-challenge.test.ts` (success, 400+code, 404, 503, network-down)

  ### #149 — Suspense boundary
  - New: `src/components/auth/login-button.tsx` — all client hooks + sign-in button
  - `src/app/(auth)/login/page.tsx` → server component, wraps `<LoginButton>` in `<Suspense>`
  - New: `src/app/(auth)/login/login-page.test.tsx` (smoke render)
  - Acceptance gate: `next build` emits no `useSearchParams` warnings

  ### #167 — Branded 404
  - New: `src/app/not-found.tsx` — root 404 with BrandBlitz logo, links to / and /leaderboard
  - New: `src/app/(brand)/not-found.tsx` — brand-segment 404, inherits Header/Footer
  - New: `e2e/tests/not-found.spec.ts` — HTTP 404 status + DOM assertions

  ### #125 — Mobile responsive
  - `header.tsx`: hamburger toggle (`md:hidden`), mobile nav drawer, close-on-navigate, close-on-link-click
  - `brand-kit-form.tsx`: color grid `grid-cols-1 sm:grid-cols-2`
  - New: `e2e/tests/responsive.spec.ts` — no-overflow + hamburger/nav visibility at 375/768/1024/1280 px

  ## Test plan
  - [ ] `pnpm --filter web test` — new Vitest tests pass (5 hook tests, 2 login tests)
  - [ ] `pnpm --filter web build` — no `useSearchParams` warnings ← primary gate for #149
  - [ ] `pnpm e2e` — not-found and responsive Playwright tests pass
  - [ ] Manual: 375 px on `/` → hamburger visible, tap opens nav, tap link closes nav
  - [ ] Manual: `/login?callbackUrl=/dashboard` → redirects to `/dashboard` after sign-in
  - [ ] Manual: navigate to `/nonexistent-xyz` → branded 404 with correct CTAs