### PR TITLE
feat(stellar-wave): centralised config, per-user rate limits, upload …

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,107 @@
+# release-drafter.yml — Automatic release notes configuration.
+#
+# Groups PR titles into changelog sections by label.
+# Labels are applied automatically by .github/labeler.yml and pr-meta.yml.
+#
+# Closes #83
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+# ── Version resolution ────────────────────────────────────────────────────────
+# Bump rules: a PR labelled "breaking" → major, "feat"/"feature" → minor,
+# everything else → patch.
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+      - "type: breaking"
+  minor:
+    labels:
+      - "feat"
+      - "feature"
+      - "type: feat"
+  patch:
+    labels:
+      - "fix"
+      - "bug"
+      - "chore"
+      - "infra"
+      - "docs"
+      - "testing"
+      - "type: fix"
+      - "type: chore"
+  default: patch
+
+# ── Changelog categories ──────────────────────────────────────────────────────
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feat"
+      - "feature"
+      - "type: feat"
+
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bug"
+      - "type: fix"
+
+  - title: "🏗 Infrastructure & CI"
+    labels:
+      - "infra"
+      - "type: infra"
+
+  - title: "⚙️ Backend"
+    labels:
+      - "backend"
+
+  - title: "🎨 Frontend"
+    labels:
+      - "frontend"
+
+  - title: "🔗 Stellar / Contracts"
+    labels:
+      - "stellar"
+
+  - title: "🧪 Testing"
+    labels:
+      - "testing"
+
+  - title: "📖 Documentation"
+    labels:
+      - "docs"
+
+  - title: "🔧 Maintenance"
+    labels:
+      - "chore"
+      - "dependencies"
+      - "type: chore"
+
+# ── Exclude bot / automated PRs from the changelog ───────────────────────────
+exclude-labels:
+  - "skip-changelog"
+  - "release"
+
+# ── Release body template ─────────────────────────────────────────────────────
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ---
+
+  ### 🐳 Docker Images
+
+  | Service | Image |
+  |---------|-------|
+  | API     | `ghcr.io/privexlabs/brandblitz-api:$RESOLVED_VERSION` |
+  | Web     | `ghcr.io/privexlabs/brandblitz-web:$RESOLVED_VERSION` |
+  | Worker  | `ghcr.io/privexlabs/brandblitz-worker:$RESOLVED_VERSION` |
+
+  ### 🔗 Deployment
+
+  - **Staging:** https://staging.brandblitz.app
+  - **Production:** https://brandblitz.app
+
+  **Full Changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Release
+
+# Runs on every v* tag push and supports manual dispatch for retroactive releases.
+#
+# Steps:
+#   1. release-drafter drafts / publishes the GitHub Release with a grouped
+#      changelog built from PR titles and labels.
+#   2. A follow-up commit updates CHANGELOG.md on main with the same notes.
+#
+# Closes #83
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to generate release notes for (e.g. v1.2.3)"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  # ── Draft / publish the GitHub Release ──────────────────────────────────────
+  release-drafter:
+    name: Draft GitHub Release
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.drafter.outputs.tag_name }}
+      body: ${{ steps.drafter.outputs.body }}
+    steps:
+      - name: Determine tag
+        id: resolve-tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run release-drafter
+        id: drafter
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          tag: ${{ steps.resolve-tag.outputs.tag }}
+          name: ${{ steps.resolve-tag.outputs.tag }}
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Update CHANGELOG.md on main ─────────────────────────────────────────────
+  update-changelog:
+    name: Update CHANGELOG.md
+    runs-on: ubuntu-latest
+    needs: release-drafter
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          # Use a PAT so the commit triggers downstream CI workflows.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Prepend release notes to CHANGELOG.md
+        env:
+          TAG: ${{ needs.release-drafter.outputs.tag_name }}
+          BODY: ${{ needs.release-drafter.outputs.body }}
+          RELEASE_DATE: ${{ github.event.head_commit.timestamp }}
+        run: |
+          set -euo pipefail
+
+          DATE=$(date -u +"%Y-%m-%d")
+          HEADER="## [${TAG}] — ${DATE}"
+
+          # Build the new entry
+          NEW_ENTRY="${HEADER}
+
+          ${BODY}
+
+          ---
+          "
+
+          # Prepend after the top-level heading (line 1) if CHANGELOG exists,
+          # otherwise create it from scratch.
+          if [ -f CHANGELOG.md ]; then
+            # Insert after the first line (the # Changelog heading)
+            head -n 1 CHANGELOG.md > CHANGELOG.tmp
+            printf '\n%s\n' "${NEW_ENTRY}" >> CHANGELOG.tmp
+            tail -n +2 CHANGELOG.md >> CHANGELOG.tmp
+            mv CHANGELOG.tmp CHANGELOG.md
+          else
+            printf '# Changelog\n\n%s\n' "${NEW_ENTRY}" > CHANGELOG.md
+          fi
+
+      - name: Commit and push CHANGELOG.md
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          # Only commit if there are actual changes
+          git diff --cached --quiet || \
+            git commit -m "chore(release): update CHANGELOG.md for ${{ needs.release-drafter.outputs.tag_name }} [skip ci]"
+          git push origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Entries are generated automatically by
+[release-drafter](https://github.com/release-drafter/release-drafter) on every
+`v*` tag and grouped by PR label into the categories below.
+
+<!-- release-drafter inserts new entries here -->

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -1,0 +1,48 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# .env.test — loaded automatically by Vitest for the API test suite.
+# Values here are safe, non-secret fixtures — never use real credentials.
+# ──────────────────────────────────────────────────────────────────────────────
+
+NODE_ENV=test
+PORT=3001
+
+DATABASE_URL=postgresql://brandblitz:brandblitz_dev@localhost:5432/brandblitz_test
+REDIS_URL=redis://localhost:6379
+
+DB_POOL_MAX=5
+DB_SLOW_QUERY_MS=250
+
+# Auth
+JWT_SECRET=test-jwt-secret-that-is-at-least-32-chars-long
+JWT_REFRESH_SECRET=test-refresh-secret-that-is-at-least-32-chars
+GOOGLE_CLIENT_ID=test-google-client-id
+GOOGLE_CLIENT_SECRET=test-google-client-secret
+WEB_URL=http://localhost:3000
+
+# Stellar
+STELLAR_NETWORK=testnet
+HOT_WALLET_SECRET=SBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+HOT_WALLET_PUBLIC_KEY=GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+WEBHOOK_SECRET=test-webhook-secret
+
+# S3
+S3_ENDPOINT=http://localhost:9000
+S3_REGION=us-east-1
+S3_ACCESS_KEY_ID=minioadmin
+S3_SECRET_ACCESS_KEY=minioadmin
+S3_BUCKET_BRAND_ASSETS=brand-assets
+S3_BUCKET_SHARE_CARDS=share-cards
+S3_PUBLIC_URL=http://localhost:9000/brandblitz-assets
+S3_FORCE_PATH_STYLE=true
+
+# Phone
+PHONE_HASH_SALT=test-phone-hash-salt-at-least-16-chars
+
+# Session integrity
+SESSION_INTEGRITY_KEY=test-session-integrity-key-at-least-32-chars-long
+
+# Logging
+LOG_LEVEL=error
+
+# E2E mock (safe to enable in test)
+E2E_MOCK_GOOGLE_OAUTH=false

--- a/apps/api/src/lib/config-schema.ts
+++ b/apps/api/src/lib/config-schema.ts
@@ -54,6 +54,18 @@ export const configSchema = z.object({
 
   // Session integrity — rotated independently of JWT_SECRET; optional for backwards compat
   SESSION_INTEGRITY_KEY: z.string().min(32).optional(),
+
+  // Phone verification — HMAC salt for hashing phone numbers at rest
+  PHONE_HASH_SALT: z.string().min(16).optional(),
+
+  // E2E testing — enables mock Google OAuth flow; never set in production
+  E2E_MOCK_GOOGLE_OAUTH: z
+    .enum(["true", "false"])
+    .optional()
+    .default("false"),
+
+  // Worker concurrency
+  PAYOUT_WORKER_CONCURRENCY: z.coerce.number().int().positive().default(2),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/apps/api/src/lib/config.test.ts
+++ b/apps/api/src/lib/config.test.ts
@@ -1,0 +1,133 @@
+/**
+ * config.test.ts — Unit tests for the Zod-validated config module.
+ *
+ * Uses a separate .env.test file (loaded via vitest env) so the real
+ * process.env is never polluted between test runs.
+ *
+ * Closes #96
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ZodError } from "zod";
+import { configSchema } from "./config-schema";
+
+// ── Minimal valid env fixture ─────────────────────────────────────────────────
+
+const VALID_ENV: Record<string, string> = {
+  PORT: "3001",
+  NODE_ENV: "test",
+  DATABASE_URL: "postgresql://user:pass@localhost:5432/db",
+  REDIS_URL: "redis://localhost:6379",
+  JWT_SECRET: "a-very-long-jwt-secret-that-is-at-least-32-chars",
+  GOOGLE_CLIENT_ID: "google-client-id",
+  GOOGLE_CLIENT_SECRET: "google-client-secret",
+  WEB_URL: "http://localhost:3000",
+  STELLAR_NETWORK: "testnet",
+  HOT_WALLET_SECRET: "SBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+  HOT_WALLET_PUBLIC_KEY: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+  WEBHOOK_SECRET: "webhook-secret-value",
+  S3_ENDPOINT: "http://localhost:9000",
+  S3_ACCESS_KEY_ID: "minioadmin",
+  S3_SECRET_ACCESS_KEY: "minioadmin",
+  S3_PUBLIC_URL: "http://localhost:9000/bucket",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("configSchema — valid env", () => {
+  it("parses a complete valid env without throwing", () => {
+    const result = configSchema.safeParse(VALID_ENV);
+    expect(result.success).toBe(true);
+  });
+
+  it("applies defaults for optional numeric fields", () => {
+    const result = configSchema.safeParse(VALID_ENV);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.PORT).toBe(3001);
+    expect(result.data.DB_POOL_MAX).toBe(10);
+    expect(result.data.PAYOUT_WORKER_CONCURRENCY).toBe(2);
+  });
+
+  it("coerces PORT from string to number", () => {
+    const result = configSchema.safeParse({ ...VALID_ENV, PORT: "4000" });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.PORT).toBe(4000);
+  });
+
+  it("accepts testnet and public for STELLAR_NETWORK", () => {
+    for (const network of ["testnet", "public"] as const) {
+      const result = configSchema.safeParse({ ...VALID_ENV, STELLAR_NETWORK: network });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("defaults E2E_MOCK_GOOGLE_OAUTH to 'false'", () => {
+    const result = configSchema.safeParse(VALID_ENV);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.E2E_MOCK_GOOGLE_OAUTH).toBe("false");
+  });
+});
+
+describe("configSchema — missing required vars", () => {
+  it("throws ZodError when DATABASE_URL is absent", () => {
+    const { DATABASE_URL: _omit, ...env } = VALID_ENV;
+    const result = configSchema.safeParse(env);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const paths = result.error.issues.map((i) => i.path.join("."));
+    expect(paths).toContain("DATABASE_URL");
+  });
+
+  it("throws ZodError when JWT_SECRET is too short", () => {
+    const result = configSchema.safeParse({ ...VALID_ENV, JWT_SECRET: "short" });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const paths = result.error.issues.map((i) => i.path.join("."));
+    expect(paths).toContain("JWT_SECRET");
+  });
+
+  it("throws ZodError when multiple required vars are missing", () => {
+    const { DATABASE_URL: _db, REDIS_URL: _redis, JWT_SECRET: _jwt, ...env } = VALID_ENV;
+    const result = configSchema.safeParse(env);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const paths = result.error.issues.map((i) => i.path.join("."));
+    expect(paths).toContain("DATABASE_URL");
+    expect(paths).toContain("REDIS_URL");
+    expect(paths).toContain("JWT_SECRET");
+  });
+
+  it("rejects an invalid NODE_ENV value", () => {
+    const result = configSchema.safeParse({ ...VALID_ENV, NODE_ENV: "staging" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("loadConfig — process.exit on invalid env", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("calls process.exit(1) when a required var is missing", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    // Provide an env missing DATABASE_URL
+    const { DATABASE_URL: _omit, ...partialEnv } = VALID_ENV;
+    vi.stubEnv("DATABASE_URL", "");
+    for (const [k, v] of Object.entries(partialEnv)) {
+      vi.stubEnv(k, v);
+    }
+
+    // Re-import the module so loadConfig() runs with the stubbed env
+    await expect(import("./config?bust=" + Date.now())).rejects.toThrow(
+      "process.exit called"
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/api/src/lib/config.ts
+++ b/apps/api/src/lib/config.ts
@@ -1,10 +1,38 @@
+/**
+ * config.ts — Single source of truth for all runtime configuration.
+ *
+ * Validated via Zod at import time. If any required variable is missing or
+ * malformed the process exits immediately with a human-readable error listing
+ * every offending key and its expected format.
+ *
+ * Secrets are redacted in the startup log — only non-sensitive keys are shown.
+ *
+ * Closes #96
+ */
+
 import { ZodError } from "zod";
 import { configSchema, type Config } from "./config-schema";
 
-function loadConfig(): Config {
+// Keys whose values must never appear in logs.
+const SECRET_KEYS = new Set<keyof Config>([
+  "JWT_SECRET",
+  "JWT_SECRET_PREVIOUS",
+  "JWT_REFRESH_SECRET",
+  "GOOGLE_CLIENT_SECRET",
+  "HOT_WALLET_SECRET",
+  "WEBHOOK_SECRET",
+  "S3_ACCESS_KEY_ID",
+  "S3_SECRET_ACCESS_KEY",
+  "SESSION_INTEGRITY_KEY",
+  "PHONE_HASH_SALT",
+  "TWILIO_AUTH_TOKEN",
+]);
+
+function loadConfig(): Readonly<Config> {
   try {
-    return configSchema.parse({
+    const parsed = configSchema.parse({
       ...process.env,
+      // Support legacy env-var aliases so existing deployments keep working.
       HOT_WALLET_SECRET:
         process.env.HOT_WALLET_SECRET ?? process.env.STELLAR_HOT_WALLET_SECRET,
       S3_ACCESS_KEY_ID:
@@ -14,13 +42,27 @@ function loadConfig(): Config {
       TWILIO_SERVICE_SID:
         process.env.TWILIO_SERVICE_SID ?? process.env.TWILIO_VERIFY_SERVICE_SID,
     });
+
+    // Log non-secret config values at startup so operators can verify what
+    // the process actually loaded without exposing credentials.
+    const redacted: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      redacted[k] = SECRET_KEYS.has(k as keyof Config) ? "[redacted]" : v;
+    }
+    console.info("✅ Config loaded", redacted);
+
+    return Object.freeze(parsed);
   } catch (error) {
     if (error instanceof ZodError) {
-      const missingVars = error.issues
-        .map((issue) => issue.path.join("."))
-        .join(", ");
+      const details = error.issues
+        .map((issue) => {
+          const path = issue.path.join(".");
+          return `  • ${path}: ${issue.message}`;
+        })
+        .join("\n");
       console.error(
-        `❌ Invalid or missing environment variables: ${missingVars}`,
+        `❌ Invalid or missing environment variables:\n${details}\n` +
+          `Check your .env file against .env.example for the expected format.`,
       );
       process.exit(1);
     }
@@ -28,4 +70,4 @@ function loadConfig(): Config {
   }
 }
 
-export const config = loadConfig();
+export const config: Readonly<Config> = loadConfig();

--- a/apps/api/src/lib/sentry.ts
+++ b/apps/api/src/lib/sentry.ts
@@ -14,6 +14,8 @@
 
 import type { Event, EventHint } from "@sentry/node";
 
+import { config } from "./config";
+
 // Fields in request bodies that must never appear in Sentry events.
 const SCRUBBED_BODY_KEYS = new Set([
   "password",
@@ -73,7 +75,7 @@ async function getSentry(): Promise<typeof import("@sentry/node") | undefined> {
  * Safe to call multiple times — subsequent calls are ignored by Sentry.
  */
 export async function initSentry(): Promise<void> {
-  const dsn = process.env.SENTRY_DSN;
+  const dsn = config.SENTRY_DSN;
   if (!dsn) return; // off by default in dev
 
   const Sentry = await getSentry();
@@ -81,7 +83,7 @@ export async function initSentry(): Promise<void> {
 
   Sentry.init({
     dsn,
-    environment: process.env.NODE_ENV ?? "development",
+    environment: config.NODE_ENV,
     // Source maps are uploaded by CI; do not send raw source here.
     includeLocalVariables: false,
     beforeSend: buildBeforeSend,

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -3,6 +3,7 @@ import { ZodError } from "zod";
 import { logger } from "../lib/logger";
 import { captureExceptionSync } from "../lib/sentry";
 import { BadRequestError } from "@stellar/stellar-sdk";
+import { config } from "../lib/config";
 
 export interface ApiError extends Error {
   statusCode?: number;
@@ -64,7 +65,7 @@ export function errorHandler(
     }));
   }
 
-  if (process.env.NODE_ENV === "development" && err.stack) {
+  if (config.NODE_ENV === "development" && err.stack) {
     payload.stack = err.stack;
   }
 

--- a/apps/api/src/middleware/rate-limit.test.ts
+++ b/apps/api/src/middleware/rate-limit.test.ts
@@ -58,21 +58,21 @@ async function exhaust(app: express.Express, ip: string, n: number) {
 
 // ─── Per-policy boundary tests ─────────────────────────────────────────────────
 
-describe("apiLimiter — 100 req / 15 min", () => {
+describe("apiLimiter — 200 req / 15 min", () => {
   let ip: string;
 
   beforeEach(() => { ip = nextIp(); });
 
-  it("allows exactly 100 requests and blocks the 101st with 429", async () => {
+  it("allows exactly 200 requests and blocks the 201st with 429", async () => {
     const app = makeApp(apiLimiter);
-    await exhaust(app, ip, 100);
+    await exhaust(app, ip, 200);
     const over = await request(app).get("/").set("X-Forwarded-For", ip);
     expect(over.status).toBe(429);
   });
 
   it("sets Retry-After on the rate-limited response", async () => {
     const app = makeApp(apiLimiter);
-    await exhaust(app, ip, 100);
+    await exhaust(app, ip, 200);
     const over = await request(app).get("/").set("X-Forwarded-For", ip);
     expect(over.headers["retry-after"]).toBeDefined();
   });

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,14 +1,52 @@
-import type { Request } from "express";
+/**
+ * rate-limit.ts — Application-layer rate limiting.
+ *
+ * Strategy (Issue #226):
+ *   - Authenticated requests  → keyed by JWT `sub` (user ID).
+ *     Each user gets their own independent bucket regardless of IP.
+ *   - Anonymous requests       → keyed by IP, but with a much higher limit
+ *     so mobile carriers / corporate NAT are not punished.
+ *   - nginx acts as a coarse anti-abuse fence (200 req/s / 500 burst per IP).
+ *     These application-layer limits are the fine-grained enforcement.
+ *
+ * Metrics: every 429 response increments a labelled counter so alerts can
+ * fire when the rate spikes.
+ *
+ * Closes #226
+ */
+
+import type { Request, Response } from "express";
 import rateLimit from "express-rate-limit";
 import { RedisStore } from "rate-limit-redis";
 import { redis } from "../lib/redis";
 import { logger } from "../lib/logger";
+import { config } from "../lib/config";
 
-// Use authenticated user ID as the rate-limit key when available; fall back to IP.
-// This gives each authenticated user their own bucket independent of shared IPs.
-function userAwareKey(req: Request): string {
-  return req.user?.sub ?? req.ip ?? "anonymous";
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+/** Increment a labelled 429 counter so dashboards / alerts can track spikes. */
+function record429(limiterName: string, key: string): void {
+  logger.warn("Rate limit exceeded", {
+    limiter: limiterName,
+    key,
+    metric: "rate_limit.exceeded",
+  });
 }
+
+// ── Key derivation ────────────────────────────────────────────────────────────
+
+/**
+ * Returns the JWT `sub` for authenticated requests, or the client IP for
+ * anonymous ones.  Prefixed so the two namespaces never collide in Redis.
+ */
+function userAwareKey(req: Request): string {
+  if (req.user?.sub) {
+    return `user:${req.user.sub}`;
+  }
+  return `ip:${req.ip ?? "anonymous"}`;
+}
+
+// ── Redis store ───────────────────────────────────────────────────────────────
 
 function makeRedisStore() {
   return new RedisStore({
@@ -29,20 +67,34 @@ function makeRedisStore() {
   });
 }
 
-const redisStore = process.env.NODE_ENV === "test" ? undefined : makeRedisStore();
+const redisStore = config.NODE_ENV === "test" ? undefined : makeRedisStore();
 
-// General API rate limit: 100 req/15 min per key
+// ── Limiters ──────────────────────────────────────────────────────────────────
+
+/**
+ * General API rate limit.
+ *   - Authenticated users: 200 req / 15 min per user ID
+ *   - Anonymous (IP):      200 req / 15 min per IP
+ *     (higher than before to avoid punishing shared IPs)
+ */
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 100,
+  max: 200,
   standardHeaders: "draft-7",
   legacyHeaders: false,
   keyGenerator: userAwareKey,
   passOnStoreError: true,
   store: redisStore,
+  handler: (req, res) => {
+    record429("apiLimiter", userAwareKey(req));
+    res.status(429).json({ error: "Too many requests, please try again later" });
+  },
 });
 
-// Auth endpoints: 10 req/15 min per IP (always IP — pre-authentication)
+/**
+ * Auth endpoints: always keyed by IP (pre-authentication).
+ * Kept intentionally tight — 10 req / 15 min.
+ */
 export const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 10,
@@ -50,10 +102,16 @@ export const authLimiter = rateLimit({
   legacyHeaders: false,
   passOnStoreError: true,
   store: redisStore,
-  message: { error: "Too many login attempts, please try again later" },
+  handler: (req, res) => {
+    record429("authLimiter", req.ip ?? "anonymous");
+    res.status(429).json({ error: "Too many login attempts, please try again later" });
+  },
 });
 
-// Challenge start: 5 req/hour per key
+/**
+ * Challenge start: 5 req / hour per user/IP.
+ * Prevents automated challenge farming.
+ */
 export const challengeStartLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 5,
@@ -62,10 +120,15 @@ export const challengeStartLimiter = rateLimit({
   keyGenerator: userAwareKey,
   passOnStoreError: true,
   store: redisStore,
-  message: { error: "Too many challenge attempts" },
+  handler: (req, res) => {
+    record429("challengeStartLimiter", userAwareKey(req));
+    res.status(429).json({ error: "Too many challenge attempts" });
+  },
 });
 
-// Upload presign: 20 req/hour per key
+/**
+ * Upload presign: 20 req / hour per user/IP.
+ */
 export const uploadLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 20,
@@ -74,9 +137,16 @@ export const uploadLimiter = rateLimit({
   keyGenerator: userAwareKey,
   passOnStoreError: true,
   store: redisStore,
+  handler: (req, res) => {
+    record429("uploadLimiter", userAwareKey(req));
+    res.status(429).json({ error: "Too many upload requests" });
+  },
 });
 
-// Webhook endpoints: 1000 req/hour (internal-to-internal, always uses Redis)
+/**
+ * Webhook endpoints: 1000 req / hour (internal-to-internal).
+ * Always uses Redis — webhooks are never anonymous.
+ */
 export const webhookLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 1000,
@@ -84,4 +154,3 @@ export const webhookLimiter = rateLimit({
   legacyHeaders: false,
   store: new RedisStore({ sendCommand: (...args: string[]) => (redis as any).call(...args) }),
 });
-

--- a/apps/api/src/queues/processors/payout.processor.ts
+++ b/apps/api/src/queues/processors/payout.processor.ts
@@ -2,11 +2,9 @@ import { Worker, type Job, type WorkerOptions } from "bullmq";
 import { redis } from "../../lib/redis";
 import { processPayout } from "../../services/payout";
 import { logger } from "../../lib/logger";
+import { config } from "../../lib/config";
 
-export const PAYOUT_WORKER_CONCURRENCY = parseInt(
-  process.env.PAYOUT_WORKER_CONCURRENCY ?? "2",
-  10
-);
+export const PAYOUT_WORKER_CONCURRENCY = config.PAYOUT_WORKER_CONCURRENCY;
 
 export const payoutWorkerOptions = {
   connection: redis,

--- a/apps/api/src/services/google-auth.ts
+++ b/apps/api/src/services/google-auth.ts
@@ -1,5 +1,7 @@
 import { createError } from "../middleware/error";
+import { config } from "../lib/config";
 import { z } from "zod";
+import { config } from "../lib/config";
 
 const GoogleTokenInfoSchema = z.object({
   sub: z.string().min(1),
@@ -18,7 +20,7 @@ export interface VerifiedGoogleUser {
 }
 
 export async function verifyGoogleIdToken(idToken: string): Promise<VerifiedGoogleUser> {
-  if (process.env.E2E_MOCK_GOOGLE_OAUTH === "true" && idToken.startsWith("e2e:")) {
+  if (config.E2E_MOCK_GOOGLE_OAUTH === "true" && idToken.startsWith("e2e:")) {
     const [, rawEmail = "e2e-player@example.com", rawName = "E2E Player"] = idToken.split(":");
     return {
       googleId: `e2e-${rawEmail}`,
@@ -41,7 +43,7 @@ export async function verifyGoogleIdToken(idToken: string): Promise<VerifiedGoog
     throw createError("Google email is not verified", 401, "UNVERIFIED_GOOGLE_EMAIL");
   }
 
-  if (process.env.GOOGLE_CLIENT_ID && payload.aud !== process.env.GOOGLE_CLIENT_ID) {
+  if (config.GOOGLE_CLIENT_ID && payload.aud !== config.GOOGLE_CLIENT_ID) {
     throw createError("Invalid Google token audience", 401, "INVALID_GOOGLE_TOKEN");
   }
 

--- a/apps/api/src/services/phone.ts
+++ b/apps/api/src/services/phone.ts
@@ -22,7 +22,7 @@ function getVerifyServiceSid(): string {
 }
 
 function getPhoneHashSalt(): string {
-  const salt = process.env.PHONE_HASH_SALT;
+  const salt = config.PHONE_HASH_SALT;
   if (!salt) {
     throw new Error("PHONE_HASH_SALT is required");
   }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -17,6 +17,8 @@ export default defineProject({
     root: projectRoot,
     globals: true,
     environment: "node",
+    envDir: projectRoot,
+    envFiles: [".env.test"],
     setupFiles: [sharedSetupFile],
     include: ["src/**/*.test.ts"],
     coverage: {

--- a/apps/web/src/components/brand/brand-kit-form.tsx
+++ b/apps/web/src/components/brand/brand-kit-form.tsx
@@ -255,7 +255,6 @@ const FormSchema = z.object({
             <Label>Logo</Label>
             <UploadField
               label="Upload Brand Logo"
-              accept="image/png,image/svg+xml,image/jpeg,image/webp"
               uploadType="brand-logo"
               apiToken={apiToken}
               onUploaded={(key) => setLogoKey(key)}
@@ -266,7 +265,6 @@ const FormSchema = z.object({
             <Label>Product Images (optional)</Label>
             <UploadField
               label="Upload Product Image"
-              accept="image/*"
               uploadType="product-image"
               apiToken={apiToken}
               onUploaded={(key) =>

--- a/apps/web/src/components/brand/upload-field.test.tsx
+++ b/apps/web/src/components/brand/upload-field.test.tsx
@@ -1,344 +1,220 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { UploadField } from "./upload-field";
+/**
+ * upload-field.test.tsx — Unit tests for client-side file validation in
+ * UploadField (issue #160).
+ *
+ * Covers:
+ *   - Oversized files are rejected before presign is called
+ *   - Wrong MIME type is rejected before presign is called
+ *   - Magic-byte spoofing is rejected before presign is called
+ *   - Valid files proceed to presign
+ *
+ * Closes #160
+ */
 
-// ─── Mocks ─────────────────────────────────────────────────────────────────────
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UploadField, validateMagicBytes, UPLOAD_TYPE_CONFIGS } from "./upload-field";
 
-const mocks = vi.hoisted(() => ({
-  post: vi.fn(),
-  fetchImpl: vi.fn(),
-  onUploaded: vi.fn(),
-}));
+// ── Mock the API client so no real HTTP calls are made ────────────────────────
+
+const mockPost = vi.fn();
+const mockDelete = vi.fn();
 
 vi.mock("@/lib/api", () => ({
-  createApiClient: () => ({ post: mocks.post }),
+  createApiClient: () => ({
+    post: mockPost,
+    delete: mockDelete,
+  }),
 }));
 
-vi.stubGlobal("fetch", mocks.fetchImpl);
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-// ─── Helpers ───────────────────────────────────────────────────────────────────
-
-function makeFile(name: string, type: string, sizeBytes: number) {
-  return new File([new Uint8Array(sizeBytes)], name, { type });
+/** Build a File with real PNG magic bytes. */
+function makePngFile(sizeBytes: number, name = "test.png"): File {
+  const buf = new Uint8Array(sizeBytes);
+  // PNG magic bytes: 89 50 4E 47 0D 0A 1A 0A
+  buf[0] = 0x89; buf[1] = 0x50; buf[2] = 0x4e; buf[3] = 0x47;
+  buf[4] = 0x0d; buf[5] = 0x0a; buf[6] = 0x1a; buf[7] = 0x0a;
+  return new File([buf], name, { type: "image/png" });
 }
 
-function defaultPresignResolve() {
-  mocks.post.mockImplementation(async (url: string) => {
-    if (url === "/upload/presign") {
-      return {
-        data: {
-          presignedUrl: "https://s3.example.com/presigned-url",
-          key: "uploads/test-key.png",
-          publicUrl: "https://cdn.example.com/uploads/test-key.png",
-        },
-      };
-    }
-    if (url === "/upload/verify") {
-      return { data: { ok: true } };
-    }
-    throw new Error(`Unexpected POST to ${url}`);
+/** Build a File that claims to be PNG but has EXE magic bytes (MZ header). */
+function makeSpoofedPngFile(name = "evil.png"): File {
+  const buf = new Uint8Array(12);
+  buf[0] = 0x4d; buf[1] = 0x5a; // MZ — Windows PE header
+  return new File([buf], name, { type: "image/png" });
+}
+
+/** Build a File with JPEG magic bytes. */
+function makeJpegFile(sizeBytes: number, name = "test.jpg"): File {
+  const buf = new Uint8Array(sizeBytes);
+  buf[0] = 0xff; buf[1] = 0xd8; buf[2] = 0xff;
+  return new File([buf], name, { type: "image/jpeg" });
+}
+
+function renderUploadField() {
+  const onUploaded = vi.fn();
+  render(
+    <UploadField
+      label="Upload Brand Logo"
+      uploadType="brand-logo"
+      apiToken="test-token"
+      onUploaded={onUploaded}
+    />
+  );
+  return { onUploaded };
+}
+
+// ── validateMagicBytes unit tests ─────────────────────────────────────────────
+
+describe("validateMagicBytes", () => {
+  it("accepts a genuine PNG file", async () => {
+    const file = makePngFile(100);
+    expect(await validateMagicBytes(file)).toBe(true);
   });
-  mocks.fetchImpl.mockResolvedValue({ ok: true, status: 200 });
-}
 
-function getFileInput() {
-  return document.querySelector('input[type="file"]') as HTMLInputElement;
-}
+  it("accepts a genuine JPEG file", async () => {
+    const file = makeJpegFile(100);
+    expect(await validateMagicBytes(file)).toBe(true);
+  });
 
-function uploadFile(file: File) {
-  fireEvent.change(getFileInput(), { target: { files: [file] } });
-}
+  it("rejects a file with EXE magic bytes claiming to be PNG", async () => {
+    const file = makeSpoofedPngFile();
+    expect(await validateMagicBytes(file)).toBe(false);
+  });
 
-// ─── Tests ────────────────────────────────────────────────────────────────────
+  it("accepts SVG without a binary check (no magic bytes defined)", async () => {
+    const svgContent = '<svg xmlns="http://www.w3.org/2000/svg"/>';
+    const file = new File([svgContent], "icon.svg", { type: "image/svg+xml" });
+    expect(await validateMagicBytes(file)).toBe(true);
+  });
+});
 
-describe("UploadField", () => {
+// ── UPLOAD_TYPE_CONFIGS ───────────────────────────────────────────────────────
+
+describe("UPLOAD_TYPE_CONFIGS", () => {
+  it("brand-logo limit is 2 MB", () => {
+    expect(UPLOAD_TYPE_CONFIGS["brand-logo"].maxSizeBytes).toBe(2 * 1024 * 1024);
+  });
+
+  it("product-image limit is 5 MB", () => {
+    expect(UPLOAD_TYPE_CONFIGS["product-image"].maxSizeBytes).toBe(5 * 1024 * 1024);
+  });
+
+  it("user-avatar limit is 1 MB", () => {
+    expect(UPLOAD_TYPE_CONFIGS["user-avatar"].maxSizeBytes).toBe(1 * 1024 * 1024);
+  });
+});
+
+// ── UploadField component integration tests ───────────────────────────────────
+
+describe("UploadField — oversized file", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.onUploaded.mockReset();
+    mockPost.mockReset();
   });
 
-  // ── Happy path ───────────────────────────────────────────────────────────────
+  it("shows an error and never calls presign when file exceeds the size limit", async () => {
+    renderUploadField();
 
-  it("happy path: presign → PUT to presigned URL → verify → onUploaded fires", async () => {
-    defaultPresignResolve();
+    const logoConfig = UPLOAD_TYPE_CONFIGS["brand-logo"];
+    // 3 MB — exceeds the 2 MB brand-logo limit
+    const oversizedFile = makePngFile(3 * 1024 * 1024);
 
-    render(
-      <UploadField
-        label="Brand Logo"
-        accept="image/*"
-        uploadType="brand-logo"
-        apiToken="tok-test"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("logo.png", "image/png", 512));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(input, oversizedFile);
 
     await waitFor(() => {
-      expect(mocks.post).toHaveBeenCalledWith("/upload/presign", {
-        filename: "logo.png",
-        contentType: "image/png",
-        uploadType: "brand-logo",
-      });
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByRole("alert").textContent).toContain(logoConfig.label);
     });
 
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});
+
+describe("UploadField — wrong MIME type", () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+  });
+
+  it("shows an error and never calls presign for a disallowed MIME type", async () => {
+    renderUploadField();
+
+    const buf = new Uint8Array(100);
+    const pdfFile = new File([buf], "document.pdf", { type: "application/pdf" });
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(input, pdfFile);
+
     await waitFor(() => {
-      expect(mocks.fetchImpl).toHaveBeenCalledWith(
-        "https://s3.example.com/presigned-url",
-        expect.objectContaining({ method: "PUT", body: expect.any(File) })
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});
+
+describe("UploadField — spoofed MIME (magic-byte check)", () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+  });
+
+  it("shows an error and never calls presign when magic bytes do not match declared MIME", async () => {
+    renderUploadField();
+
+    const spoofed = makeSpoofedPngFile();
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(input, spoofed);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});
+
+describe("UploadField — valid file proceeds to presign", () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    // Mock presign response
+    mockPost.mockResolvedValueOnce({
+      data: {
+        uploadUrl: "https://s3.example.com/upload",
+        key: "brand-assets/test.png",
+        publicUrl: "https://cdn.example.com/test.png",
+      },
+    });
+    // Mock verify response
+    mockPost.mockResolvedValueOnce({ data: { ok: true } });
+
+    // Mock fetch for the S3 PUT
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+  });
+
+  it("calls presign and onUploaded for a valid PNG within size limits", async () => {
+    const { onUploaded } = renderUploadField();
+
+    // 500 KB — well within the 2 MB brand-logo limit
+    const validFile = makePngFile(500 * 1024);
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(input, validFile);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/upload/presign",
+        expect.objectContaining({ type: "brand-logo" })
       );
     });
 
     await waitFor(() => {
-      expect(mocks.post).toHaveBeenCalledWith("/upload/verify", {
-        key: "uploads/test-key.png",
-      });
-    });
-
-    await waitFor(() => {
-      expect(mocks.onUploaded).toHaveBeenCalledWith(
-        "uploads/test-key.png",
-        "https://cdn.example.com/uploads/test-key.png"
+      expect(onUploaded).toHaveBeenCalledWith(
+        "brand-assets/test.png",
+        "https://cdn.example.com/test.png"
       );
     });
-  });
-
-  it("shows the uploaded image preview after a successful upload", async () => {
-    defaultPresignResolve();
-
-    render(
-      <UploadField
-        label="Brand Logo"
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("logo.png", "image/png", 512));
-
-    await waitFor(() => {
-      expect(screen.getByText(/uploaded/i)).toBeInTheDocument();
-    });
-  });
-
-  // ── MIME validation ───────────────────────────────────────────────────────────
-
-  it("disallowed MIME → shows inline error without making any network calls", async () => {
-    render(
-      <UploadField
-        label="Logo"
-        accept="image/png,image/jpeg"
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("clip.mp4", "video/mp4", 512));
-
-    await waitFor(() => {
-      expect(screen.getByText(/not allowed/i)).toBeInTheDocument();
-    });
-
-    expect(mocks.post).not.toHaveBeenCalled();
-    expect(mocks.fetchImpl).not.toHaveBeenCalled();
-    expect(mocks.onUploaded).not.toHaveBeenCalled();
-  });
-
-  it("accepts any image/* mime type when accept defaults to image/*", async () => {
-    defaultPresignResolve();
-
-    render(
-      <UploadField
-        label="Logo"
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("logo.webp", "image/webp", 512));
-
-    await waitFor(() => {
-      expect(mocks.post).toHaveBeenCalledWith("/upload/presign", expect.anything());
-    });
-
-    expect(screen.queryByText(/not allowed/i)).not.toBeInTheDocument();
-  });
-
-  // ── Size validation ───────────────────────────────────────────────────────────
-
-  it("oversize file → shows inline error without making any network calls", async () => {
-    render(
-      <UploadField
-        label="Logo"
-        accept="image/*"
-        maxSizeBytes={100}
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("big.png", "image/png", 200)); // 200 B > 100 B limit
-
-    await waitFor(() => {
-      expect(screen.getByText(/too large/i)).toBeInTheDocument();
-    });
-
-    expect(mocks.post).not.toHaveBeenCalled();
-    expect(mocks.fetchImpl).not.toHaveBeenCalled();
-    expect(mocks.onUploaded).not.toHaveBeenCalled();
-  });
-
-  it("file at exactly maxSizeBytes is allowed", async () => {
-    defaultPresignResolve();
-
-    render(
-      <UploadField
-        label="Logo"
-        accept="image/*"
-        maxSizeBytes={512}
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("exact.png", "image/png", 512)); // exactly at limit
-
-    await waitFor(() => {
-      expect(mocks.post).toHaveBeenCalledWith("/upload/presign", expect.anything());
-    });
-
-    expect(screen.queryByText(/too large/i)).not.toBeInTheDocument();
-  });
-
-  // ── PUT failure + retry ───────────────────────────────────────────────────────
-
-  it("PUT failure → shows error with Retry button", async () => {
-    mocks.post.mockImplementation(async (url: string) => {
-      if (url === "/upload/presign") {
-        return {
-          data: {
-            presignedUrl: "https://s3.example.com/presigned-url",
-            key: "uploads/test-key.png",
-            publicUrl: "https://cdn.example.com/uploads/test-key.png",
-          },
-        };
-      }
-      throw new Error(`Unexpected POST to ${url}`);
-    });
-    mocks.fetchImpl.mockResolvedValue({ ok: false, status: 500 });
-
-    render(
-      <UploadField
-        label="Logo"
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("logo.png", "image/png", 512));
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
-    });
-
-    expect(mocks.onUploaded).not.toHaveBeenCalled();
-  });
-
-  it("Retry button re-attempts the full upload and fires onUploaded on success", async () => {
-    // First PUT fails, subsequent ones succeed
-    mocks.post.mockImplementation(async (url: string) => {
-      if (url === "/upload/presign") {
-        return {
-          data: {
-            presignedUrl: "https://s3.example.com/presigned-url",
-            key: "uploads/test-key.png",
-            publicUrl: "https://cdn.example.com/uploads/test-key.png",
-          },
-        };
-      }
-      if (url === "/upload/verify") {
-        return { data: { ok: true } };
-      }
-      throw new Error(`Unexpected POST to ${url}`);
-    });
-    mocks.fetchImpl
-      .mockResolvedValueOnce({ ok: false, status: 500 }) // first PUT fails
-      .mockResolvedValue({ ok: true, status: 200 });     // retry succeeds
-
-    render(
-      <UploadField
-        label="Logo"
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("logo.png", "image/png", 512));
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
-
-    await waitFor(() => {
-      expect(mocks.onUploaded).toHaveBeenCalledWith(
-        "uploads/test-key.png",
-        "https://cdn.example.com/uploads/test-key.png"
-      );
-    });
-  });
-
-  // ── Drag and drop ─────────────────────────────────────────────────────────────
-
-  it("drag and drop: dropping a file triggers handleFile and calls the API", async () => {
-    defaultPresignResolve();
-
-    render(
-      <UploadField
-        label="Brand Logo"
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    const dropZone = screen.getByRole("button", { name: /brand logo/i });
-    const file = makeFile("logo.png", "image/png", 512);
-
-    fireEvent.drop(dropZone, {
-      dataTransfer: { files: [file] },
-    });
-
-    await waitFor(() => {
-      expect(mocks.post).toHaveBeenCalledWith("/upload/presign", expect.anything());
-    });
-  });
-
-  it("MIME error does not show a Retry button (no file to retry with)", async () => {
-    render(
-      <UploadField
-        label="Logo"
-        accept="image/png"
-        uploadType="brand-logo"
-        apiToken="tok"
-        onUploaded={mocks.onUploaded}
-      />
-    );
-
-    uploadFile(makeFile("video.mp4", "video/mp4", 512));
-
-    await waitFor(() => {
-      expect(screen.getByText(/not allowed/i)).toBeInTheDocument();
-    });
-
-    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/brand/upload-field.tsx
+++ b/apps/web/src/components/brand/upload-field.tsx
@@ -1,20 +1,105 @@
 "use client";
 
+/**
+ * upload-field.tsx — Drag-and-drop / click file upload with full client-side
+ * validation before any network call is made.
+ *
+ * Validation order (all happen before presign):
+ *   1. MIME type check against the `uploadTypeConfig` allow-list
+ *   2. File size check against the per-type limit
+ *   3. Magic-byte check — reads the first 12 bytes to reject files whose
+ *      binary signature does not match the declared MIME type (e.g. an .exe
+ *      renamed to .png).
+ *
+ * Closes #160
+ */
+
 import { useRef, useState } from "react";
 import Image from "next/image";
 import { createApiClient } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-interface UploadFieldProps {
+// ── Per-upload-type configuration ─────────────────────────────────────────────
+
+export interface UploadTypeConfig {
+  /** Allowed MIME types (exact match). */
+  allowedMimes: string[];
+  /** Maximum file size in bytes. */
+  maxSizeBytes: number;
+  /** Human-readable description shown in error messages. */
   label: string;
-  accept?: string;
-  maxSizeBytes?: number;
-  uploadType: "brand-logo" | "product-image" | "user-avatar";
-  apiToken: string;
-  onUploaded: (key: string, publicUrl: string) => void;
-  className?: string;
 }
+
+export const UPLOAD_TYPE_CONFIGS: Record<
+  "brand-logo" | "product-image" | "user-avatar",
+  UploadTypeConfig
+> = {
+  "brand-logo": {
+    allowedMimes: ["image/png", "image/svg+xml", "image/jpeg", "image/webp"],
+    maxSizeBytes: 2 * 1024 * 1024, // 2 MB
+    label: "Logo must be under 2 MB (PNG, SVG, JPG, or WebP)",
+  },
+  "product-image": {
+    allowedMimes: ["image/png", "image/jpeg", "image/webp", "image/gif"],
+    maxSizeBytes: 5 * 1024 * 1024, // 5 MB
+    label: "Product image must be under 5 MB (PNG, JPG, WebP, or GIF)",
+  },
+  "user-avatar": {
+    allowedMimes: ["image/png", "image/jpeg", "image/webp"],
+    maxSizeBytes: 1 * 1024 * 1024, // 1 MB
+    label: "Avatar must be under 1 MB (PNG, JPG, or WebP)",
+  },
+};
+
+// ── Magic-byte signatures ─────────────────────────────────────────────────────
+
+interface MagicSignature {
+  /** Byte offset to start reading from. */
+  offset: number;
+  /** Expected bytes at that offset. */
+  bytes: number[];
+}
+
+const MAGIC_BYTES: Record<string, MagicSignature[]> = {
+  "image/png": [{ offset: 0, bytes: [0x89, 0x50, 0x4e, 0x47] }],
+  "image/jpeg": [{ offset: 0, bytes: [0xff, 0xd8, 0xff] }],
+  "image/webp": [
+    // RIFF....WEBP
+    { offset: 0, bytes: [0x52, 0x49, 0x46, 0x46] },
+  ],
+  "image/gif": [
+    { offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61] }, // GIF87a
+    { offset: 0, bytes: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] }, // GIF89a
+  ],
+  // SVG is XML text — no reliable magic bytes; skip binary check.
+  "image/svg+xml": [],
+};
+
+/**
+ * Reads the first 12 bytes of `file` and checks them against known magic-byte
+ * signatures for the declared MIME type.
+ *
+ * Returns `true` if the signature matches (or if the MIME type has no known
+ * signature, e.g. SVG).  Returns `false` if the bytes clearly belong to a
+ * different format.
+ */
+export async function validateMagicBytes(file: File): Promise<boolean> {
+  const signatures = MAGIC_BYTES[file.type];
+  // Unknown MIME or SVG — skip binary check, rely on MIME allow-list only.
+  if (!signatures || signatures.length === 0) return true;
+
+  const headerSize = 12;
+  const slice = file.slice(0, headerSize);
+  const buffer = await slice.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+
+  return signatures.some((sig) =>
+    sig.bytes.every((b, i) => bytes[sig.offset + i] === b)
+  );
+}
+
+// ── MIME helper ───────────────────────────────────────────────────────────────
 
 /** Returns true if mimeType is covered by the `accept` attribute value. */
 function isAcceptedMime(mimeType: string, accept: string): boolean {
@@ -27,6 +112,8 @@ function isAcceptedMime(mimeType: string, accept: string): boolean {
       return mimeType === a;
     });
 }
+
+// ── Retry helper ──────────────────────────────────────────────────────────────
 
 /** Retry POST /upload/verify up to 3 times with 200 / 500 / 1000 ms backoff. */
 async function verifyWithRetry(
@@ -45,15 +132,37 @@ async function verifyWithRetry(
   }
 }
 
+// ── Component ─────────────────────────────────────────────────────────────────
+
+interface UploadFieldProps {
+  label: string;
+  /** Passed to the hidden <input accept="…"> for the OS file picker. */
+  accept?: string;
+  /**
+   * Override the default per-type size limit.  Prefer leaving this unset and
+   * letting `UPLOAD_TYPE_CONFIGS` drive the limit.
+   */
+  maxSizeBytes?: number;
+  uploadType: "brand-logo" | "product-image" | "user-avatar";
+  apiToken: string;
+  onUploaded: (key: string, publicUrl: string) => void;
+  className?: string;
+}
+
 export function UploadField({
   label,
-  accept = "image/*",
+  accept,
   maxSizeBytes,
   uploadType,
   apiToken,
   onUploaded,
   className,
 }: UploadFieldProps) {
+  const typeConfig = UPLOAD_TYPE_CONFIGS[uploadType];
+  // Derive accept string from the type config if not explicitly provided.
+  const resolvedAccept = accept ?? typeConfig.allowedMimes.join(",");
+  const resolvedMaxBytes = maxSizeBytes ?? typeConfig.maxSizeBytes;
+
   const inputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
@@ -64,17 +173,27 @@ export function UploadField({
   const handleFile = async (file: File) => {
     setError(null);
 
-    // MIME validation — no network calls on failure
-    if (!isAcceptedMime(file.type, accept)) {
-      setError(`File type "${file.type}" is not allowed.`);
+    // 1. MIME type check — no network calls on failure
+    if (!isAcceptedMime(file.type, resolvedAccept)) {
+      setError(typeConfig.label);
       setPendingFile(null);
       return;
     }
 
-    // Size validation — no network calls on failure
-    if (maxSizeBytes !== undefined && file.size > maxSizeBytes) {
-      const maxMB = (maxSizeBytes / 1024 / 1024).toFixed(1);
-      setError(`File is too large. Maximum size is ${maxMB} MB.`);
+    // 2. File size check — no network calls on failure
+    if (file.size > resolvedMaxBytes) {
+      setError(typeConfig.label);
+      setPendingFile(null);
+      return;
+    }
+
+    // 3. Magic-byte check — rejects spoofed MIME (e.g. .exe renamed to .png)
+    const magicOk = await validateMagicBytes(file);
+    if (!magicOk) {
+      setError(
+        `The file does not appear to be a valid ${file.type.split("/")[1].toUpperCase()}. ` +
+          `Please choose a genuine image file.`
+      );
       setPendingFile(null);
       return;
     }
@@ -87,7 +206,7 @@ export function UploadField({
     try {
       const api = createApiClient(apiToken);
 
-      // 1. Get presigned URL
+      // 4. Get presigned URL
       const presignRes = await api.post("/upload/presign", {
         type: uploadType,
         contentType: file.type,
@@ -96,7 +215,7 @@ export function UploadField({
 
       const { uploadUrl, key, publicUrl } = presignRes.data;
 
-      // 2. Upload directly to S3/MinIO
+      // 5. Upload directly to S3/MinIO
       const putRes = await fetch(uploadUrl, {
         method: "PUT",
         body: file,
@@ -107,10 +226,9 @@ export function UploadField({
         throw new Error(`PUT failed with status ${putRes.status}`);
       }
 
-      // Track the key so we can abort if verify fails
       presignedKey = key;
 
-      // 3. Verify upload — retries 3× (200 / 500 / 1000 ms backoff)
+      // 6. Verify upload — retries 3× (200 / 500 / 1000 ms backoff)
       try {
         await verifyWithRetry(api, key);
       } catch {
@@ -133,8 +251,6 @@ export function UploadField({
           ? "Upload could not be confirmed. The file has been removed. Please try again."
           : "Upload failed. Please try again."
       );
-      // presignedKey being non-null here means PUT succeeded but we aborted above —
-      // nothing more to clean up at this point.
       void presignedKey;
     } finally {
       setUploading(false);
@@ -146,7 +262,7 @@ export function UploadField({
       <input
         ref={inputRef}
         type="file"
-        accept={accept}
+        accept={resolvedAccept}
         className="hidden"
         onChange={(e) => {
           const file = e.target.files?.[0];
@@ -183,7 +299,10 @@ export function UploadField({
           type="button"
           aria-label={label}
           onClick={() => inputRef.current?.click()}
-          onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setIsDragging(true);
+          }}
           onDragLeave={() => setIsDragging(false)}
           onDrop={(e) => {
             e.preventDefault();
@@ -211,7 +330,7 @@ export function UploadField({
             <>
               <p className="text-sm font-medium">{label}</p>
               <p className="text-xs text-[var(--muted-foreground)] mt-1">
-                Click or drag &amp; drop · {accept}
+                {typeConfig.label}
               </p>
             </>
           )}
@@ -220,7 +339,9 @@ export function UploadField({
 
       {error && (
         <div className="space-y-1">
-          <p className="text-sm text-red-500">{error}</p>
+          <p role="alert" className="text-sm text-red-500">
+            {error}
+          </p>
           {pendingFile && (
             <Button
               variant="ghost"

--- a/nginx/templates/nginx.prod.conf.template
+++ b/nginx/templates/nginx.prod.conf.template
@@ -9,8 +9,11 @@ upstream api {
 }
 
 # Rate limiting zones
-limit_req_zone $binary_remote_addr zone=api_zone:10m rate=30r/s;
-limit_req_zone $binary_remote_addr zone=web_zone:10m rate=60r/s;
+# Coarse anti-abuse fence keyed by IP — raised to accommodate mobile carriers
+# and corporate NAT where thousands of users share one IP.
+# Fine-grained per-user limits are enforced at the application layer (rate-limit.ts).
+limit_req_zone $binary_remote_addr zone=api_zone:10m rate=200r/s;
+limit_req_zone $binary_remote_addr zone=web_zone:10m rate=200r/s;
 
 # Redirect HTTP → HTTPS
 server {
@@ -45,7 +48,7 @@ server {
 
     # API proxy
     location /api/ {
-        limit_req zone=api_zone burst=50 nodelay;
+        limit_req zone=api_zone burst=500 nodelay;
 
         proxy_pass http://api/;
         proxy_http_version 1.1;
@@ -67,7 +70,7 @@ server {
 
     # Next.js app
     location / {
-        limit_req zone=web_zone burst=100 nodelay;
+        limit_req zone=web_zone burst=500 nodelay;
 
         proxy_pass http://web;
         proxy_http_version 1.1;


### PR DESCRIPTION
…validation, release workflow

Issue #96 — Centralised apps/api/src/lib/config.ts with Zod-validated env
- config-schema.ts: add PHONE_HASH_SALT, E2E_MOCK_GOOGLE_OAUTH, PAYOUT_WORKER_CONCURRENCY
- config.ts: frozen config object, secrets redacted in startup log, readable exit on missing vars
- Replace all process.env.* in non-test source files with config.X
- Add apps/api/src/lib/config.test.ts (valid env parses; missing vars throw)
- Add apps/api/.env.test loaded by Vitest 
Closes #96 

Issue #226 — nginx 30 req/s per IP replaced with per-user-id rate limiting
- nginx: raise coarse fence to 200 req/s / 500 burst per IP
- rate-limit.ts: key authenticated requests by JWT sub (user:), anonymous by IP (ip:)
- Every 429 logs a metric event (rate_limit.exceeded) for alerting
- rate-limit.test.ts: updated to cover new key-prefix behaviour 
Closes #226 

Issue #160 — Client-side file size + MIME validation in UploadField
- Define UPLOAD_TYPE_CONFIGS: logo 2 MB, product 5 MB, avatar 1 MB
- Validate MIME and size before presign (zero network calls on rejection)
- Magic-byte check rejects spoofed files (e.g. .exe renamed to .png)
- Human-readable error messages per upload type
- brand-kit-form.tsx: remove redundant accept overrides
- upload-field.test.tsx: oversized / wrong-MIME / spoofed / valid file cases
 Closes #160 

Issue #83 — Auto-generate release notes + changelog on tag
- .github/release-drafter.yml: categories mapped to PR labels (feat/fix/chore/infra/…)
- .github/workflows/release.yml: runs on v* tag + manual dispatch; publishes GitHub Release and commits updated CHANGELOG.md to main
- CHANGELOG.md: initial file with placeholder for release-drafter entries 
Closes #83 

