### PR TITLE
fix: auth redirect loop, async error handling, OG escaping, challenge pagination

### DIFF
--- a/apps/api/src/routes/brands.ts
+++ b/apps/api/src/routes/brands.ts
@@ -26,7 +26,11 @@ import { config } from "../lib/config";
 const router = Router();
 
 const BrandKitSchema = z.object({
-  name: z.string().min(1).max(100),
+  name: z
+    .string()
+    .min(1)
+    .max(100)
+    .refine((v) => !/<[^>]*>/.test(v), { message: "Brand name must not contain HTML tags" }),
   logoKey: z.string().optional(),
   primaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
   secondaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),

--- a/apps/web/src/app/(game)/challenge/[id]/challenge-page.tsx
+++ b/apps/web/src/app/(game)/challenge/[id]/challenge-page.tsx
@@ -39,6 +39,7 @@ export function ChallengePage({ params }: Props) {
   const [challengeToken, setChallengeToken] = React.useState("");
   const [sessionId, setSessionId] = React.useState("");
   const [scores, setScores] = React.useState<number[]>([]);
+  const [loadError, setLoadError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     if (!challengeId) return;
@@ -51,16 +52,26 @@ export function ChallengePage({ params }: Props) {
     const apiToken = (session as any).apiToken as string;
     const api = createApiClient(apiToken);
 
-    api.get(`/challenges/${challengeId}`).then((res) => {
-      setChallenge(res.data.challenge);
-      setQuestions(res.data.questions);
-      // Send visitorId (FingerprintJS) as deviceId for anti-cheat multi-account detection
-      // If FingerprintJS fails to load, visitorId will be null and backend will flag for review
-      api.post(`/sessions/${challengeId}/warmup-start`, { deviceId: visitorId }).then((r) => {
+    void (async () => {
+      try {
+        const res = await api.get(`/challenges/${challengeId}`);
+        setChallenge(res.data.challenge);
+        setQuestions(res.data.questions);
+      } catch {
+        setLoadError("Couldn't load the challenge. Check your connection and try again.");
+        return;
+      }
+
+      try {
+        // Send visitorId (FingerprintJS) as deviceId for anti-cheat multi-account detection.
+        // If FingerprintJS fails to load, visitorId will be null and backend will flag for review.
+        const r = await api.post(`/sessions/${challengeId}/warmup-start`, { deviceId: visitorId });
         setSessionId(r.data.sessionId);
         setPhase("warmup");
-      });
-    });
+      } catch {
+        setLoadError("Couldn't start the game session. Please try again.");
+      }
+    })();
   }, [challengeId, session, status, router, visitorId]);
 
   const handleWarmupComplete = (token: string) => {
@@ -131,6 +142,20 @@ export function ChallengePage({ params }: Props) {
     if (!last) return;
     void handleAnswer(last.option, last.reactionTimeMs);
   };
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <p className="text-lg font-medium text-[var(--foreground)]">{loadError}</p>
+        <button
+          className="rounded-md bg-[var(--primary)] px-4 py-2 text-sm font-medium text-[var(--primary-foreground)] hover:opacity-90"
+          onClick={() => { setLoadError(null); router.refresh(); }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
 
   if (phase === "loading") {
     return (

--- a/apps/web/src/app/(game)/challenge/page.tsx
+++ b/apps/web/src/app/(game)/challenge/page.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
@@ -7,23 +10,63 @@ import { api } from "@/lib/api";
 import { formatUsdc } from "@/lib/utils";
 import type { Challenge } from "@/lib/api";
 
-async function getActiveChallenges(): Promise<{ challenges: Challenge[]; failed: boolean }> {
-  try {
-    const res = await api.get("/challenges?limit=20");
-    return {
-      challenges: res.data.challenges,
-      failed: false,
-    };
-  } catch {
-    return {
-      challenges: [],
-      failed: true,
-    };
-  }
-}
+const PAGE_SIZE = 20;
 
-export default async function ChallengeIndexPage() {
-  const { challenges, failed } = await getActiveChallenges();
+export default function ChallengeIndexPage() {
+  const [challenges, setChallenges] = useState<Challenge[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const fetchPage = useCallback(async (pageOffset: number, replace: boolean) => {
+    try {
+      const res = await api.get(`/challenges?limit=${PAGE_SIZE}&offset=${pageOffset}`);
+      const page: Challenge[] = res.data.challenges;
+      setChallenges((prev) => replace ? page : [...prev, ...page]);
+      setHasMore(page.length === PAGE_SIZE);
+      setOffset(pageOffset + page.length);
+      setFailed(false);
+    } catch {
+      setFailed(true);
+    }
+  }, []);
+
+  // Initial load — render only the first 20 cards into the DOM (#362).
+  useEffect(() => {
+    void fetchPage(0, true).finally(() => setLoading(false));
+  }, [fetchPage]);
+
+  const handleLoadMore = async () => {
+    setLoadingMore(true);
+    await fetchPage(offset, false);
+    setLoadingMore(false);
+  };
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-5xl px-6 py-12">
+        <h1 className="mb-2 text-3xl font-bold">Active Challenges</h1>
+        <p className="mb-8 text-[var(--muted-foreground)]">
+          Pick a challenge, study the brand, and earn USDC
+        </p>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="animate-pulse">
+              <CardHeader>
+                <div className="h-12 w-32 rounded bg-[var(--muted)] mb-2" />
+                <div className="h-5 w-40 rounded bg-[var(--muted)]" />
+              </CardHeader>
+              <CardContent>
+                <div className="h-10 w-full rounded bg-[var(--muted)]" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="mx-auto max-w-5xl px-6 py-12">
@@ -32,51 +75,71 @@ export default async function ChallengeIndexPage() {
         Pick a challenge, study the brand, and earn USDC
       </p>
 
-      {failed ? (
+      {failed && challenges.length === 0 ? (
         <p className="text-[var(--muted-foreground)]">
           Couldn&apos;t load active challenges right now. Refresh and try again.
         </p>
       ) : challenges.length === 0 ? (
         <p className="text-[var(--muted-foreground)]">No active challenges yet. Check back soon!</p>
       ) : (
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {challenges.map((c) => (
-            <Card key={c.id} className="transition-shadow hover:shadow-lg">
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  {c.logo_url ? (
-                    <Image
-                      src={c.logo_url}
-                      alt={c.brand_name ?? "Brand logo"}
-                      width={160}
-                      height={48}
-                      sizes="160px"
-                      className="h-12 w-auto object-contain"
-                    />
-                  ) : (
-                    <div
-                      className="h-12 w-12 rounded-lg"
-                      style={{ backgroundColor: c.primary_color ?? "var(--primary)" }}
-                    />
-                  )}
-                  <Badge variant="default">Active</Badge>
-                </div>
-                <CardTitle>{c.brand_name ?? "Untitled brand"}</CardTitle>
-                <CardDescription>Prize pool: {formatUsdc(c.pool_amount_usdc)} USDC</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Link href={`/challenge/${c.id}`}>
-                  <Button
-                    className="w-full"
-                    style={{ backgroundColor: c.primary_color ?? undefined }}
-                  >
-                    Accept Challenge
-                  </Button>
-                </Link>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        <>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {challenges.map((c) => (
+              <Card key={c.id} className="transition-shadow hover:shadow-lg">
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    {c.logo_url ? (
+                      <Image
+                        src={c.logo_url}
+                        alt={c.brand_name ?? "Brand logo"}
+                        width={160}
+                        height={48}
+                        sizes="160px"
+                        className="h-12 w-auto object-contain"
+                      />
+                    ) : (
+                      <div
+                        className="h-12 w-12 rounded-lg"
+                        style={{ backgroundColor: c.primary_color ?? "var(--primary)" }}
+                      />
+                    )}
+                    <Badge variant="default">Active</Badge>
+                  </div>
+                  <CardTitle>{c.brand_name ?? "Untitled brand"}</CardTitle>
+                  <CardDescription>Prize pool: {formatUsdc(c.pool_amount_usdc)} USDC</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Link href={`/challenge/${c.id}`}>
+                    <Button
+                      className="w-full"
+                      style={{ backgroundColor: c.primary_color ?? undefined }}
+                    >
+                      Accept Challenge
+                    </Button>
+                  </Link>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {hasMore && (
+            <div className="mt-10 flex justify-center">
+              <Button
+                variant="outline"
+                onClick={handleLoadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore ? "Loading…" : "Load more challenges"}
+              </Button>
+            </div>
+          )}
+
+          {failed && challenges.length > 0 && (
+            <p className="mt-6 text-center text-sm text-[var(--muted-foreground)]">
+              Couldn&apos;t load more challenges. Try again.
+            </p>
+          )}
+        </>
       )}
     </main>
   );

--- a/apps/web/src/app/api/og/challenge/[id]/route.tsx
+++ b/apps/web/src/app/api/og/challenge/[id]/route.tsx
@@ -1,7 +1,29 @@
 import { ImageResponse } from "next/og";
-import { type NextRequest } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
+
+/** Escape HTML special characters before interpolating into Satori JSX (#361). */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** 1×1 transparent PNG returned when OG generation fails unexpectedly. */
+function fallbackResponse(): NextResponse {
+  const png = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "base64"
+  );
+  return new NextResponse(png, {
+    status: 200,
+    headers: { "Content-Type": "image/png", "Cache-Control": "public, max-age=60" },
+  });
+}
 
 export async function GET(
   _req: NextRequest,
@@ -28,45 +50,55 @@ export async function GET(
     // Use defaults
   }
 
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          width: "100%",
-          height: "100%",
-          background: "linear-gradient(135deg, #0f172a 0%, #1e293b 100%)",
-          fontFamily: "sans-serif",
-          padding: "48px",
-        }}
-      >
-        {logoUrl && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={logoUrl}
-            alt={brandName}
-            width={80}
-            height={80}
-            style={{ borderRadius: "50%", marginBottom: "24px", objectFit: "cover" }}
-          />
-        )}
-        <div style={{ fontSize: 48, fontWeight: 700, color: "#f8fafc", textAlign: "center", lineHeight: 1.2 }}>
-          {brandName} Challenge
+  // Escape special characters before interpolating into Satori JSX to prevent
+  // render exceptions on brand names containing &, <, >, ", or ' (#361).
+  const safeBrandName = escapeHtml(brandName);
+
+  try {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            height: "100%",
+            background: "linear-gradient(135deg, #0f172a 0%, #1e293b 100%)",
+            fontFamily: "sans-serif",
+            padding: "48px",
+          }}
+        >
+          {logoUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={logoUrl}
+              alt={safeBrandName}
+              width={80}
+              height={80}
+              style={{ borderRadius: "50%", marginBottom: "24px", objectFit: "cover" }}
+            />
+          )}
+          <div style={{ fontSize: 48, fontWeight: 700, color: "#f8fafc", textAlign: "center", lineHeight: 1.2 }}>
+            {safeBrandName} Challenge
+          </div>
+          <div style={{ fontSize: 28, color: "#22d3ee", marginTop: "16px", fontWeight: 600 }}>
+            Win {prizePool} USDC
+          </div>
+          <div style={{ fontSize: 18, color: "#94a3b8", marginTop: "12px", textAlign: "center" }}>
+            Compete in a 45-second brand challenge. Top players win USDC instantly.
+          </div>
+          <div style={{ marginTop: "32px", fontSize: 14, color: "#475569" }}>
+            brandblitz.gg
+          </div>
         </div>
-        <div style={{ fontSize: 28, color: "#22d3ee", marginTop: "16px", fontWeight: 600 }}>
-          Win {prizePool} USDC
-        </div>
-        <div style={{ fontSize: 18, color: "#94a3b8", marginTop: "12px", textAlign: "center" }}>
-          Compete in a 45-second brand challenge. Top players win USDC instantly.
-        </div>
-        <div style={{ marginTop: "32px", fontSize: 14, color: "#475569" }}>
-          brandblitz.gg
-        </div>
-      </div>
-    ),
-    { width: 1200, height: 630 }
-  );
+      ),
+      { width: 1200, height: 630 }
+    );
+  } catch {
+    // Satori render failed — return a 1×1 transparent PNG so link previews
+    // don't get a 500 and crawlers don't retry aggressively (#361).
+    return fallbackResponse();
+  }
 }

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -1,13 +1,37 @@
 "use client";
 
+import { useEffect } from "react";
 import dynamic from "next/dynamic";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
 
 const SessionProvider = dynamic(() => import("next-auth/react").then((m) => m.SessionProvider));
+
+// Capture unhandled promise rejections so they surface as toasts rather than
+// being silently swallowed in production (issue #570).
+function UnhandledRejectionHandler() {
+  useEffect(() => {
+    const handler = (event: PromiseRejectionEvent) => {
+      event.preventDefault();
+      const reason = event.reason;
+      const message =
+        reason instanceof Error
+          ? reason.message
+          : typeof reason === "string"
+            ? reason
+            : "An unexpected error occurred.";
+      console.error("[unhandledrejection]", reason);
+      toast.error(message);
+    };
+    window.addEventListener("unhandledrejection", handler);
+    return () => window.removeEventListener("unhandledrejection", handler);
+  }, []);
+  return null;
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
+      <UnhandledRejectionHandler />
       {children}
       <Toaster closeButton position="top-right" richColors />
     </SessionProvider>

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { randomBytes } from "crypto";
+import { getToken } from "next-auth/jwt";
 
 const REF_COOKIE_NAME = "ref";
 const REF_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -41,7 +42,31 @@ function buildCSPHeader(nonce: string): string {
   ].join("; ");
 }
 
-export function middleware(request: NextRequest): NextResponse {
+export async function middleware(request: NextRequest): Promise<NextResponse> {
+  const { pathname } = request.nextUrl;
+
+  // ── Auth redirect guard (issue #571) ──────────────────────────────────────
+  // getToken returns null for missing OR expired tokens, so checking its
+  // return value is the correct way to distinguish valid vs. expired sessions.
+  // This prevents the /login ↔ /dashboard redirect loop caused by checking
+  // only cookie presence without verifying the JWT expiry claim.
+  if (pathname === "/login" || pathname.startsWith("/login/")) {
+    const token = await getToken({
+      req: request,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+    if (token) {
+      // Session is valid and unexpired — redirect away from login.
+      const url = request.nextUrl.clone();
+      url.pathname = "/challenge";
+      url.search = "";
+      return NextResponse.redirect(url);
+    }
+    // No token or expired token — fall through to render /login normally.
+    // NextAuth will clear its own cookie on the next /api/auth/* call.
+  }
+  // ──────────────────────────────────────────────────────────────────────────
+
   // Generate nonce for this request
   const nonce = generateNonce();
 


### PR DESCRIPTION
## Summary

- **#571** — `middleware.ts` now calls `getToken()` from `next-auth/jwt` to verify JWT expiry before redirecting away from `/login`. Expired or missing tokens fall through to render the login form; valid tokens redirect to `/challenge`. Eliminates the `/login` ↔ `/dashboard` infinite redirect loop caused by checking only cookie presence.
- **#570** — `challenge-page.tsx` useEffect chains converted from `.then()` to `async/await` with `try/catch`; failed loads show an inline error banner with a "Try again" button instead of a blank screen. `providers.tsx` adds a global `window.unhandledrejection` handler that forwards rejections to Sonner toasts so no promise failure is silently swallowed.
- **#361** — OG image route adds `escapeHtml()` sanitization of `brandName` before interpolating into Satori JSX (fixes crashes on `&`, `<`, `>`, `"`, `'`); wraps `new ImageResponse(...)` in `try/catch` returning a 1×1 fallback PNG so link previews never get a 500. `brands.ts` `BrandKitSchema` rejects names containing raw HTML tags at creation time.
- **#362** — `challenge/page.tsx` converted to a client component with offset-based "Load more" pagination; initial render mounts exactly 20 cards regardless of total count; additional pages load on demand without a full page reload; skeleton cards shown during initial fetch.

## Test plan

- [ ] Visit `/login` with an expired session cookie — confirm the login form renders (no redirect)
- [ ] Visit `/login` with a valid session — confirm redirect to `/challenge`
- [ ] Visit `/login` with no cookie — confirm login form renders normally
- [ ] Simulate network failure during challenge load — confirm inline error banner appears with retry
- [ ] Trigger an unhandled promise rejection in the console — confirm a toast appears
- [ ] Create a brand with name `Acme &amp; Co <test>` — confirm 400 from API
- [ ] Open `/api/og/challenge/[id]` for a challenge whose brand name contains `&` — confirm 200 PNG
- [ ] Load the challenges page with 20+ active challenges — confirm only 20 cards initially
- [ ] Click "Load more" — confirm next 20 cards append without page reload

Closes #361
Closes #362  
Closes #570  
Closes #571 