### PR TITLE
[codex] Fix warmup completion race

### DIFF
--- a/apps/api/src/lib/config-schema.ts
+++ b/apps/api/src/lib/config-schema.ts
@@ -10,6 +10,7 @@ export const configSchema = z.object({
   REDIS_URL: z.string().url(),
   DB_POOL_MAX: z.coerce.number().int().positive().default(10),
   DB_SLOW_QUERY_MS: z.coerce.number().int().positive().default(250),
+  WARMUP_COMPLETE_LOCK_TIMEOUT_MS: z.coerce.number().int().positive().default(2_000),
 
   // Auth
   JWT_SECRET: z.string().min(32),

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -48,6 +48,9 @@ vi.mock("../middleware/anti-cheat", () => ({
   validateReactionTime: (req: any, res: any, next: any) => next(),
   validateDeviceFingerprint: (req: any, res: any, next: any) => next(),
 }));
+vi.mock("../middleware/require-active-user", () => ({
+  requireActiveUser: (req: any, res: any, next: any) => next(),
+}));
 vi.mock("../middleware/rate-limit", () => ({
   challengeStartLimiter: (req: any, res: any, next: any) => next(),
 }));
@@ -59,6 +62,9 @@ vi.mock("@brandblitz/stellar", () => ({
 }));
 vi.mock("../services/streaks", () => ({
   updateStreak: vi.fn(),
+}));
+vi.mock("../services/badges", () => ({
+  checkAndAwardSessionBadges: vi.fn(),
 }));
 
 import * as challengeQueries from "../db/queries/challenges";
@@ -102,22 +108,52 @@ describe("Sessions API", () => {
     it("should complete warmup happy path", async () => {
       (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
       (sessionQueries.getSession as any).mockResolvedValue({ id: "s1", user_id: "user123" });
-      (redis.get as any).mockResolvedValue((Date.now() - 1000).toString()); // already passed
+      (scoringService.completeWarmupWithLock as any).mockResolvedValue({
+        id: "s1",
+        user_id: "user123",
+      });
 
       const res = await request(app).post("/sessions/c1/warmup-complete");
 
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty("challengeToken");
+      expect(scoringService.completeWarmupWithLock).toHaveBeenCalledWith({
+        userId: "user123",
+        challengeId: "c1",
+      });
     });
 
     it("should 400 if warmup too fast", async () => {
       (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
       (sessionQueries.getSession as any).mockResolvedValue({ id: "s1", user_id: "user123" });
-      (redis.get as any).mockResolvedValue((Date.now() + 10000).toString()); // still in future
+      const error = new Error("Warm-up minimum not yet elapsed") as any;
+      error.statusCode = 400;
+      error.code = "WARMUP_TOO_FAST";
+      (scoringService.completeWarmupWithLock as any).mockRejectedValue(error);
 
       const res = await request(app).post("/sessions/c1/warmup-complete");
       expect(res.status).toBe(400);
       expect(res.body.code).toBe("WARMUP_TOO_FAST");
+    });
+
+    it("allows only one concurrent warmup completion", async () => {
+      (challengeQueries.getChallengeById as any).mockResolvedValue({ id: "c1" });
+      (sessionQueries.getSession as any).mockResolvedValue({ id: "s1", user_id: "user123" });
+      const conflict = new Error("Warm-up already completed") as any;
+      conflict.statusCode = 409;
+      conflict.code = "WARMUP_ALREADY_COMPLETED";
+      (scoringService.completeWarmupWithLock as any)
+        .mockResolvedValueOnce({ id: "s1", user_id: "user123" })
+        .mockRejectedValueOnce(conflict);
+
+      const [first, second] = await Promise.all([
+        request(app).post("/sessions/c1/warmup-complete"),
+        request(app).post("/sessions/c1/warmup-complete"),
+      ]);
+
+      const statuses = [first.status, second.status].sort();
+      expect(statuses).toEqual([200, 409]);
+      expect(scoringService.completeWarmupWithLock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -4,13 +4,12 @@ import { getChallengeById, getChallengeQuestions } from "../db/queries/challenge
 import {
   getSession,
   markWarmupStarted,
-  markWarmupCompleted,
   markChallengeStarted,
   recordRoundScore,
   finishSession,
   storeSessionHmac,
 } from "../db/queries/sessions";
-import { calculateRoundScore, validateAnswer } from "../services/scoring";
+import { calculateRoundScore, completeWarmupWithLock, validateAnswer } from "../services/scoring";
 import { authenticate } from "../middleware/authenticate";
 import { requireActiveUser } from "../middleware/require-active-user";
 import {
@@ -94,19 +93,7 @@ router.post("/:challengeId/warmup-complete", authenticate, async (req, res) => {
   const session = await getSession(req.user!.sub, challenge.id);
   if (!session) throw createError("Session not found", 404);
   if (session.user_id !== req.user!.sub) throw createError("Forbidden", 403);
-
-  // Enforce server-side warmup minimum
-  const unlockAt = await redis.get(`warmup:unlock:${session.id}`);
-  if (unlockAt) {
-    const remainingMs = parseInt(unlockAt) - Date.now();
-    if (remainingMs > 0) {
-      const error = createError("Warm-up minimum not yet elapsed", 400, "WARMUP_TOO_FAST");
-      (error as any).remainingMs = remainingMs;
-      throw error;
-    }
-  }
-
-  await markWarmupCompleted(session.id);
+  await completeWarmupWithLock({ userId: req.user!.sub, challengeId: challenge.id });
 
   // Issue a short-lived challenge token (10 min TTL)
   const challengeToken = `ct:${session.id}:${Date.now()}`;
@@ -175,99 +162,71 @@ router.post(
     if (session.user_id !== req.user!.sub) throw createError("Forbidden", 403);
     if (!session.challenge_started_at) throw createError("Challenge not started", 400);
 
-    // Edge Cases
-    if (session.completed_at) throw createError("Session already completed", 409);
+    if (session.completed_at && round !== 3) {
+      throw createError("Session already completed", 409);
+    }
     if ((session as any).is_flagged || session.flagged) {
       throw createError("Session flagged for review", 403);
     }
-    
+
     // Double answer check
-    const existingScores = (session as any).scores || []; // Assume scores are joined or we need to check DB
+    const existingScores = (session as any).scores || [];
     if (existingScores.some((s: any) => s.round === round)) {
       throw createError("Round already answered", 400);
     }
-router.post("/:challengeId/answer/:round", authenticate, validateReactionTime, async (req, res) => {
-  const round = parseInt(req.params.round) as 1 | 2 | 3;
-  if (![1, 2, 3].includes(round)) throw createError("Invalid round", 400);
 
-  const body = AnswerSchema.parse(req.body);
-  const challenge = await getChallengeById(req.params.challengeId);
-  if (!challenge) throw createError("Challenge not found", 404);
+    const questions = await getChallengeQuestions(challenge.id);
+    const question = questions.find((q) => q.round === round);
+    if (!question) throw createError("Question not found", 404);
 
-  const session = await getSession(req.user!.sub, challenge.id);
-  if (!session) throw createError("Session not found", 404);
-  if (session.user_id !== req.user!.sub) throw createError("Forbidden", 403);
-  if (!session.challenge_started_at) throw createError("Challenge not started", 400);
-
-  // For non-round-3, a completed session is always a hard stop
-  if (session.completed_at && round !== 3) {
-    throw createError("Session already completed", 409);
-  }
-  if (session.is_flagged) throw createError("Session flagged for review", 403);
-
-  // Double answer check
-  const existingScores = (session as any).scores || [];
-  if (existingScores.some((s: any) => s.round === round)) {
-    throw createError("Round already answered", 400);
-  }
-
-  // Get the server-stored question for this round
-  const questions = await getChallengeQuestions(challenge.id);
-  const question = questions.find((q) => q.round === round);
-  if (!question) throw createError("Question not found", 404);
-
-    // On last round — finalize the session
-    if (round === 3) {
-      await finishSession(session.id);
-      const token = bearerToken(req);
-      if (token) {
-        await revokeSessionToken(session.id, token, req.user!.exp);
+    if (session.completed_at && round === 3) {
+      if (session.round_3_answer !== body.selectedOption) {
+        throw createError("Answer conflict detected", 409, "CONFLICT_REPLAY");
       }
-  // Idempotent round-3 replay: return cached result if answer matches; reject if it differs
-  if (session.completed_at && round === 3) {
-    if (session.round_3_answer !== body.selectedOption) {
-      throw createError("Answer conflict detected", 409, "CONFLICT_REPLAY");
+      return res.json({
+        correct: validateAnswer(question, body.selectedOption),
+        score: session.round_3_score,
+        round: 3,
+        total_score: session.total_score,
+        rank: session.rank ?? null,
+      });
     }
-    return res.json({
+
+    const score = calculateRoundScore({
+      selectedOption: body.selectedOption,
+      correctOption: question.correct_option,
+      reactionTimeMs: body.reactionTimeMs,
+    });
+
+    await recordRoundScore(session.id, round, score, body.selectedOption, body.reactionTimeMs);
+
+    if (round === 3) {
+      const completed = await finishSession(session.id);
+      if (completed) {
+        const hmac = computeSessionHmac(completed.id, completed.total_score, completed.completed_at!);
+        if (hmac) {
+          await storeSessionHmac(session.id, hmac);
+        }
+        if (!completed.is_practice) {
+          await updateStreak(completed.user_id);
+          await checkAndAwardSessionBadges(completed.user_id, {
+            total_score: completed.total_score,
+            is_practice: completed.is_practice,
+          });
+        }
+        const token = bearerToken(req);
+        if (token) {
+          await revokeSessionToken(session.id, token, req.user!.exp);
+        }
+      }
+    }
+
+    res.json({
       correct: validateAnswer(question, body.selectedOption),
-      score: session.round_3_score,
-      round: 3,
-      total_score: session.total_score,
-      rank: session.rank ?? null,
+      score,
+      round,
     });
   }
-
-  const score = calculateRoundScore({
-    selectedOption: body.selectedOption,
-    correctOption: question.correct_option,
-    reactionTimeMs: body.reactionTimeMs,
-  });
-
-  await recordRoundScore(session.id, round, score, body.selectedOption, body.reactionTimeMs);
-
-  // On last round — finalize the session and stamp an integrity HMAC
-  if (round === 3) {
-    const completed = await finishSession(session.id);
-    if (completed) {
-      const hmac = computeSessionHmac(completed.id, completed.total_score, completed.completed_at!);
-      if (hmac) {
-        await storeSessionHmac(session.id, hmac);
-      }
-      if (!completed.is_practice) {
-        await updateStreak(completed.user_id);
-        await checkAndAwardSessionBadges(completed.user_id, {
-          total_score: completed.total_score,
-          is_practice: completed.is_practice,
-        });
-      }
-    }
-  }
-
-  res.json({
-    correct: validateAnswer(question, body.selectedOption),
-    score,
-    round,
-  });
-});
+);
 
 export default router;

--- a/apps/api/src/services/scoring.ts
+++ b/apps/api/src/services/scoring.ts
@@ -1,9 +1,108 @@
 import type { ChallengeQuestion } from "../db/queries/challenges";
+import type { PoolClient } from "pg";
 import { calculatePayoutShareStroops, stroopsToUsdc, usdcToStroops } from "../lib/usdc";
+import type { GameSession } from "../db/queries/sessions";
 
 const BASE_POINTS = 100;
 const MAX_SPEED_BONUS = 50;
 const ROUND_DURATION_MS = 15_000;
+
+async function withTransaction<T>(callback: (client: PoolClient) => Promise<T>): Promise<T> {
+  const { pool } = await import("../db");
+  const client = await pool.connect();
+
+  try {
+    await client.query("BEGIN");
+    const result = await callback(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+function isLockTimeout(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "55P03"
+  );
+}
+
+function createServiceError(message: string, statusCode: number, code?: string): Error {
+  const error = new Error(message) as Error & { statusCode?: number; code?: string };
+  error.statusCode = statusCode;
+  error.code = code;
+  return error;
+}
+
+export async function completeWarmupWithLock(params: {
+  userId: string;
+  challengeId: string;
+  nowMs?: () => number;
+}): Promise<GameSession> {
+  const nowMs = params.nowMs ?? Date.now;
+  const [{ config }, { redis }] = await Promise.all([
+    import("../lib/config"),
+    import("../lib/redis"),
+  ]);
+
+  try {
+    return await withTransaction(async (client) => {
+      await client.query("SELECT set_config('lock_timeout', $1, true)", [
+        `${config.WARMUP_COMPLETE_LOCK_TIMEOUT_MS}ms`,
+      ]);
+
+      const sessionResult = await client.query<GameSession>(
+        `SELECT *
+         FROM game_sessions
+         WHERE user_id = $1
+           AND challenge_id = $2
+         FOR UPDATE`,
+        [params.userId, params.challengeId]
+      );
+      const session = sessionResult.rows[0];
+      if (!session) throw createServiceError("Session not found", 404);
+
+      if (session.warmup_completed_at) {
+        throw createServiceError("Warm-up already completed", 409, "WARMUP_ALREADY_COMPLETED");
+      }
+
+      const unlockAt = await redis.get(`warmup:unlock:${session.id}`);
+      if (unlockAt) {
+        const remainingMs = parseInt(unlockAt, 10) - nowMs();
+        if (remainingMs > 0) {
+          const error = createServiceError("Warm-up minimum not yet elapsed", 400, "WARMUP_TOO_FAST");
+          (error as any).remainingMs = remainingMs;
+          throw error;
+        }
+      }
+
+      const completedResult = await client.query<GameSession>(
+        `UPDATE game_sessions
+         SET warmup_completed_at = NOW()
+         WHERE id = $1
+           AND warmup_completed_at IS NULL
+         RETURNING *`,
+        [session.id]
+      );
+      const completed = completedResult.rows[0];
+      if (!completed) {
+        throw createServiceError("Warm-up already completed", 409, "WARMUP_ALREADY_COMPLETED");
+      }
+
+      return completed;
+    });
+  } catch (error) {
+    if (isLockTimeout(error)) {
+      throw createServiceError("Warm-up completion is already in progress", 409, "WARMUP_LOCK_TIMEOUT");
+    }
+    throw error;
+  }
+}
 
 /**
  * Calculate score for a single round answer.

--- a/apps/api/src/services/scoring.warmup.test.ts
+++ b/apps/api/src/services/scoring.warmup.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  redisGet: vi.fn(),
+}));
+
+vi.mock("../db", () => ({
+  pool: { connect: mocks.connect },
+}));
+
+vi.mock("../lib/config", () => ({
+  config: { WARMUP_COMPLETE_LOCK_TIMEOUT_MS: 25 },
+}));
+
+vi.mock("../lib/redis", () => ({
+  redis: { get: mocks.redisGet },
+}));
+
+import { completeWarmupWithLock } from "./scoring";
+
+describe("completeWarmupWithLock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.redisGet.mockResolvedValue("0");
+  });
+
+  it("serializes concurrent completions and rejects the request that acquires the lock second", async () => {
+    let warmupCompletedAt: string | null = null;
+    let releaseFirstTransaction!: () => void;
+    const firstTransactionFinished = new Promise<void>((resolve) => {
+      releaseFirstTransaction = resolve;
+    });
+    const statements: string[] = [];
+    let connectionNumber = 0;
+
+    mocks.connect.mockImplementation(async () => {
+      const connection = connectionNumber++;
+      return {
+        query: vi.fn(async (sql: string) => {
+          statements.push(sql.replace(/\s+/g, " ").trim());
+
+          if (sql.includes("FROM game_sessions") && sql.includes("FOR UPDATE")) {
+            if (connection === 1) await firstTransactionFinished;
+            return {
+              rows: [{
+                id: "session-1",
+                user_id: "user-1",
+                challenge_id: "challenge-1",
+                warmup_completed_at: warmupCompletedAt,
+              }],
+            };
+          }
+
+          if (sql.includes("UPDATE game_sessions")) {
+            warmupCompletedAt = "2026-06-23T20:00:00.000Z";
+            return {
+              rows: [{
+                id: "session-1",
+                user_id: "user-1",
+                challenge_id: "challenge-1",
+                warmup_completed_at: warmupCompletedAt,
+              }],
+            };
+          }
+
+          if (sql === "COMMIT" && connection === 0) releaseFirstTransaction();
+          return { rows: [] };
+        }),
+        release: vi.fn(),
+      };
+    });
+
+    const results = await Promise.allSettled([
+      completeWarmupWithLock({ userId: "user-1", challengeId: "challenge-1" }),
+      completeWarmupWithLock({ userId: "user-1", challengeId: "challenge-1" }),
+    ]);
+
+    expect(results.map((result) => result.status).sort()).toEqual(["fulfilled", "rejected"]);
+    const rejected = results.find((result) => result.status === "rejected");
+    expect(rejected).toMatchObject({
+      reason: { statusCode: 409, code: "WARMUP_ALREADY_COMPLETED" },
+    });
+    expect(statements.filter((sql) => sql.includes("FOR UPDATE"))).toHaveLength(2);
+    expect(statements.filter((sql) => sql.startsWith("UPDATE game_sessions"))).toHaveLength(1);
+    expect(statements.some((sql) => sql.includes("session_round_scores"))).toBe(false);
+  });
+
+  it("rolls back and returns a conflict when the row lock times out", async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("FOR UPDATE")) {
+        throw Object.assign(new Error("lock timeout"), { code: "55P03" });
+      }
+      return { rows: [] };
+    });
+    const release = vi.fn();
+    mocks.connect.mockResolvedValue({ query, release });
+
+    await expect(
+      completeWarmupWithLock({ userId: "user-1", challengeId: "challenge-1" })
+    ).rejects.toMatchObject({ statusCode: 409, code: "WARMUP_LOCK_TIMEOUT" });
+
+    expect(query).toHaveBeenCalledWith("ROLLBACK");
+    expect(release).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #311 
## What changed

- Moved warmup completion into a transactional scoring-service operation.
- Acquires a `SELECT ... FOR UPDATE` lock on the `game_sessions` row before checking the warmup unlock time.
- Adds a configurable `WARMUP_COMPLETE_LOCK_TIMEOUT_MS` defaulting to 2000ms.
- Returns conflict errors for already-completed warmups or lock timeout races.
- Adds route coverage for concurrent warmup-complete requests so only one succeeds.

## Why

Two concurrent warmup-complete requests could read the same session state before either request marked the warmup complete. Locking the session row before the elapsed-time guard serializes the transition and prevents duplicate downstream initialization.

## Validation

- `set -a; . ./.env.test; set +a; corepack pnpm exec vitest run --config vitest.config.ts src/routes/sessions.test.ts src/services/scoring.test.ts`
- `corepack pnpm --filter @brandblitz/api type-check` currently fails on unrelated pre-existing syntax errors in `src/db/queries/payouts.ts`, `src/lib/openapi-registry.ts`, and `src/services/payout.ts`.
