### PR TITLE
[codex] Validate challenge end time on creation

### DIFF
--- a/apps/api/src/routes/brands.distractors.integration.test.ts
+++ b/apps/api/src/routes/brands.distractors.integration.test.ts
@@ -39,6 +39,10 @@ vi.mock("../middleware/authenticate", () => ({
   },
 }));
 
+vi.mock("../middleware/require-tos", () => ({
+  requireCurrentTosAccepted: (_req: any, _res: any, next: any) => next(),
+}));
+
 vi.mock("@brandblitz/storage", () => ({
   optimizeImage: vi.fn(),
   getPublicUrl: (_bucket: string, key: string) => `https://storage.example.com/${key}`,
@@ -239,5 +243,29 @@ describe("POST /brands/challenges distractor integration", () => {
     );
 
     expect(hasFallbackOption).toBe(true);
+  });
+
+  it("rejects challenge creation when endsAt is in the past", async () => {
+    const response = await postChallenge({
+      brandId,
+      poolAmountUsdc: "50.0000000",
+      endsAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.data.error).toBe("Challenge end time must be in the future");
+    expect(mocks.createChallenge).not.toHaveBeenCalled();
+  });
+
+  it("rejects challenge creation when duration is less than one hour", async () => {
+    const response = await postChallenge({
+      brandId,
+      poolAmountUsdc: "50.0000000",
+      endsAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.data.error).toBe("Challenge duration must be at least 1 hour");
+    expect(mocks.createChallenge).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/brands.ts
+++ b/apps/api/src/routes/brands.ts
@@ -41,8 +41,29 @@ const ChallengeSchema = z.object({
   brandId: z.string().uuid(),
   poolAmountUsdc: z.string().regex(/^\d+(\.\d{1,7})?$/),
   maxPlayers: z.number().int().positive().optional(),
-  endsAt: z.string().datetime().optional(),
+  endsAt: z.string().datetime(),
 });
+
+const MIN_CHALLENGE_DURATION_MS = 60 * 60 * 1000;
+const CHALLENGE_DURATION_GRACE_MS = 5_000;
+
+function validateChallengeEndsAt(endsAt: string): void {
+  const endsAtMs = new Date(endsAt).getTime();
+  const nowMs = Date.now();
+  const minEndsAtMs = nowMs + MIN_CHALLENGE_DURATION_MS;
+
+  if (endsAtMs <= nowMs) {
+    throw createError("Challenge end time must be in the future", 400, "ENDS_AT_PAST");
+  }
+
+  if (endsAtMs < minEndsAtMs - CHALLENGE_DURATION_GRACE_MS) {
+    throw createError(
+      "Challenge duration must be at least 1 hour",
+      400,
+      "ENDS_AT_TOO_SOON"
+    );
+  }
+}
 
 /**
  * GET /brands
@@ -134,6 +155,7 @@ router.post("/", authenticate, async (req, res) => {
  */
 router.post("/challenges", authenticate, requireCurrentTosAccepted, async (req, res) => {
   const body = ChallengeSchema.parse(req.body);
+  validateChallengeEndsAt(body.endsAt);
 
   const brand = await getBrandById(body.brandId);
   if (!brand) throw createError("Brand not found", 404);

--- a/apps/web/src/components/brand/brand-kit-form.test.tsx
+++ b/apps/web/src/components/brand/brand-kit-form.test.tsx
@@ -1,56 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useRouter } from "next/navigation";
 import { BrandKitForm } from "./brand-kit-form";
 import * as apiModule from "@/lib/api";
-
-// Mock next/navigation
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: pushMock,
-  }),
-}));
-
-vi.mock("@/lib/api", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
-
-  return {
-    ...actual,
-    createApiClient: () => ({
-      post: postMock,
-    }),
-  };
-});
-
-vi.mock("./upload-field", () => ({
-  UploadField: ({
-    label,
-    uploadType,
-    onUploaded,
-  }: {
-    label: string;
-    uploadType: "brand-logo" | "product-image";
-    onUploaded: (key: string, publicUrl: string) => void;
-  }) => (
-    <button
-      type="button"
-      onClick={() => {
-        if (uploadType === "brand-logo") {
-          onUploaded("logo-key-123", "https://cdn.example/logo.webp");
-          return;
-        }
-
-        const count = (globalThis as any).__productUploadCount ?? 0;
-        const nextCount = count + 1;
-        (globalThis as any).__productUploadCount = nextCount;
-        onUploaded(`product-key-${nextCount}`, `https://cdn.example/product-${nextCount}.webp`);
-      }}
-    >
-      Upload {label}
-    </button>
-  ),
-}));
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
@@ -71,18 +23,18 @@ vi.mock("@/lib/api", () => ({
 
 // Mock the upload field
 vi.mock("./upload-field", () => ({
-  UploadField: ({ onUploaded }: any) => (
-    <button onClick={() => onUploaded("test-logo-key")}>Upload Logo</button>
+  UploadField: ({ label, onUploaded }: any) => (
+    <button type="button" onClick={() => onUploaded("test-logo-key")}>
+      {label}
+    </button>
   ),
 }));
 
 describe("BrandKitForm", () => {
-  let mockRouter: any;
   let mockApiClient: any;
 
   beforeEach(() => {
-    mockRouter = { push: vi.fn() };
-    vi.mocked(useRouter).mockReturnValue(mockRouter);
+    mocks.push.mockReset();
 
     mockApiClient = {
       post: vi.fn(),
@@ -123,18 +75,18 @@ describe("BrandKitForm", () => {
     await user.type(screen.getByLabelText(/Prize Pool/i), "100");
 
     // Upload logo
-    await user.click(screen.getByText("Upload Logo"));
+    await user.click(screen.getByText("Upload Brand Logo"));
 
     // Submit form
     await user.click(screen.getByRole("button", { name: /Create Brand Kit/i }));
 
     // Wait for redirect
     await waitFor(() => {
-      expect(mockRouter.push).toHaveBeenCalled();
+      expect(mocks.push).toHaveBeenCalled();
     });
 
     // Verify redirect URL does NOT contain secrets
-    const redirectUrl = mockRouter.push.mock.calls[0][0];
+    const redirectUrl = mocks.push.mock.calls[0][0];
     expect(redirectUrl).toBe("/brand/brand-123");
     expect(redirectUrl).not.toContain("depositAddress");
     expect(redirectUrl).not.toContain("memo");

--- a/apps/web/src/components/brand/brand-kit-form.tsx
+++ b/apps/web/src/components/brand/brand-kit-form.tsx
@@ -17,6 +17,8 @@ interface BrandKitFormProps {
 }
 
 const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/;
+const MIN_CHALLENGE_DURATION_HOURS = 1;
+const MAX_CHALLENGE_DURATION_HOURS = 720;
 
 export function BrandKitForm({ apiToken }: BrandKitFormProps) {
   const router = useRouter();
@@ -44,8 +46,8 @@ export function BrandKitForm({ apiToken }: BrandKitFormProps) {
   const hasValidDuration =
     fields.durationHours.trim() !== "" &&
     Number.isInteger(Number(fields.durationHours)) &&
-    Number(fields.durationHours) >= 1 &&
-    Number(fields.durationHours) <= 720;
+    Number(fields.durationHours) >= MIN_CHALLENGE_DURATION_HOURS &&
+    Number(fields.durationHours) <= MAX_CHALLENGE_DURATION_HOURS;
   const canSubmit =
     !submitting &&
     hasRequiredFields &&
@@ -63,7 +65,11 @@ const FormSchema = z.object({
   poolAmountUsdc: z.string().refine((val) => Number(val) >= 10, "Minimum pool amount is 10 USDC"),
   durationHours: z.string().refine((val) => {
     const num = Number(val);
-    return Number.isInteger(num) && num >= 1 && num <= 720;
+    return (
+      Number.isInteger(num) &&
+      num >= MIN_CHALLENGE_DURATION_HOURS &&
+      num <= MAX_CHALLENGE_DURATION_HOURS
+    );
   }, "Duration must be between 1 and 720 hours"),
 });
 
@@ -109,7 +115,13 @@ const FormSchema = z.object({
         const durationHours = Number.isFinite(parsedDurationHours) && parsedDurationHours > 0
           ? parsedDurationHours
           : 72;
-        const endsAt = new Date(Date.now() + durationHours * 60 * 60 * 1000).toISOString();
+        const nowMs = Date.now();
+        const endsAtMs = nowMs + durationHours * 60 * 60 * 1000;
+        if (endsAtMs < nowMs + MIN_CHALLENGE_DURATION_HOURS * 60 * 60 * 1000) {
+          setError("Challenge duration must be at least 1 hour.");
+          return;
+        }
+        const endsAt = new Date(endsAtMs).toISOString();
 
         // Fix path if it should be /challenges instead of /brands/challenges or vice-versa
         // Assuming backend uses /brands/challenges based on the routes
@@ -312,8 +324,8 @@ const FormSchema = z.object({
             <Input
               id="durationHours"
               type="number"
-              min="1"
-              max="720"
+              min={MIN_CHALLENGE_DURATION_HOURS}
+              max={MAX_CHALLENGE_DURATION_HOURS}
               value={fields.durationHours}
               onChange={set("durationHours")}
             />


### PR DESCRIPTION
Closes #316 
## What changed

- Requires `endsAt` on challenge creation and validates it server-side.
- Rejects challenge end times in the past or less than one hour out.
- Adds focused API coverage for past and too-soon `endsAt` payloads.
- Adds client-side duration validation to the brand kit plus challenge creation form.
- Cleans up the form test mocks so the challenge creation redirect test runs reliably.

## Notes

The issue text points at `apps/api/src/routes/challenges.ts` and `apps/web/src/app/(brand)/dashboard/page.tsx`, but in this checkout challenge creation is implemented in `apps/api/src/routes/brands.ts` and the client creation flow lives in `apps/web/src/components/brand/brand-kit-form.tsx`.

## Validation

- `set -a; . ./.env.test; set +a; corepack pnpm exec vitest run --config vitest.config.ts src/routes/brands.distractors.integration.test.ts`
- `corepack pnpm exec vitest run src/components/brand/brand-kit-form.test.tsx`
- `corepack pnpm --filter @brandblitz/web type-check` currently fails on an unrelated existing parse error in `src/app/(game)/challenge/[id]/challenge-page.tsx`.
