### PR TITLE
[codex] Validate challenge end time

### DIFF
--- a/apps/api/src/routes/brands.distractors.integration.test.ts
+++ b/apps/api/src/routes/brands.distractors.integration.test.ts
@@ -39,6 +39,10 @@ vi.mock("../middleware/authenticate", () => ({
   },
 }));
 
+vi.mock("../middleware/require-tos", () => ({
+  requireCurrentTosAccepted: (_req: any, _res: any, next: any) => next(),
+}));
+
 vi.mock("@brandblitz/storage", () => ({
   optimizeImage: vi.fn(),
   getPublicUrl: (_bucket: string, key: string) => `https://storage.example.com/${key}`,
@@ -55,6 +59,7 @@ vi.mock("../lib/logger", () => ({
 }));
 
 import router from "./brands";
+import { errorHandler } from "../middleware/error";
 
 function buildBrand(params: {
   id: string;
@@ -100,9 +105,7 @@ async function postChallenge(body: Record<string, unknown>) {
   const app = express();
   app.use(express.json());
   app.use("/brands", router);
-  app.use((err: any, _req: any, res: any, _next: any) => {
-    res.status(err?.statusCode ?? 500).json({ error: err?.message ?? "Unexpected error" });
-  });
+  app.use(errorHandler);
 
   const server = app.listen(0);
 
@@ -239,5 +242,27 @@ describe("POST /brands/challenges distractor integration", () => {
     );
 
     expect(hasFallbackOption).toBe(true);
+  });
+
+  it("rejects a challenge whose end time is in the past", async () => {
+    const response = await postChallenge({
+      brandId,
+      poolAmountUsdc: "50.0000000",
+      endsAt: "2020-01-01T00:00:00.000Z",
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.createChallenge).not.toHaveBeenCalled();
+  });
+
+  it("rejects a challenge shorter than the one-hour minimum", async () => {
+    const response = await postChallenge({
+      brandId,
+      poolAmountUsdc: "50.0000000",
+      endsAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.createChallenge).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/brands.ts
+++ b/apps/api/src/routes/brands.ts
@@ -25,6 +25,8 @@ import { config } from "../lib/config";
 
 const router = Router();
 
+const MIN_CHALLENGE_DURATION_MS = 60 * 60 * 1000;
+
 const BrandKitSchema = z.object({
   name: z.string().min(1).max(100),
   logoKey: z.string().optional(),
@@ -41,7 +43,14 @@ const ChallengeSchema = z.object({
   brandId: z.string().uuid(),
   poolAmountUsdc: z.string().regex(/^\d+(\.\d{1,7})?$/),
   maxPlayers: z.number().int().positive().optional(),
-  endsAt: z.string().datetime().optional(),
+  endsAt: z
+    .string()
+    .datetime()
+    .refine(
+      (value) => new Date(value).getTime() >= Date.now() + MIN_CHALLENGE_DURATION_MS,
+      "Challenge must end at least 1 hour in the future"
+    )
+    .optional(),
 });
 
 /**

--- a/apps/web/src/components/brand/brand-kit-form.tsx
+++ b/apps/web/src/components/brand/brand-kit-form.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { UploadField } from "./upload-field";
 import { useSubmitting } from "@/hooks/use-submitting";
+import { challengeEndsAt } from "./challenge-validation";
 
 interface BrandKitFormProps {
   apiToken: string;
@@ -105,11 +106,11 @@ const FormSchema = z.object({
         );
 
         const brandId = brandRes.data.brand.id;
-        const parsedDurationHours = Number.parseInt(fields.durationHours, 10);
-        const durationHours = Number.isFinite(parsedDurationHours) && parsedDurationHours > 0
-          ? parsedDurationHours
-          : 72;
-        const endsAt = new Date(Date.now() + durationHours * 60 * 60 * 1000).toISOString();
+        const endsAt = challengeEndsAt(fields.durationHours);
+        if (!endsAt) {
+          setError("Challenge duration must be between 1 and 720 hours.");
+          return;
+        }
 
         // Fix path if it should be /challenges instead of /brands/challenges or vice-versa
         // Assuming backend uses /brands/challenges based on the routes

--- a/apps/web/src/components/brand/challenge-ends-at.test.ts
+++ b/apps/web/src/components/brand/challenge-ends-at.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { challengeEndsAt } from "./challenge-validation";
+
+describe("challengeEndsAt", () => {
+  const now = Date.parse("2026-06-23T12:00:00.000Z");
+
+  it("returns a future end time for a valid duration", () => {
+    expect(challengeEndsAt("1", now)).toBe("2026-06-23T13:00:00.000Z");
+  });
+
+  it.each(["0", "-1", "0.5", "721", "not-a-number"])(
+    "rejects invalid duration %s",
+    (duration) => {
+      expect(challengeEndsAt(duration, now)).toBeNull();
+    }
+  );
+});

--- a/apps/web/src/components/brand/challenge-validation.ts
+++ b/apps/web/src/components/brand/challenge-validation.ts
@@ -1,0 +1,16 @@
+const MIN_CHALLENGE_DURATION_HOURS = 1;
+const MAX_CHALLENGE_DURATION_HOURS = 720;
+
+export function challengeEndsAt(durationHours: string, nowMs = Date.now()): string | null {
+  const hours = Number(durationHours);
+  if (
+    !Number.isInteger(hours) ||
+    hours < MIN_CHALLENGE_DURATION_HOURS ||
+    hours > MAX_CHALLENGE_DURATION_HOURS
+  ) {
+    return null;
+  }
+
+  const endsAtMs = nowMs + hours * 60 * 60 * 1000;
+  return endsAtMs > nowMs ? new Date(endsAtMs).toISOString() : null;
+}


### PR DESCRIPTION
Closes #316.

## What changed

- rejects supplied challenge end times that are less than one hour in the future
- keeps the minimum duration enforced at the API trust boundary
- validates and derives the challenge end timestamp in the client form without silently falling back to a default
- adds API tests for past and too-short challenges and client tests for valid and invalid durations

## Why

The creation endpoint accepted past timestamps, allowing a new challenge to enter the ended-processing path immediately.

## Validation

- API Vitest: 4 tests passed
- Web Vitest: 6 tests passed
- API ESLint passed
- `git diff --check` passed

Web ESLint is currently blocked by the pre-existing `next is not a function` error in `apps/web/eslint.config.mjs`.
