### PR TITLE
[codex] Skip referral bonuses for fraud sessions

### DIFF
--- a/apps/api/src/queues/processors/referral-bonus.processor.test.ts
+++ b/apps/api/src/queues/processors/referral-bonus.processor.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findReferralPayoutById: vi.fn(),
+  updateReferralPayoutStatus: vi.fn(),
+  getSession: vi.fn(),
+  isFraudSession: vi.fn(),
+  auditReferralBonusSkipped: vi.fn(),
+  submitBatchPayout: vi.fn(),
+}));
+
+vi.mock("@brandblitz/stellar", () => ({
+  submitBatchPayout: mocks.submitBatchPayout,
+}));
+
+vi.mock("../../lib/config", () => ({
+  config: {
+    HOT_WALLET_SECRET: "test-hot-wallet-secret",
+    STELLAR_NETWORK: "testnet",
+  },
+}));
+
+vi.mock("../../lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../lib/redis", () => ({
+  stellarSequenceStore: {},
+  redis: {},
+}));
+
+vi.mock("../../db/queries/referral-payouts", () => ({
+  findReferralPayoutById: mocks.findReferralPayoutById,
+  updateReferralPayoutStatus: mocks.updateReferralPayoutStatus,
+}));
+
+vi.mock("../../db/queries/sessions", () => ({
+  getSession: mocks.getSession,
+}));
+
+vi.mock("../../services/referrals", () => ({
+  isFraudSession: mocks.isFraudSession,
+  auditReferralBonusSkipped: mocks.auditReferralBonusSkipped,
+}));
+
+vi.mock("../referral-bonus.queue", () => ({
+  referralBonusQueue: { name: "referral-bonus" },
+}));
+
+vi.mock("../dlq", () => ({
+  forwardToDlq: vi.fn(),
+  referralBonusDlqQueue: {},
+}));
+
+import { processReferralBonusJob } from "./referral-bonus.processor";
+
+function buildPayout() {
+  return {
+    id: "payout-1",
+    referral_id: "referral-1",
+    challenge_id: "challenge-1",
+    referrer_id: "referrer-1",
+    referred_id: "referred-1",
+    referrer_stellar_address: "GREFERRER",
+    referred_stellar_address: "GREFERRED",
+    referrer_amount_stroops: "5000000",
+    referred_amount_stroops: "10000000",
+    status: "pending",
+  };
+}
+
+describe("processReferralBonusJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findReferralPayoutById.mockResolvedValue(buildPayout());
+    mocks.getSession.mockResolvedValue({ id: "session-1" });
+    mocks.isFraudSession.mockResolvedValue(false);
+    mocks.submitBatchPayout.mockResolvedValue([{ success: true, txHash: "tx-1" }]);
+  });
+
+  it("cancels the payout when fraud is detected before processing", async () => {
+    mocks.isFraudSession.mockResolvedValue(true);
+
+    await processReferralBonusJob({ data: { referralPayoutId: "payout-1" } } as any);
+
+    expect(mocks.submitBatchPayout).not.toHaveBeenCalled();
+    expect(mocks.updateReferralPayoutStatus).toHaveBeenCalledWith(
+      "payout-1",
+      "failed",
+      undefined,
+      "Referral bonus skipped because session was flagged as fraud"
+    );
+    expect(mocks.auditReferralBonusSkipped).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-1",
+        referrerId: "referrer-1",
+        referredId: "referred-1",
+        referralPayoutId: "payout-1",
+      })
+    );
+  });
+
+  it("processes the referral bonus when no fraud flags exist", async () => {
+    await processReferralBonusJob({ data: { referralPayoutId: "payout-1" } } as any);
+
+    expect(mocks.submitBatchPayout).toHaveBeenCalledWith(
+      [
+        { address: "GREFERRER", amount: "5000000" },
+        { address: "GREFERRED", amount: "10000000" },
+      ],
+      "test-hot-wallet-secret",
+      "referral-payout-1",
+      "testnet",
+      { sequenceStore: {} }
+    );
+    expect(mocks.updateReferralPayoutStatus).toHaveBeenCalledWith("payout-1", "sent", "tx-1");
+  });
+});

--- a/apps/api/src/queues/processors/referral-bonus.processor.ts
+++ b/apps/api/src/queues/processors/referral-bonus.processor.ts
@@ -9,12 +9,17 @@ import {
 } from "../../db/queries/referral-payouts";
 import { referralBonusQueue } from "../referral-bonus.queue";
 import { forwardToDlq, referralBonusDlqQueue } from "../dlq";
+import {
+  auditReferralBonusSkipped,
+  isFraudSession,
+} from "../../services/referrals";
+import { getSession } from "../../db/queries/sessions";
 
 export const referralBonusWorkerOptions = {
   concurrency: 2,
 } as const;
 
-async function processReferralBonusJob(
+export async function processReferralBonusJob(
   job: Job<{ referralPayoutId: string }>,
 ): Promise<void> {
   const payout = await findReferralPayoutById(job.data.referralPayoutId);
@@ -31,6 +36,31 @@ async function processReferralBonusJob(
       status: payout.status,
     });
     return;
+  }
+
+  if (payout.challenge_id) {
+    const session = await getSession(payout.referred_id, payout.challenge_id);
+    if (session && (await isFraudSession(session.id))) {
+      await updateReferralPayoutStatus(
+        payout.id,
+        "failed",
+        undefined,
+        "Referral bonus skipped because session was flagged as fraud",
+      );
+      await auditReferralBonusSkipped({
+        sessionId: session.id,
+        referrerId: payout.referrer_id,
+        referredId: payout.referred_id,
+        referralId: payout.referral_id,
+        referralPayoutId: payout.id,
+        challengeId: payout.challenge_id,
+      });
+      logger.info("Referral bonus skipped for fraud-flagged session", {
+        referralPayoutId: payout.id,
+        sessionId: session.id,
+      });
+      return;
+    }
   }
 
   if (!payout.referrer_stellar_address || !payout.referred_stellar_address) {

--- a/apps/api/src/services/referrals.test.ts
+++ b/apps/api/src/services/referrals.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  findReferralByReferredId: vi.fn(),
+  findUserById: vi.fn(),
+  createReferralPayout: vi.fn(),
+  enqueueReferralBonus: vi.fn(),
+  getSession: vi.fn(),
+  markReferralRewarded: vi.fn(),
+}));
+
+vi.mock("../db", () => ({
+  query: mocks.query,
+}));
+
+vi.mock("../db/queries/referrals", () => ({
+  createReferral: vi.fn(),
+  countReferralConversions: vi.fn(),
+  countReferralInvites: vi.fn(),
+  findReferralByReferrerAndReferred: vi.fn(),
+  findReferralByReferredId: mocks.findReferralByReferredId,
+  markReferralRewarded: mocks.markReferralRewarded,
+}));
+
+vi.mock("../db/queries/users", () => ({
+  findUserById: mocks.findUserById,
+  findUserByReferralCode: vi.fn(),
+  getUserReferralCode: vi.fn(),
+  setUserReferralCode: vi.fn(),
+}));
+
+vi.mock("../db/queries/referral-payouts", () => ({
+  createReferralPayout: mocks.createReferralPayout,
+  getReferralPayoutTotalsForUser: vi.fn(),
+}));
+
+vi.mock("../db/queries/sessions", () => ({
+  getSession: mocks.getSession,
+}));
+
+vi.mock("../queues/referral-bonus.queue", () => ({
+  enqueueReferralBonus: mocks.enqueueReferralBonus,
+}));
+
+vi.mock("../lib/redis", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../middleware/error", () => ({
+  createError: (message: string, statusCode: number) =>
+    Object.assign(new Error(message), { statusCode }),
+}));
+
+import { queueReferralBonusForPayout } from "./referrals";
+
+describe("queueReferralBonusForPayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findReferralByReferredId.mockResolvedValue({
+      id: "referral-1",
+      referrer_id: "referrer-1",
+      referred_id: "referred-1",
+      rewarded: false,
+    });
+    mocks.findUserById.mockImplementation((userId: string) =>
+      Promise.resolve({
+        id: userId,
+        stellar_address: `${userId}-stellar`,
+        embedded_wallet_address: null,
+      })
+    );
+    mocks.getSession.mockResolvedValue({ id: "session-1" });
+    mocks.createReferralPayout.mockResolvedValue({
+      id: "payout-1",
+      status: "pending",
+    });
+  });
+
+  it("skips enqueue and writes audit log when the referred session has fraud flags", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ exists: true }] }).mockResolvedValueOnce({
+      rows: [],
+    });
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 100_000_000n,
+    });
+
+    expect(mocks.createReferralPayout).not.toHaveBeenCalled();
+    expect(mocks.enqueueReferralBonus).not.toHaveBeenCalled();
+    expect(mocks.query).toHaveBeenCalledWith(
+      expect.stringContaining("referral_bonus_skipped"),
+      expect.arrayContaining([
+        "session-1",
+        expect.objectContaining({
+          sessionId: "session-1",
+          referrerId: "referrer-1",
+          referredId: "referred-1",
+          reason: "fraud_flag",
+        }),
+      ])
+    );
+  });
+
+  it("enqueues the referral bonus when the referred session has no fraud flags", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ exists: false }] });
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 100_000_000n,
+    });
+
+    expect(mocks.createReferralPayout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        referralId: "referral-1",
+        referrerId: "referrer-1",
+        referredId: "referred-1",
+      })
+    );
+    expect(mocks.markReferralRewarded).toHaveBeenCalledWith("referral-1");
+    expect(mocks.enqueueReferralBonus).toHaveBeenCalledWith("payout-1");
+  });
+});

--- a/apps/api/src/services/referrals.ts
+++ b/apps/api/src/services/referrals.ts
@@ -22,6 +22,8 @@ import {
   createReferralPayout,
   getReferralPayoutTotalsForUser,
 } from "../db/queries/referral-payouts";
+import { query } from "../db";
+import { getSession } from "../db/queries/sessions";
 import { enqueueReferralBonus } from "../queues/referral-bonus.queue";
 
 const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -183,6 +185,49 @@ export async function getReferralStats(userId: string): Promise<{
   };
 }
 
+export async function isFraudSession(sessionId: string): Promise<boolean> {
+  const result = await query<{ exists: boolean }>(
+    "SELECT EXISTS (SELECT 1 FROM fraud_flags WHERE session_id = $1) AS exists",
+    [sessionId],
+  );
+  return result.rows[0]?.exists === true;
+}
+
+async function findReferralSessionId(
+  referredUserId: string,
+  challengeId?: string | null,
+): Promise<string | null> {
+  if (!challengeId) return null;
+  const session = await getSession(referredUserId, challengeId);
+  return session?.id ?? null;
+}
+
+export async function auditReferralBonusSkipped(params: {
+  sessionId: string;
+  referrerId: string;
+  referredId: string;
+  referralId?: string | null;
+  referralPayoutId?: string | null;
+  challengeId?: string | null;
+}): Promise<void> {
+  await query(
+    `INSERT INTO audit_log (actor_id, action, entity, entity_key, after)
+     VALUES (NULL, 'referral_bonus_skipped', 'game_sessions', $1, $2)`,
+    [
+      params.sessionId,
+      {
+        sessionId: params.sessionId,
+        referrerId: params.referrerId,
+        referredId: params.referredId,
+        referralId: params.referralId ?? null,
+        referralPayoutId: params.referralPayoutId ?? null,
+        challengeId: params.challengeId ?? null,
+        reason: "fraud_flag",
+      },
+    ],
+  );
+}
+
 export async function queueReferralBonusForPayout(params: {
   referredUserId: string;
   challengeId?: string | null;
@@ -190,6 +235,18 @@ export async function queueReferralBonusForPayout(params: {
 }): Promise<void> {
   const referral = await findReferralByReferredId(params.referredUserId);
   if (!referral || referral.rewarded) return;
+
+  const sessionId = await findReferralSessionId(params.referredUserId, params.challengeId);
+  if (sessionId && (await isFraudSession(sessionId))) {
+    await auditReferralBonusSkipped({
+      sessionId,
+      referrerId: referral.referrer_id,
+      referredId: referral.referred_id,
+      referralId: referral.id,
+      challengeId: params.challengeId ?? null,
+    });
+    return;
+  }
 
   const [referrerUser, referredUser] = await Promise.all([
     findUserById(referral.referrer_id),


### PR DESCRIPTION
Closes #319 
## What changed

- Adds `isFraudSession(sessionId)` in the referral service.
- Resolves the referred user session from `(referredUserId, challengeId)` before creating/enqueuing referral bonus payouts.
- Skips referral bonuses when the referred session has any fraud flag.
- Writes `audit_log` records with `action = 'referral_bonus_skipped'` and session/user/referral context.
- Rechecks fraud flags in the referral bonus worker immediately before payout processing and cancels the payout if fraud appeared after enqueue.
- Adds focused service and worker tests for fraud and non-fraud paths.

## Why

Referral bonuses were queued after referred-user completion without checking whether the triggering session had been fraud-flagged. A fraudulent referred session could therefore trigger monetary referral payouts.

## Validation

- `set -a; . ./.env.test; set +a; corepack pnpm exec vitest run --config vitest.config.ts src/services/referrals.test.ts src/queues/processors/referral-bonus.processor.test.ts`
- `corepack pnpm --filter @brandblitz/api type-check` currently fails on unrelated existing syntax errors in `src/db/queries/payouts.ts`, `src/lib/openapi-registry.ts`, `src/routes/sessions.ts`, and `src/services/payout.ts`.
