### PR TITLE
fix: validate deposit memos and escrow balances

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -9,8 +9,14 @@ import { findPayoutByTxHash } from "../db/queries/payouts";
 import { webhookLimiter } from "../middleware/rate-limit";
 import { logger } from "../lib/logger";
 import { config } from "../lib/config";
+import { getAccountUsdcBalance } from "@brandblitz/stellar";
 
 const router = Router();
+
+function usdcToStroops(value: string): bigint {
+  const [whole, fraction = ""] = value.split(".");
+  return BigInt(`${whole}${fraction.padEnd(7, "0").slice(0, 7)}`);
+}
 
 const DepositWebhookSchema = z
   .object({
@@ -53,6 +59,20 @@ router.post("/stellar/deposit", webhookLimiter, async (req, res) => {
 
   if (challenge.status !== "pending_deposit") {
     res.json({ status: "already_processed" });
+    return;
+  }
+
+  const requiredBalance = usdcToStroops(challenge.pool_amount_usdc);
+  const currentBalance = await getAccountUsdcBalance(
+    config.HOT_WALLET_PUBLIC_KEY,
+    config.STELLAR_NETWORK
+  );
+  if (currentBalance < requiredBalance) {
+    res.status(422).json({
+      code: "INSUFFICIENT_ESCROW_BALANCE",
+      currentBalance: currentBalance.toString(),
+      requiredAmount: requiredBalance.toString(),
+    });
     return;
   }
 

--- a/packages/stellar/src/accounts.ts
+++ b/packages/stellar/src/accounts.ts
@@ -95,3 +95,23 @@ export async function accountHasUsdcTrustline(
     return false;
   }
 }
+
+/** Return an account's USDC trustline balance in Stellar stroops (7 decimals). */
+export async function getAccountUsdcBalance(
+  publicKey: string,
+  network: NetworkName = "testnet"
+): Promise<bigint> {
+  const horizon = getHorizonServer(network);
+  const usdc = getUsdcAsset(network);
+  const account = await horizon.loadAccount(publicKey);
+  const balance = account.balances.find(
+    (item) =>
+      item.asset_type === "credit_alphanum4" &&
+      (item as any).asset_code === "USDC" &&
+      (item as any).asset_issuer === usdc.getIssuer()
+  ) as { balance?: string } | undefined;
+
+  if (!balance?.balance) return 0n;
+  const [whole, fraction = ""] = balance.balance.split(".");
+  return BigInt(`${whole}${fraction.padEnd(7, "0").slice(0, 7)}`);
+}

--- a/packages/stellar/src/deposit.ts
+++ b/packages/stellar/src/deposit.ts
@@ -11,6 +11,19 @@ export interface DepositEvent {
   createdAt: string;
 }
 
+export type DepositMemoValidation =
+  | { valid: true; memo: string }
+  | { valid: false; reason: "missing" | "invalid_format" };
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function validateDepositMemo(memo: string | null): DepositMemoValidation {
+  if (!memo?.trim()) return { valid: false, reason: "missing" };
+  if (!UUID_V4_PATTERN.test(memo)) return { valid: false, reason: "invalid_format" };
+  return { valid: true, memo };
+}
+
 /**
  * Poll Stellar RPC getEvents for USDC transfers to the hot wallet.
  * Returns a list of deposit events since the given cursor ledger.
@@ -57,13 +70,23 @@ export async function fetchDepositEvents(
         continue;
       }
 
-      const memo = (txMeta as any).memo?.text ?? "";
+      const memo = (txMeta as any).memo?.text ?? null;
+      const memoValidation = validateDepositMemo(memo);
+      if (!memoValidation.valid) {
+        console.warn("Rejecting deposit with invalid memo", {
+          reason: memoValidation.reason,
+          memo: memo?.slice(0, 28) ?? null,
+          txHash: event.txHash,
+          senderAccount: (event as any).from ?? null,
+        });
+        continue;
+      }
       const amount = event.value?.toString() ?? "0";
 
       events.push({
         txHash: event.txHash,
         amount,
-        memo,
+        memo: memoValidation.memo,
         to: hotWalletAddress,
         ledger: event.ledger,
         createdAt: new Date(event.ledgerClosedAt).toISOString(),

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./client";
 export * from "./constants";
 export * from "./deposit";
+export * from "./accounts";
 export * from "./payout";
 export * from "./accounts";
 export * from "./sequence";


### PR DESCRIPTION
## Summary

- Validate Stellar deposit memos as UUID v4 values before processing deposit events.
- Reject and log malformed or missing memos with transaction context.
- Add a USDC balance lookup for Stellar accounts.
- Block challenge activation when the hot-wallet escrow balance cannot cover the prize pool.

Closes #560  
Closes #558  
Closes #562, 
Closes #563
