### PR TITLE
feat: Add database pool metrics, ISR, streaming SSR, and cache coalescing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,14 @@ SESSION_INTEGRITY_KEY=replace-with-at-least-32-random-chars-openssl-rand-hex-32
 # If set, the API grants admin role to this email on boot (logs loudly)
 # ADMIN_BOOTSTRAP_EMAIL=admin@example.com
 
+# === Next.js Revalidation ===
+# Shared secret for on-demand ISR revalidation. Used by the API to trigger
+# Next.js cache invalidation when scores are committed.
+# Generate with: openssl rand -hex 32
+# REVALIDATE_SECRET=replace-with-at-least-16-random-chars
+# URL of the Next.js web app (used for revalidation API calls)
+# NEXT_REVALIDATE_URL=http://localhost:3000
+
 # === Logging ===
 # error, warn, info, http, verbose, debug, silly
 LOG_LEVEL=info

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,6 +43,7 @@
     "jsonwebtoken": "9.0.3",
     "multer": "2.1.1",
     "pg": "8.20.0",
+    "prom-client": "15.1.3",
     "rate-limit-redis": "^4.3.1",
     "sharp": "0.34.5",
     "twilio": "5.13.1",

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -1,7 +1,13 @@
 import { Pool, type QueryResult, type QueryResultRow } from "pg";
 import { logger } from "../lib/logger";
 import { config } from "../lib/config";
-import { metrics } from "../lib/metrics";
+import {
+  metrics,
+  dbPoolTotalConnections,
+  dbPoolIdleConnections,
+  dbPoolWaitingClients,
+  dbPoolMaxConnections,
+} from "../lib/metrics";
 
 const pool = new Pool({
   connectionString: config.DATABASE_URL,
@@ -38,6 +44,17 @@ export async function connectDb(): Promise<void> {
 
 export async function closeDb(): Promise<void> {
   await pool.end();
+}
+
+/**
+ * Update Prometheus gauges with current PostgreSQL connection pool stats.
+ * Called at scrape time by the /metrics endpoint.
+ */
+export function updatePoolMetrics(): void {
+  dbPoolTotalConnections.set(pool.totalCount);
+  dbPoolIdleConnections.set(pool.idleCount);
+  dbPoolWaitingClients.set(pool.waitingCount);
+  dbPoolMaxConnections.set(config.DB_POOL_MAX);
 }
 
 export { pool };

--- a/apps/api/src/lib/cache.ts
+++ b/apps/api/src/lib/cache.ts
@@ -54,3 +54,86 @@ export async function cached<T>(
   await redis.set(key, JSON.stringify(value), "EX", ttlSec);
   return value;
 }
+
+/**
+ * Request coalescing cache wrapper to prevent thundering herd on cold start.
+ *
+ * Uses a Redis lock (SETNX) to ensure only one request regenerates the cache
+ * value when a key expires. Other concurrent requests wait briefly and reuse
+ * the result. If the lock holder crashes, the lock expires after lockTtlSec
+ * and subsequent requests regenerate the value.
+ *
+ * @param key - Redis cache key
+ * @param ttlSec - Cache TTL in seconds
+ * @param loader - Async function that regenerates the cache value
+ * @param lockTtlSec - Lock expiry in seconds (default: 5)
+ * @returns Cached or freshly loaded value
+ */
+export async function withCoalescing<T>(
+  key: string,
+  ttlSec: number,
+  loader: () => Promise<T>,
+  lockTtlSec: number = 5,
+): Promise<T> {
+  // Check cache first
+  const hit = await redis.get(key);
+  if (hit !== null) {
+    metrics.inc("cache.hit_total", { key });
+    return JSON.parse(hit) as T;
+  }
+
+  metrics.inc("cache.miss_total", { key });
+
+  const lockKey = `coalesce:${key}`;
+
+  // Try to acquire the lock
+  const acquired = await redis.set(lockKey, "1", "EX", lockTtlSec, "NX");
+
+  if (acquired === "OK") {
+    // This request won the race — regenerate the value
+    try {
+      const value = await loader();
+      await redis.set(key, JSON.stringify(value), "EX", ttlSec);
+      return value;
+    } finally {
+      // Release the lock
+      await redis.del(lockKey);
+    }
+  }
+
+  // Another request holds the lock — wait for it to populate the cache
+  const waitStart = Date.now();
+  const waitDeadline = waitStart + (lockTtlSec * 1000);
+
+  while (Date.now() < waitDeadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+    const cached = await redis.get(key);
+    if (cached !== null) {
+      metrics.inc("cache.coalesced_total", { key });
+      return JSON.parse(cached) as T;
+    }
+
+    // Check if lock expired (holder crashed)
+    const lockExists = await redis.exists(lockKey);
+    if (lockExists === 0) {
+      // Lock expired — try to acquire and regenerate
+      const retryAcquired = await redis.set(lockKey, "1", "EX", lockTtlSec, "NX");
+      if (retryAcquired === "OK") {
+        try {
+          const value = await loader();
+          await redis.set(key, JSON.stringify(value), "EX", ttlSec);
+          return value;
+        } finally {
+          await redis.del(lockKey);
+        }
+      }
+    }
+  }
+
+  // Timeout — fall through and regenerate without lock
+  metrics.inc("cache.coalesce_timeout_total", { key });
+  const value = await loader();
+  await redis.set(key, JSON.stringify(value), "EX", ttlSec);
+  return value;
+}

--- a/apps/api/src/lib/config-schema.ts
+++ b/apps/api/src/lib/config-schema.ts
@@ -94,6 +94,9 @@ export const configSchema = z.object({
 
   // Admin bootstrap — if set, this email is granted admin role on API boot
   ADMIN_BOOTSTRAP_EMAIL: z.string().email().optional(),
-});
 
+  // Next.js revalidation — secret for on-demand ISR revalidation
+  REVALIDATE_SECRET: z.string().min(16).optional(),
+  NEXT_REVALIDATE_URL: z.string().url().optional(),
+});
 export type Config = z.infer<typeof configSchema>;

--- a/apps/api/src/lib/metrics.ts
+++ b/apps/api/src/lib/metrics.ts
@@ -1,4 +1,35 @@
 import { logger } from "./logger";
+import { Registry, Gauge, collectDefaultMetrics } from "prom-client";
+
+export const registry = new Registry();
+
+// Collect default Node.js metrics (CPU, memory, event loop, etc.)
+collectDefaultMetrics({ register: registry });
+
+// Database connection pool metrics
+export const dbPoolTotalConnections = new Gauge({
+  name: "db_pool_total_connections",
+  help: "Current number of connections in the PostgreSQL pool (both idle and active)",
+  registers: [registry],
+});
+
+export const dbPoolIdleConnections = new Gauge({
+  name: "db_pool_idle_connections",
+  help: "Number of idle connections waiting to be reused in the PostgreSQL pool",
+  registers: [registry],
+});
+
+export const dbPoolWaitingClients = new Gauge({
+  name: "db_pool_waiting_clients",
+  help: "Number of clients currently waiting for a connection from the pool",
+  registers: [registry],
+});
+
+export const dbPoolMaxConnections = new Gauge({
+  name: "db_pool_max_connections",
+  help: "Maximum number of connections allowed in the PostgreSQL pool (configured via DB_POOL_MAX)",
+  registers: [registry],
+});
 
 export const metrics = {
   inc(name: string, labels?: Record<string, unknown>): void {

--- a/apps/api/src/lib/revalidate.ts
+++ b/apps/api/src/lib/revalidate.ts
@@ -1,0 +1,40 @@
+import { config } from "./config";
+import { logger } from "./logger";
+
+/**
+ * Trigger on-demand Next.js ISR revalidation for the leaderboard page.
+ * Called after score commits to ensure high-impact updates propagate quickly.
+ */
+export async function revalidateLeaderboard(): Promise<void> {
+  if (!config.NEXT_REVALIDATE_URL || !config.REVALIDATE_SECRET) {
+    logger.debug("Skipping revalidation: NEXT_REVALIDATE_URL or REVALIDATE_SECRET not configured");
+    return;
+  }
+
+  try {
+    const response = await fetch(`${config.NEXT_REVALIDATE_URL}/api/revalidate/leaderboard`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        secret: config.REVALIDATE_SECRET,
+      }),
+    });
+
+    if (!response.ok) {
+      logger.warn("Leaderboard revalidation failed", {
+        status: response.status,
+        statusText: response.statusText,
+      });
+      return;
+    }
+
+    const data = await response.json();
+    logger.info("Leaderboard revalidated", { data });
+  } catch (error) {
+    logger.error("Failed to trigger leaderboard revalidation", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/apps/api/src/routes/challenges.ts
+++ b/apps/api/src/routes/challenges.ts
@@ -10,7 +10,7 @@ import { getBrandById } from "../db/queries/brands";
 import { getLeaderboard, getArchivedLeaderboard } from "../db/queries/sessions";
 import { optionalAuth, authenticate } from "../middleware/authenticate";
 import { createError } from "../middleware/error";
-import { cached } from "../lib/cache";
+import { withCoalescing } from "../lib/cache";
 import { config } from "../lib/config";
 
 const router = Router();
@@ -44,7 +44,7 @@ router.get("/", optionalAuth, async (req, res) => {
     return;
   }
 
-  const challenges = await cached(
+  const challenges = await withCoalescing(
     `challenges:active:${limit}:${offset}`,
     60,
     () => getActiveChallenges(limit, offset)

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -17,12 +17,14 @@ import deleteAccountRoutes from "./me/delete-account";
 import docsRoutes from "./docs";
 import cspReportRoutes from "./csp-report";
 import legalRoutes from "./legal";
+import metricsRoutes from "./metrics";
 
 export function registerRoutes(app: Express): void {
   // #143 — interactive OpenAPI 3.1 docs at /docs (Scalar UI) plus
   // the JSON spec at /docs/openapi.json. Mounted first so it can't
   // be accidentally shadowed by a route added below.
   app.use("/docs", docsRoutes);
+  app.use("/metrics", metricsRoutes);
   app.use("/csp-report", cspReportRoutes);
   app.use("/legal", legalRoutes);
   app.use("/auth", authRoutes);

--- a/apps/api/src/routes/leaderboard.ts
+++ b/apps/api/src/routes/leaderboard.ts
@@ -6,7 +6,7 @@ import {
   getTopSessionsPerChallenge,
   getGlobalLeaderboardFromView,
 } from "../db/queries/sessions";
-import { cached } from "../lib/cache";
+import { withCoalescing } from "../lib/cache";
 
 const router = Router();
 
@@ -107,7 +107,7 @@ router.get("/global", async (req, res) => {
     offset: z.coerce.number().min(0).default(0),
   }).parse(req.query);
 
-  const response = await cached(`leaderboard:global:${limit}:${offset}`, 300, async () => {
+  const response = await withCoalescing(`leaderboard:global:${limit}:${offset}`, 300, async () => {
     const challenges = await getActiveChallenges(10);
     const challengeIds = challenges.map((c) => c.id);
 

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -1,0 +1,20 @@
+import { Router } from "express";
+import { registry } from "../lib/metrics";
+import { updatePoolMetrics } from "../db";
+
+const router = Router();
+
+/**
+ * GET /metrics
+ * Prometheus scraping endpoint — exposes application and database pool metrics.
+ */
+router.get("/", async (_req, res) => {
+  // Sample pool stats at scrape time to reflect current state
+  updatePoolMetrics();
+
+  res.setHeader("Content-Type", registry.contentType);
+  const metrics = await registry.metrics();
+  res.send(metrics);
+});
+
+export default router;

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -26,6 +26,7 @@ import { updateStreak } from "../services/streaks";
 import { checkAndAwardSessionBadges } from "../services/badges";
 import { WARMUP_MIN_SECONDS } from "@brandblitz/stellar";
 import { tokenRevocationKey, tokenTtlSeconds } from "../middleware/authenticate";
+import { revalidateLeaderboard } from "../lib/revalidate";
 
 const router = Router();
 
@@ -229,6 +230,9 @@ router.post(
           total_score: completed.total_score,
           is_practice: completed.is_practice,
         });
+
+        // Trigger on-demand revalidation for leaderboard page
+        void revalidateLeaderboard();
       }
     }
   }

--- a/apps/web/src/app/api/revalidate/leaderboard/route.ts
+++ b/apps/web/src/app/api/revalidate/leaderboard/route.ts
@@ -1,0 +1,45 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+/**
+ * POST /api/revalidate/leaderboard
+ * On-demand ISR revalidation for the leaderboard page.
+ * Triggered by the API when new scores are committed.
+ *
+ * Requires REVALIDATE_SECRET in request body for security.
+ */
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { secret } = body;
+
+    const expectedSecret = process.env.REVALIDATE_SECRET;
+
+    if (!expectedSecret) {
+      return NextResponse.json(
+        { error: "Server misconfigured: REVALIDATE_SECRET not set" },
+        { status: 500 }
+      );
+    }
+
+    if (!secret || secret !== expectedSecret) {
+      return NextResponse.json(
+        { error: "Unauthorized: invalid or missing secret" },
+        { status: 401 }
+      );
+    }
+
+    revalidatePath("/leaderboard");
+
+    return NextResponse.json({
+      revalidated: true,
+      path: "/leaderboard",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+}

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -6,6 +6,8 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import type { Metadata } from "next";
+import { Suspense } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export const metadata: Metadata = {
   title: "Global Leaderboard",
@@ -15,6 +17,9 @@ export const metadata: Metadata = {
     description: "See the top performers across all BrandBlitz challenges and their USDC earnings.",
   },
 };
+
+// Enable ISR with 30-second revalidation
+export const revalidate = 30;
 
 async function getGlobalLeaderboard(): Promise<{
   entries: LeaderboardEntry[];
@@ -37,9 +42,50 @@ async function getGlobalLeaderboard(): Promise<{
   }
 }
 
-export default async function LeaderboardPage() {
+function LeaderboardSkeleton() {
+  return (
+    <div className="border-b border-[var(--border)] last:border-0 px-6 py-4 space-y-4">
+      {Array.from({ length: 6 }).map((_, idx) => (
+        <div
+          key={idx}
+          className="grid grid-cols-[80px_1fr_120px_120px] gap-4 items-center"
+        >
+          <Skeleton className="h-5 w-10" />
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-8 w-8 rounded-full" />
+            <Skeleton className="h-4 w-36" />
+          </div>
+          <Skeleton className="h-4 w-20 ml-auto" />
+          <Skeleton className="h-4 w-16 ml-auto" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+async function LeaderboardContent() {
   const { entries, hasMore, failed } = await getGlobalLeaderboard();
 
+  if (failed) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          title="Couldn't load leaderboard"
+          description="We couldn't load the rankings right now. Please try again."
+          action={
+            <Link href="/leaderboard">
+              <Button variant="outline">Try Again</Button>
+            </Link>
+          }
+        />
+      </div>
+    );
+  }
+
+  return <LiveGlobalLeaderboard initial={entries} initialHasMore={hasMore} />;
+}
+
+export default function LeaderboardPage() {
   return (
     <main className="mx-auto max-w-3xl px-6 py-12">
       <h1 className="mb-2 text-3xl font-bold">Global Leaderboard</h1>
@@ -50,21 +96,9 @@ export default async function LeaderboardPage() {
           <CardTitle>All-Time Rankings</CardTitle>
         </CardHeader>
         <CardContent className="p-0">
-          {failed ? (
-            <div className="p-6">
-              <EmptyState
-                title="Couldn't load leaderboard"
-                description="We couldn't load the rankings right now. Please try again."
-                action={
-                  <Link href="/leaderboard">
-                    <Button variant="outline">Try Again</Button>
-                  </Link>
-                }
-              />
-            </div>
-          ) : (
-            <LiveGlobalLeaderboard initial={entries} initialHasMore={hasMore} />
-          )}
+          <Suspense fallback={<LeaderboardSkeleton />}>
+            <LeaderboardContent />
+          </Suspense>
         </CardContent>
       </Card>
     </main>


### PR DESCRIPTION


This PR implements performance and observability improvements across the API and web application.


### Changes

**Database Pool Metrics**
Added PostgreSQL connection pool monitoring to the `/metrics` Prometheus endpoint. Operators can now track pool saturation and set alerts before exhaustion causes request queuing. Metrics include total connections, idle connections, waiting clients, and max pool size.

**Streaming SSR for Leaderboard**
Refactored the leaderboard page to use React Suspense, streaming the shell immediately while score data loads asynchronously. This reduces Time to First Byte and improves perceived performance under load. The skeleton fallback matches final layout dimensions to prevent cumulative layout shift.

**ISR with On-Demand Revalidation**
Enabled Incremental Static Regeneration for the leaderboard page with a 30-second revalidation window. Added a secure revalidation endpoint that the API triggers after score commits, ensuring high-impact updates propagate within seconds rather than waiting for the full revalidation cycle.

**Request Coalescing in Redis Cache**
Implemented a coalescing layer using Redis SETNX locks to prevent thundering herd on cache expiry. When a cached key expires, only one request regenerates the value while others wait and reuse the result. The lock expires after 5 seconds if the holder crashes, allowing recovery without manual intervention. Applied to leaderboard and challenges endpoints.

### Technical Details

- Added `prom-client` dependency for Prometheus metrics collection
- Created `withCoalescing` cache utility with configurable lock TTL
- Integrated revalidation webhook with shared secret authentication
- Pool metrics sampled at scrape time to reflect current state
- All changes maintain backward compatibility

### Configuration

Two new optional environment variables for ISR revalidation:
- `REVALIDATE_SECRET` - Shared secret for webhook authentication (min 16 chars)
- `NEXT_REVALIDATE_URL` - Web app URL for revalidation API calls

See `.env.example` for details.



Closes #548
Closes #550
Closes #546
Closes #551
