### PR TITLE
Feat/game sessions

### DIFF
--- a/apps/api/src/db/queries/analytics.test.ts
+++ b/apps/api/src/db/queries/analytics.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the query function
+const mockQuery = vi.fn();
+vi.mock("../../db/index", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+// Import after mocking
+import { getBrandAnalytics } from "./analytics";
+
+describe("getBrandAnalytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns zero stats when brand has no challenges", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // No challenges
+
+    const result = await getBrandAnalytics("brand-1");
+
+    expect(result).toEqual({
+      totalSessions: 0,
+      completedSessions: 0,
+      completionRate: 0,
+      questionAccuracy: [],
+      costPerSession: [],
+    });
+  });
+
+  it("calculates completion rate correctly", async () => {
+    // Mock challenge IDs
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "ch1" }, { id: "ch2" }],
+    });
+
+    // Mock session stats
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total_sessions: 100, completed_sessions: 75 }],
+    });
+
+    // Mock question accuracy
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    // Mock cost per session
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await getBrandAnalytics("brand-1");
+
+    expect(result.totalSessions).toBe(100);
+    expect(result.completedSessions).toBe(75);
+    expect(result.completionRate).toBe(75);
+  });
+
+  it("handles date range parameters", async () => {
+    const from = new Date("2024-01-01");
+    const to = new Date("2024-01-31");
+
+    // Mock challenge IDs with date filters
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "ch1" }],
+    });
+
+    // Mock session stats
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total_sessions: 50, completed_sessions: 40 }],
+    });
+
+    // Mock question accuracy
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    // Mock cost per session
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await getBrandAnalytics("brand-1", from, to);
+
+    expect(result.totalSessions).toBe(50);
+    expect(result.completedSessions).toBe(40);
+    expect(result.completionRate).toBe(80);
+
+    // Verify the first query includes date parameters
+    const firstQuery = mockQuery.mock.calls[0];
+    expect(firstQuery[1]).toContain(from.toISOString());
+    expect(firstQuery[1]).toContain(to.toISOString());
+  });
+
+  it("returns question accuracy data", async () => {
+    // Mock challenge IDs
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "ch1" }],
+    });
+
+    // Mock session stats
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total_sessions: 30, completed_sessions: 25 }],
+    });
+
+    // Mock question accuracy
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          round: 1,
+          question_type: "which_brand",
+          question_text: "Which brand uses this logo?",
+          total_attempts: 25,
+          correct_attempts: 20,
+        },
+      ],
+    });
+
+    // Mock cost per session
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await getBrandAnalytics("brand-1");
+
+    expect(result.questionAccuracy).toHaveLength(1);
+    expect(result.questionAccuracy[0].accuracy).toBe(80);
+    expect(result.questionAccuracy[0].totalAttempts).toBe(25);
+    expect(result.questionAccuracy[0].correctAttempts).toBe(20);
+  });
+
+  it("returns cost per session time series", async () => {
+    // Mock challenge IDs
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "ch1" }],
+    });
+
+    // Mock session stats
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ total_sessions: 20, completed_sessions: 18 }],
+    });
+
+    // Mock question accuracy
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    // Mock cost per session
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { date: "2024-01-15", total_cost: 10.5, session_count: 10 },
+        { date: "2024-01-16", total_cost: 8.4, session_count: 8 },
+      ],
+    });
+
+    const result = await getBrandAnalytics("brand-1");
+
+    expect(result.costPerSession).toHaveLength(2);
+    expect(result.costPerSession[0].costPerSession).toBe(1.05);
+    expect(result.costPerSession[1].costPerSession).toBe(1.05);
+  });
+
+  it("returns empty results when no date range matches", async () => {
+    // Mock empty challenge IDs (no challenges in date range)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const from = new Date("2020-01-01");
+    const to = new Date("2020-01-31");
+
+    const result = await getBrandAnalytics("brand-1", from, to);
+
+    expect(result).toEqual({
+      totalSessions: 0,
+      completedSessions: 0,
+      completionRate: 0,
+      questionAccuracy: [],
+      costPerSession: [],
+    });
+  });
+});

--- a/apps/api/src/db/queries/analytics.ts
+++ b/apps/api/src/db/queries/analytics.ts
@@ -1,0 +1,176 @@
+import { query } from "../index";
+
+export interface BrandAnalytics {
+  totalSessions: number;
+  completedSessions: number;
+  completionRate: number;
+  questionAccuracy: Array<{
+    round: number;
+    questionType: string;
+    questionText: string;
+    totalAttempts: number;
+    correctAttempts: number;
+    accuracy: number;
+  }>;
+  costPerSession: Array<{
+    date: string;
+    totalCost: number;
+    sessionCount: number;
+    costPerSession: number;
+  }>;
+}
+
+export async function getBrandAnalytics(
+  brandId: string,
+  from?: Date,
+  to?: Date
+): Promise<BrandAnalytics> {
+  const challengeIds = await getChallengeIdsForBrand(brandId, from, to);
+
+  if (challengeIds.length === 0) {
+    return {
+      totalSessions: 0,
+      completedSessions: 0,
+      completionRate: 0,
+      questionAccuracy: [],
+      costPerSession: [],
+    };
+  }
+
+  const [sessionStats, questionAccuracy, costData] = await Promise.all([
+    getSessionStats(challengeIds),
+    getQuestionAccuracy(challengeIds),
+    getCostPerSession(challengeIds, from, to),
+  ]);
+
+  return {
+    totalSessions: sessionStats.totalSessions,
+    completedSessions: sessionStats.completedSessions,
+    completionRate: sessionStats.totalSessions > 0
+      ? Math.round((sessionStats.completedSessions / sessionStats.totalSessions) * 100)
+      : 0,
+    questionAccuracy,
+    costPerSession: costData,
+  };
+}
+
+async function getChallengeIdsForBrand(
+  brandId: string,
+  from?: Date,
+  to?: Date
+): Promise<string[]> {
+  let sql = `SELECT id FROM challenges WHERE brand_id = $1 AND deleted_at IS NULL`;
+  const params: unknown[] = [brandId];
+
+  if (from) {
+    params.push(from.toISOString());
+    sql += ` AND created_at >= $${params.length}`;
+  }
+  if (to) {
+    params.push(to.toISOString());
+    sql += ` AND created_at <= $${params.length}`;
+  }
+
+  const result = await query<{ id: string }>(sql, params);
+  return result.rows.map((r) => r.id);
+}
+
+async function getSessionStats(
+  challengeIds: string[]
+): Promise<{ totalSessions: number; completedSessions: number }> {
+  const result = await query<{ total_sessions: number; completed_sessions: number }>(
+    `SELECT
+       COUNT(*)::int AS total_sessions,
+       COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_sessions
+     FROM game_sessions
+     WHERE challenge_id = ANY($1::uuid[])`,
+    [challengeIds]
+  );
+
+  const row = result.rows[0];
+  return {
+    totalSessions: row?.total_sessions ?? 0,
+    completedSessions: row?.completed_sessions ?? 0,
+  };
+}
+
+async function getQuestionAccuracy(
+  challengeIds: string[]
+): Promise<BrandAnalytics["questionAccuracy"]> {
+  if (challengeIds.length === 0) return [];
+
+  const result = await query<{
+    round: number;
+    question_type: string;
+    question_text: string;
+    total_attempts: number;
+    correct_attempts: number;
+  }>(
+    `SELECT
+       cq.round,
+       cq.question_type,
+       cq.question_text,
+       COUNT(srs.id)::int AS total_attempts,
+       COUNT(srs.id) FILTER (WHERE srs.score > 0)::int AS correct_attempts
+     FROM challenge_questions cq
+     LEFT JOIN session_round_scores srs
+       ON srs.round = cq.round
+       AND srs.session_id IN (
+         SELECT id FROM game_sessions
+         WHERE challenge_id = ANY($1::uuid[])
+           AND status = 'completed'
+       )
+     WHERE cq.challenge_id = ANY($1::uuid[])
+     GROUP BY cq.round, cq.question_type, cq.question_text
+     ORDER BY cq.round`,
+    [challengeIds]
+  );
+
+  return result.rows.map((row) => ({
+    round: row.round,
+    questionType: row.question_type,
+    questionText: row.question_text,
+    totalAttempts: row.total_attempts,
+    correctAttempts: row.correct_attempts,
+    accuracy: row.total_attempts > 0
+      ? Math.round((row.correct_attempts / row.total_attempts) * 100)
+      : 0,
+  }));
+}
+
+async function getCostPerSession(
+  challengeIds: string[],
+  from?: Date,
+  to?: Date
+): Promise<BrandAnalytics["costPerSession"]> {
+  const fromDate = from ?? new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const toDate = to ?? new Date();
+
+  const result = await query<{
+    date: string;
+    total_cost: number;
+    session_count: number;
+  }>(
+    `SELECT
+       DATE(gs.created_at) AS date,
+       SUM(c.pool_amount_stroops::numeric / 10000000)::numeric(20,7)::float AS total_cost,
+       COUNT(gs.id)::int AS session_count
+     FROM game_sessions gs
+     JOIN challenges c ON c.id = gs.challenge_id
+     WHERE gs.challenge_id = ANY($1::uuid[])
+       AND gs.created_at >= $2
+       AND gs.created_at <= $3
+     GROUP BY DATE(gs.created_at)
+     ORDER BY date`,
+    [challengeIds, fromDate.toISOString(), toDate.toISOString()]
+  );
+
+  return result.rows.map((row) => ({
+    date: row.date,
+    totalCost: Number(row.total_cost),
+    sessionCount: row.session_count,
+    costPerSession: row.session_count > 0
+      ? Number(row.total_cost) / row.session_count
+      : 0,
+  }));
+}

--- a/apps/api/src/middleware/anti-cheat.test.ts
+++ b/apps/api/src/middleware/anti-cheat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { validateReactionTime, validateDeviceFingerprint, enforceOneSessionPerChallenge, BOT_REACTION_THRESHOLD_MS, MIN_HUMAN_REACTION_MS } from "./anti-cheat";
+import { validateReactionTime, validateDeviceFingerprint, enforceOneSessionPerChallenge, BOT_REACTION_THRESHOLD_MS, MIN_HUMAN_REACTION_MS, validateRoundScore, assertValidTotalScore } from "./anti-cheat";
 import * as fraudQueries from "../db/queries/fraud-flags";
 import { metrics } from "../lib/metrics";
 import * as sessionQueries from "../db/queries/sessions";
@@ -203,6 +203,74 @@ describe("anti-cheat middleware", () => {
         statusCode: 404,
       });
       expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("validateRoundScore", () => {
+    it("calls next when roundScore is not in body", async () => {
+      req.body = {};
+      await validateRoundScore(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("calls next for valid roundScore = 0", async () => {
+      req.body.roundScore = 0;
+      await validateRoundScore(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("calls next for valid roundScore = 150", async () => {
+      req.body.roundScore = 150;
+      await validateRoundScore(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("rejects with 422 when roundScore = 151", async () => {
+      req.body.roundScore = 151;
+      await expect(validateRoundScore(req, res, next)).rejects.toMatchObject({
+        statusCode: 422,
+        code: "ROUND_SCORE_OUT_OF_RANGE",
+      });
+      expect(fraudQueries.createFraudFlag).toHaveBeenCalled();
+    });
+
+    it("rejects with 422 when roundScore = -1", async () => {
+      req.body.roundScore = -1;
+      await expect(validateRoundScore(req, res, next)).rejects.toMatchObject({
+        statusCode: 422,
+        code: "ROUND_SCORE_OUT_OF_RANGE",
+      });
+      expect(fraudQueries.createFraudFlag).toHaveBeenCalled();
+    });
+  });
+
+  describe("assertValidTotalScore", () => {
+    it("does not throw for score = 0", () => {
+      expect(() => assertValidTotalScore(0)).not.toThrow();
+    });
+
+    it("does not throw for score = 450", () => {
+      expect(() => assertValidTotalScore(450)).not.toThrow();
+    });
+
+    it("throws 422 for score = 451", () => {
+      expect(() => assertValidTotalScore(451)).toThrow();
+      try {
+        assertValidTotalScore(451);
+      } catch (err: any) {
+        expect(err.statusCode).toBe(422);
+        expect(err.code).toBe("TOTAL_SCORE_OUT_OF_RANGE");
+      }
+    });
+
+    it("throws 422 for score = -1", () => {
+      expect(() => assertValidTotalScore(-1)).toThrow();
+      try {
+        assertValidTotalScore(-1);
+      } catch (err: any) {
+        expect(err.statusCode).toBe(422);
+        expect(err.code).toBe("TOTAL_SCORE_OUT_OF_RANGE");
+      }
     });
   });
 });

--- a/apps/api/src/middleware/anti-cheat.ts
+++ b/apps/api/src/middleware/anti-cheat.ts
@@ -8,6 +8,7 @@ import { metrics } from "../lib/metrics";
 import { computeFingerprint } from "../lib/fingerprint";
 import { createError } from "./error";
 import { normalizeClientIp } from "./rate-limit";
+import { MAX_ROUND_SCORE, MAX_TOTAL_SCORE } from "../services/scoring";
 
 export const BOT_REACTION_THRESHOLD_MS = 80;
 // Fallback defaults — override at runtime via PATCH /admin/config/anti_cheat.thresholds
@@ -221,4 +222,52 @@ export async function validateDeviceFingerprint(
   }
 
   next();
+}
+
+/**
+ * Anti-cheat Layer 4 — score bounds validation.
+ * Flags sessions where a round score exceeds the per-round maximum.
+ * Called after server-side score computation, before persisting.
+ */
+export async function validateRoundScore(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): Promise<void> {
+  const { roundScore } = req.body as { roundScore?: number };
+
+  if (roundScore === undefined) {
+    next();
+    return;
+  }
+
+  if (!Number.isFinite(roundScore) || roundScore < 0 || roundScore > MAX_ROUND_SCORE) {
+    await recordFraudFlag(req, "round_score_out_of_range", {
+      roundScore,
+      maxAllowed: MAX_ROUND_SCORE,
+      severity: "critical",
+    }).catch(() => {});
+    throw createError(
+      `Round score ${roundScore} exceeds per-round maximum of ${MAX_ROUND_SCORE}`,
+      422,
+      "ROUND_SCORE_OUT_OF_RANGE"
+    );
+  }
+
+  next();
+}
+
+/**
+ * Validate that a total session score is within bounds.
+ * Returns a structured error if the value would exceed [0, MAX_TOTAL_SCORE].
+ * Intended for use after score computation and before persistence.
+ */
+export function assertValidTotalScore(totalScore: number): void {
+  if (!Number.isFinite(totalScore) || totalScore < 0 || totalScore > MAX_TOTAL_SCORE) {
+    throw createError(
+      `Total score ${totalScore} is outside valid range [0, ${MAX_TOTAL_SCORE}]`,
+      422,
+      "TOTAL_SCORE_OUT_OF_RANGE"
+    );
+  }
 }

--- a/apps/api/src/routes/brands.ts
+++ b/apps/api/src/routes/brands.ts
@@ -11,6 +11,7 @@ import {
   updateBrand,
   deleteBrand,
 } from "../db/queries/brands";
+import { getBrandAnalytics } from "../db/queries/analytics";
 import {
   createChallenge,
   insertChallengeQuestions,
@@ -86,6 +87,34 @@ router.get("/:id", authenticate, async (req, res) => {
   if (!brand) throw createError("Brand not found", 404);
   if (brand.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
   res.json({ brand: toBrandApi(brand) });
+});
+
+/**
+ * GET /brands/:id/analytics
+ * Returns aggregated analytics data for the brand's challenges.
+ */
+router.get("/:id/analytics", authenticate, async (req, res) => {
+  const brand = await getBrandById(req.params.id);
+  if (!brand) throw createError("Brand not found", 404);
+  if (brand.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
+
+  const fromParam = req.query.from as string | undefined;
+  const toParam = req.query.to as string | undefined;
+
+  let from: Date | undefined;
+  let to: Date | undefined;
+
+  if (fromParam) {
+    from = new Date(fromParam);
+    if (isNaN(from.getTime())) throw createError("Invalid from date", 400);
+  }
+  if (toParam) {
+    to = new Date(toParam);
+    if (isNaN(to.getTime())) throw createError("Invalid to date", 400);
+  }
+
+  const analytics = await getBrandAnalytics(brand.id, from, to);
+  res.json({ analytics });
 });
 
 /**

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -9,13 +9,14 @@ import {
   finishSession,
   storeSessionHmac,
 } from "../db/queries/sessions";
-import { calculateRoundScore, completeWarmupWithLock, validateAnswer } from "../services/scoring";
+import { calculateRoundScore, completeWarmupWithLock, validateAnswer, validateRoundScore } from "../services/scoring";
 import { authenticate } from "../middleware/authenticate";
 import { requireActiveUser } from "../middleware/require-active-user";
 import {
   enforceOneSessionPerChallenge,
   validateReactionTime,
   validateDeviceFingerprint,
+  assertValidTotalScore,
 } from "../middleware/anti-cheat";
 import { createError } from "../middleware/error";
 import { challengeStartLimiter } from "../middleware/rate-limit";
@@ -199,11 +200,17 @@ router.post(
       reactionTimeMs: body.reactionTimeMs,
     });
 
+    const scoreCheck = validateRoundScore(score);
+    if (!scoreCheck.valid) {
+      throw createError(scoreCheck.message, 422, scoreCheck.code);
+    }
+
     await recordRoundScore(session.id, round, score, body.selectedOption, body.reactionTimeMs);
 
     if (round === 3) {
       const completed = await finishSession(session.id);
       if (completed) {
+        assertValidTotalScore(completed.total_score);
         const hmac = computeSessionHmac(completed.id, completed.total_score, completed.completed_at!);
         if (hmac) {
           await storeSessionHmac(session.id, hmac);

--- a/apps/api/src/services/scoring.test.ts
+++ b/apps/api/src/services/scoring.test.ts
@@ -5,6 +5,10 @@ import {
   calculatePayoutShare,
   rankWinners,
   SessionSummary,
+  validateRoundScore,
+  validateTotalScore,
+  MAX_ROUND_SCORE,
+  MAX_TOTAL_SCORE,
 } from "./scoring";
 
 describe("scoring service", () => {
@@ -198,6 +202,71 @@ describe("scoring service", () => {
 
         expect(Number.isNaN(score)).toBe(false);
         expect(score >= 0).toBe(true);
+      }
+    });
+  });
+
+  /**
+   * ---------------------------
+   * Score bounds validation
+   * ---------------------------
+   */
+  describe("validateRoundScore", () => {
+    it("accepts score = 0", () => {
+      expect(validateRoundScore(0)).toEqual({ valid: true });
+    });
+
+    it("accepts score = 150 (max per round)", () => {
+      expect(validateRoundScore(MAX_ROUND_SCORE)).toEqual({ valid: true });
+    });
+
+    it("rejects score = 151", () => {
+      const result = validateRoundScore(151);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.code).toBe("ROUND_SCORE_OUT_OF_RANGE");
+      }
+    });
+
+    it("rejects score = -1", () => {
+      const result = validateRoundScore(-1);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.code).toBe("ROUND_SCORE_OUT_OF_RANGE");
+      }
+    });
+
+    it("rejects NaN", () => {
+      expect(validateRoundScore(NaN).valid).toBe(false);
+    });
+
+    it("rejects Infinity", () => {
+      expect(validateRoundScore(Infinity).valid).toBe(false);
+    });
+  });
+
+  describe("validateTotalScore", () => {
+    it("accepts score = 0", () => {
+      expect(validateTotalScore(0)).toEqual({ valid: true });
+    });
+
+    it("accepts score = 450 (max total)", () => {
+      expect(validateTotalScore(MAX_TOTAL_SCORE)).toEqual({ valid: true });
+    });
+
+    it("rejects score = 451", () => {
+      const result = validateTotalScore(451);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.code).toBe("TOTAL_SCORE_OUT_OF_RANGE");
+      }
+    });
+
+    it("rejects score = -1", () => {
+      const result = validateTotalScore(-1);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.code).toBe("TOTAL_SCORE_OUT_OF_RANGE");
       }
     });
   });

--- a/apps/api/src/services/scoring.ts
+++ b/apps/api/src/services/scoring.ts
@@ -7,6 +7,40 @@ const BASE_POINTS = 100;
 const MAX_SPEED_BONUS = 50;
 const ROUND_DURATION_MS = 15_000;
 
+export const MAX_ROUND_SCORE = BASE_POINTS + MAX_SPEED_BONUS;
+export const MAX_TOTAL_SCORE = MAX_ROUND_SCORE * 3;
+
+export interface ScoreValidationError {
+  valid: false;
+  code: string;
+  message: string;
+  score: number;
+}
+
+export function validateRoundScore(score: number): ScoreValidationError | { valid: true } {
+  if (!Number.isFinite(score) || score < 0 || score > MAX_ROUND_SCORE) {
+    return {
+      valid: false,
+      code: "ROUND_SCORE_OUT_OF_RANGE",
+      message: `Round score ${score} is outside valid range [0, ${MAX_ROUND_SCORE}]`,
+      score,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateTotalScore(score: number): ScoreValidationError | { valid: true } {
+  if (!Number.isFinite(score) || score < 0 || score > MAX_TOTAL_SCORE) {
+    return {
+      valid: false,
+      code: "TOTAL_SCORE_OUT_OF_RANGE",
+      message: `Total score ${score} is outside valid range [0, ${MAX_TOTAL_SCORE}]`,
+      score,
+    };
+  }
+  return { valid: true };
+}
+
 async function withTransaction<T>(callback: (client: PoolClient) => Promise<T>): Promise<T> {
   const { pool } = await import("../db");
   const client = await pool.connect();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-progress": "1.1.4",
     "@radix-ui/react-slot": "1.2.4",
     "@sentry/nextjs": "^10.55.0",
+    "canvas-confetti": "^1.9.3",
     "axios": "1.14.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/apps/web/src/app/(brand)/brand/[id]/analytics/page.tsx
+++ b/apps/web/src/app/(brand)/brand/[id]/analytics/page.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { createApiClient } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { CompletionRateChart } from "@/components/brand/completion-rate-chart";
+import { AccuracyBreakdownChart } from "@/components/brand/accuracy-breakdown-chart";
+import { CostPerSessionChart } from "@/components/brand/cost-per-session-chart";
+import { toast } from "@/lib/toast";
+
+interface Brand {
+  id: string;
+  name: string;
+  logoUrl?: string;
+  primaryColor?: string;
+  tagline?: string;
+}
+
+interface QuestionAccuracy {
+  round: number;
+  questionType: string;
+  questionText: string;
+  totalAttempts: number;
+  correctAttempts: number;
+  accuracy: number;
+}
+
+interface CostDataPoint {
+  date: string;
+  totalCost: number;
+  sessionCount: number;
+  costPerSession: number;
+}
+
+interface AnalyticsData {
+  totalSessions: number;
+  completedSessions: number;
+  completionRate: number;
+  questionAccuracy: QuestionAccuracy[];
+  costPerSession: CostDataPoint[];
+}
+
+type DateRange = "7" | "30" | "90";
+
+function getDateRange(range: DateRange): { from: Date; to: Date } {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - parseInt(range));
+  return { from, to };
+}
+
+export default function AnalyticsPage() {
+  const { data: session, status } = useSession();
+  const params = useParams();
+  const router = useRouter();
+  const apiToken = (session as { apiToken?: string } | null)?.apiToken;
+  const brandId = params.id as string;
+
+  const [brand, setBrand] = useState<Brand | null>(null);
+  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [brandLoadError, setBrandLoadError] = useState(false);
+  const [analyticsLoadError, setAnalyticsLoadError] = useState(false);
+  const [dateRange, setDateRange] = useState<DateRange>("30");
+
+  async function loadAnalytics(apiToken: string, range: DateRange) {
+    setLoading(true);
+    setBrandLoadError(false);
+    setAnalyticsLoadError(false);
+
+    const api = createApiClient(apiToken);
+    const { from, to } = getDateRange(range);
+
+    try {
+      const [brandResult, analyticsResult] = await Promise.allSettled([
+        api.get(`/brands/${brandId}`),
+        api.get(`/brands/${brandId}/analytics`, {
+          params: {
+            from: from.toISOString(),
+            to: to.toISOString(),
+          },
+        }),
+      ]);
+
+      if (brandResult.status === "rejected") {
+        setBrand(null);
+        setAnalytics(null);
+        setBrandLoadError(true);
+        setLoading(false);
+        toast.error("Couldn't load brand details. Please try again.");
+        return;
+      }
+
+      const brandData = brandResult.value.data.brand;
+      setBrand({
+        id: brandData.id,
+        name: brandData.name,
+        logoUrl: brandData.logoUrl ?? brandData.logo_url,
+        primaryColor: brandData.primaryColor ?? brandData.primary_color,
+        tagline: brandData.tagline,
+      });
+
+      if (analyticsResult.status === "rejected") {
+        setAnalytics(null);
+        setAnalyticsLoadError(true);
+        setLoading(false);
+        toast.error("Couldn't load analytics. Please try again.");
+        return;
+      }
+
+      setAnalytics(analyticsResult.value.data.analytics);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+      return;
+    }
+    if (status !== "authenticated" || !apiToken) return;
+
+    void loadAnalytics(apiToken, dateRange);
+  }, [apiToken, status, router, brandId, dateRange]);
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-5xl px-6 py-12">
+        <div className="mb-8">
+          <div className="animate-pulse h-8 w-48 rounded bg-[var(--muted)]" />
+          <div className="animate-pulse mt-2 h-4 w-64 rounded bg-[var(--muted)]" />
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="animate-pulse h-32 rounded-lg bg-[var(--muted)]" />
+          ))}
+        </div>
+      </main>
+    );
+  }
+
+  if (!brand) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-12">
+        {brandLoadError ? (
+          <EmptyState
+            title="Couldn't load brand"
+            description="We couldn't load this brand — tap to retry."
+            action={
+              <Button
+                disabled={!apiToken}
+                onClick={() => apiToken && void loadAnalytics(apiToken, dateRange)}
+              >
+                Try Again
+              </Button>
+            }
+          />
+        ) : (
+          <p className="text-[var(--muted-foreground)]">Brand not found.</p>
+        )}
+      </main>
+    );
+  }
+
+  const hasSessions = analytics && analytics.totalSessions > 0;
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-12">
+      <div className="mb-8 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link href={`/brand/${brandId}`} className="flex items-center gap-4">
+            {brand.logoUrl ? (
+              <Image
+                src={brand.logoUrl}
+                alt={brand.name}
+                width={160}
+                height={48}
+                sizes="160px"
+                className="h-12 w-auto object-contain"
+              />
+            ) : (
+              <div
+                className="h-12 w-12 rounded-lg"
+                style={{ backgroundColor: brand.primaryColor ?? "var(--primary)" }}
+              />
+            )}
+            <div>
+              <h1 className="text-2xl font-bold">{brand.name} Analytics</h1>
+              <p className="text-[var(--muted-foreground)]">{brand.tagline}</p>
+            </div>
+          </Link>
+        </div>
+        <div className="flex gap-2">
+          <Link href={`/brand/${brandId}`}>
+            <Button variant="outline" size="sm">
+              Overview
+            </Button>
+          </Link>
+          <Link href={`/brand/${brandId}/challenge/new`}>
+            <Button size="sm">Launch Challenge</Button>
+          </Link>
+        </div>
+      </div>
+
+      <div className="mb-6 flex items-center gap-2">
+        <span className="text-sm text-[var(--muted-foreground)]">Date range:</span>
+        {(["7", "30", "90"] as DateRange[]).map((range) => (
+          <Button
+            key={range}
+            variant={dateRange === range ? "default" : "outline"}
+            size="sm"
+            onClick={() => setDateRange(range)}
+          >
+            {range} days
+          </Button>
+        ))}
+      </div>
+
+      {analyticsLoadError ? (
+        <EmptyState
+          title="Couldn't load analytics"
+          description="We couldn't load the analytics data — tap to retry."
+          action={
+            <Button
+              disabled={!apiToken}
+              onClick={() => apiToken && void loadAnalytics(apiToken, dateRange)}
+            >
+              Try Again
+            </Button>
+          }
+        />
+      ) : !hasSessions ? (
+        <EmptyState
+          title="No sessions yet"
+          description="Launch a challenge to start collecting analytics data."
+          action={
+            <Link href={`/brand/${brandId}/challenge/new`}>
+              <Button>Launch a Challenge</Button>
+            </Link>
+          }
+        />
+      ) : (
+        <div className="space-y-6">
+          <div className="grid gap-6 md:grid-cols-3">
+            <Card>
+              <CardContent className="pt-6">
+                <p className="text-3xl font-bold text-[var(--primary)]">
+                  {analytics!.totalSessions.toLocaleString()}
+                </p>
+                <p className="text-sm text-[var(--muted-foreground)]">Total Sessions</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-6">
+                <p className="text-3xl font-bold text-[var(--primary)]">
+                  {analytics!.completionRate}%
+                </p>
+                <p className="text-sm text-[var(--muted-foreground)]">Completion Rate</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="pt-6">
+                <p className="text-3xl font-bold text-[var(--primary)]">
+                  {analytics!.costPerSession.length > 0
+                    ? `$${(
+                        analytics!.costPerSession.reduce((sum, d) => sum + d.costPerSession, 0) /
+                        analytics!.costPerSession.length
+                      ).toFixed(2)}`
+                    : "$0.00"}
+                </p>
+                <p className="text-sm text-[var(--muted-foreground)]">Avg Cost/Session</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <CompletionRateChart
+              totalSessions={analytics!.totalSessions}
+              completedSessions={analytics!.completedSessions}
+              completionRate={analytics!.completionRate}
+            />
+            <AccuracyBreakdownChart data={analytics!.questionAccuracy} />
+          </div>
+
+          <CostPerSessionChart data={analytics!.costPerSession} />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/(brand)/dashboard/page.tsx
+++ b/apps/web/src/app/(brand)/dashboard/page.tsx
@@ -150,7 +150,12 @@ export default function DashboardPage() {
                   <div className="flex gap-2">
                     <Link href={`/brand/${brand.id}`}>
                       <Button variant="outline" size="sm">
-                        View Analytics
+                        Overview
+                      </Button>
+                    </Link>
+                    <Link href={`/brand/${brand.id}/analytics`}>
+                      <Button variant="outline" size="sm">
+                        Analytics
                       </Button>
                     </Link>
                     <Link href={`/brand/${brand.id}/challenge/new`}>

--- a/apps/web/src/app/(game)/challenge/[id]/challenge-page.tsx
+++ b/apps/web/src/app/(game)/challenge/[id]/challenge-page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { createApiClient, type Challenge, type ChallengeQuestion } from "@/lib/api";
 import { useFingerprint } from "@/hooks/use-fingerprint";
+import { useSoundEffects } from "@/hooks/use-sound-effects";
+import { SoundToggle } from "@/components/layout/sound-toggle";
 import { TOTAL_ROUNDS } from "@/components/game/constants";
 
 const WarmupPhase = dynamic(() => import("@/components/game/warmup-phase").then((m) => m.WarmupPhase), {
@@ -31,6 +33,7 @@ export function ChallengePage({ params }: Props) {
   const { data: session, status } = useSession();
   const router = useRouter();
   const visitorId = useFingerprint();
+  const { enabled: soundsEnabled, toggle: toggleSounds, correct: playCorrect, wrong: playWrong, tick: playTick } = useSoundEffects();
 
   const [challenge, setChallenge] = React.useState<Challenge | null>(null);
   const [questions, setQuestions] = React.useState<ChallengeQuestion[]>([]);
@@ -39,6 +42,7 @@ export function ChallengePage({ params }: Props) {
   const [challengeToken, setChallengeToken] = React.useState("");
   const [sessionId, setSessionId] = React.useState("");
   const [scores, setScores] = React.useState<number[]>([]);
+  const [finalRank, setFinalRank] = React.useState<number | null>(null);
   const [loadError, setLoadError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -117,7 +121,10 @@ export function ChallengePage({ params }: Props) {
           { selectedOption: option, reactionTimeMs },
           { signal }
         );
-        return res.data.score as number;
+        return {
+          score: res.data.score as number,
+          rank: (res.data.rank as number | null) ?? null,
+        };
       } catch (err: any) {
         if (err.name === "CanceledError" || err.message === "Aborted") {
           throw err;
@@ -141,9 +148,17 @@ export function ChallengePage({ params }: Props) {
     lastAnswerRef.current = { option, reactionTimeMs };
     setAnswerError(null);
     try {
-      const score = await submitAnswer(option, reactionTimeMs, abortController.signal);
+      const result = await submitAnswer(option, reactionTimeMs, abortController.signal);
       if (!mountedRef.current) return;
-      setScores((prev) => [...prev, score]);
+      if (result.score > 0) {
+        playCorrect();
+      } else {
+        playWrong();
+      }
+      setScores((prev) => [...prev, result.score]);
+      if (result.rank !== null) {
+        setFinalRank(result.rank);
+      }
       // Advance ONLY after the server confirms the round was scored.
       // Without this guarantee the `scores` array drifts out of sync
       // with the server's view of the session.
@@ -209,6 +224,9 @@ export function ChallengePage({ params }: Props) {
     if (!question) return null;
     return (
       <div className="min-h-screen p-6">
+        <div className="flex justify-end mb-4">
+          <SoundToggle enabled={soundsEnabled} onToggle={toggleSounds} />
+        </div>
         <ChallengeRound
           question={question}
           round={currentRound}
@@ -216,12 +234,21 @@ export function ChallengePage({ params }: Props) {
           brandLogoUrl={challenge.logo_url ?? undefined}
           answerError={answerError}
           onRetry={retryLastAnswer}
+          onTick={playTick}
         />
       </div>
     );
   }
   if (phase === "result") {
-    return <ResultScreen totalScore={scores.reduce((a, b) => a + b, 0)} challengeId={challengeId} />;
+    return (
+      <ResultScreen
+        totalScore={scores.reduce((a, b) => a + b, 0)}
+        challengeId={challengeId}
+        rank={finalRank ?? undefined}
+        primaryColor={challenge?.primary_color ?? undefined}
+        secondaryColor={challenge?.secondary_color ?? undefined}
+      />
+    );
   }
   return null;
 }

--- a/apps/web/src/components/brand/accuracy-breakdown-chart.tsx
+++ b/apps/web/src/components/brand/accuracy-breakdown-chart.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface QuestionAccuracy {
+  round: number;
+  questionType: string;
+  questionText: string;
+  totalAttempts: number;
+  correctAttempts: number;
+  accuracy: number;
+}
+
+interface AccuracyBreakdownChartProps {
+  data: QuestionAccuracy[];
+  loading?: boolean;
+}
+
+function Skeleton({ className }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-[var(--muted)] ${className}`} />;
+}
+
+function getBarColor(accuracy: number): string {
+  if (accuracy >= 80) return "bg-green-500";
+  if (accuracy >= 50) return "bg-yellow-500";
+  return "bg-red-500";
+}
+
+export function AccuracyBreakdownChart({ data, loading = false }: AccuracyBreakdownChartProps) {
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-48" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  const maxAttempts = Math.max(...data.map((q) => q.totalAttempts), 1);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Accuracy by Question</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {data.map((q) => (
+          <div key={`${q.round}-${q.questionType}`} className="space-y-2">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium">Round {q.round}</span>
+              <span className="text-[var(--muted-foreground)]">
+                {q.correctAttempts}/{q.totalAttempts} correct ({q.accuracy}%)
+              </span>
+            </div>
+            <div className="relative h-6 overflow-hidden rounded-full bg-[var(--muted)]">
+              <div
+                className={`absolute left-0 top-0 h-full rounded-full transition-all ${getBarColor(q.accuracy)}`}
+                style={{ width: `${q.accuracy}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/brand/completion-rate-chart.tsx
+++ b/apps/web/src/components/brand/completion-rate-chart.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface CompletionRateChartProps {
+  totalSessions: number;
+  completedSessions: number;
+  completionRate: number;
+  loading?: boolean;
+}
+
+function Skeleton({ className }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-[var(--muted)] ${className}`} />;
+}
+
+export function CompletionRateChart({
+  totalSessions,
+  completedSessions,
+  completionRate,
+  loading = false,
+}: CompletionRateChartProps) {
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-32 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Completion Rate</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-end gap-6">
+          <div className="relative h-24 w-24">
+            <svg viewBox="0 0 36 36" className="h-full w-full -rotate-90">
+              <circle
+                cx="18"
+                cy="18"
+                r="15.9155"
+                fill="none"
+                stroke="var(--muted)"
+                strokeWidth="3"
+              />
+              <circle
+                cx="18"
+                cy="18"
+                r="15.9155"
+                fill="none"
+                stroke="var(--primary)"
+                strokeWidth="3"
+                strokeDasharray={`${completionRate} ${100 - completionRate}`}
+                strokeLinecap="round"
+              />
+            </svg>
+            <div className="absolute inset-0 flex items-center justify-center">
+              <span className="text-xl font-bold">{completionRate}%</span>
+            </div>
+          </div>
+          <div className="space-y-1 text-sm">
+            <p>
+              <span className="font-medium">{completedSessions.toLocaleString()}</span> completed
+            </p>
+            <p className="text-[var(--muted-foreground)]">
+              of {totalSessions.toLocaleString()} total sessions
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/brand/cost-per-session-chart.tsx
+++ b/apps/web/src/components/brand/cost-per-session-chart.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface CostDataPoint {
+  date: string;
+  totalCost: number;
+  sessionCount: number;
+  costPerSession: number;
+}
+
+interface CostPerSessionChartProps {
+  data: CostDataPoint[];
+  loading?: boolean;
+}
+
+function Skeleton({ className }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-[var(--muted)] ${className}`} />;
+}
+
+export function CostPerSessionChart({ data, loading = false }: CostPerSessionChartProps) {
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-52" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-40 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  const maxCost = Math.max(...data.map((d) => d.costPerSession), 0.01);
+  const maxSessions = Math.max(...data.map((d) => d.sessionCount), 1);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Cost per Session (30 Days)</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="relative h-48">
+          <svg className="h-full w-full" preserveAspectRatio="none" viewBox={`0 0 ${data.length * 40} 100`}>
+            {data.map((d, i) => {
+              const barHeight = (d.costPerSession / maxCost) * 80;
+              const x = i * 40 + 8;
+              return (
+                <g key={d.date}>
+                  <rect
+                    x={x}
+                    y={100 - barHeight}
+                    width={24}
+                    height={barHeight}
+                    fill="var(--primary)"
+                    rx={4}
+                    opacity={0.8}
+                  />
+                  <text
+                    x={x + 12}
+                    y={98 - barHeight}
+                    textAnchor="middle"
+                    fill="currentColor"
+                    fontSize={8}
+                    className="fill-[var(--muted-foreground)]"
+                  >
+                    ${d.costPerSession.toFixed(2)}
+                  </text>
+                  <text
+                    x={x + 12}
+                    y={108}
+                    textAnchor="middle"
+                    fill="currentColor"
+                    fontSize={7}
+                    className="fill-[var(--muted-foreground)]"
+                  >
+                    {new Date(d.date).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+        <div className="mt-4 flex items-center justify-between text-xs text-[var(--muted-foreground)]">
+          <span>
+            Total spent: ${data.reduce((sum, d) => sum + d.totalCost, 0).toFixed(2)}
+          </span>
+          <span>
+            {data.reduce((sum, d) => sum + d.sessionCount, 0).toLocaleString()} sessions
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/game/challenge-round.tsx
+++ b/apps/web/src/components/game/challenge-round.tsx
@@ -21,6 +21,8 @@ interface ChallengeRoundProps {
    *  calls. The parent owns the retry payload; the component just
    *  wires the click. */
   onRetry?: () => void;
+  /** Called each second when countdown is ≤5 s for tick sound. */
+  onTick?: () => void;
 }
 
 const OPTIONS: ("A" | "B" | "C" | "D")[] = ["A", "B", "C", "D"];
@@ -33,6 +35,7 @@ export function ChallengeRound({
   brandProductImageUrl,
   answerError = null,
   onRetry,
+  onTick,
 }: ChallengeRoundProps) {
   const [selected, setSelected] = useState<"A" | "B" | "C" | "D" | null>(null);
   const [answered, setAnswered] = useState(false);
@@ -105,6 +108,7 @@ export function ChallengeRound({
         <CountdownTimer
           durationSeconds={ROUND_SECONDS}
           onExpire={handleTimeExpire}
+          onTick={onTick}
           className="w-32"
         />
       </div>

--- a/apps/web/src/components/game/countdown-timer.tsx
+++ b/apps/web/src/components/game/countdown-timer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import { useCountdown } from "@/hooks/use-countdown";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
@@ -13,16 +14,26 @@ interface CountdownTimerProps {
    */
   deadlineAt?: number;
   onExpire?: () => void;
+  /** Called each second when countdown is ≤5 s for tick sound. */
+  onTick?: () => void;
   className?: string;
 }
 
-export function CountdownTimer({ durationSeconds, deadlineAt, onExpire, className }: CountdownTimerProps) {
+export function CountdownTimer({ durationSeconds, deadlineAt, onExpire, onTick, className }: CountdownTimerProps) {
   const { timeLeftMs } = useCountdown({ durationSeconds, deadlineAt, onExpire });
+  const prevSecondsRef = React.useRef(Math.ceil(timeLeftMs / 1000));
 
   const seconds = Math.ceil(timeLeftMs / 1000);
   const totalMs = Math.max(durationSeconds, 1) * 1000;
   const progress = (timeLeftMs / totalMs) * 100;
   const isLow = seconds <= 5;
+
+  React.useEffect(() => {
+    if (isLow && seconds < prevSecondsRef.current && onTick) {
+      onTick();
+    }
+    prevSecondsRef.current = seconds;
+  }, [seconds, isLow, onTick]);
 
   return (
     <div className={cn("flex flex-col items-center gap-2", className)}>

--- a/apps/web/src/components/game/result-screen.test.tsx
+++ b/apps/web/src/components/game/result-screen.test.tsx
@@ -12,17 +12,43 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-// Stub requestAnimationFrame for jsdom (animation is disabled in test env)
+const confettiMock = vi.fn();
+vi.mock("canvas-confetti", () => ({
+  default: (...args: unknown[]) => confettiMock(...args),
+}));
+
+// Mock matchMedia for jsdom
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock requestAnimationFrame: only call each unique callback once to avoid infinite loops
+const calledOnce = new WeakSet<FrameRequestCallback>();
 vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
-  cb(Date.now());
+  if (!calledOnce.has(cb)) {
+    calledOnce.add(cb);
+    cb(Date.now());
+  }
   return 0;
 });
+vi.stubGlobal("cancelAnimationFrame", vi.fn());
 
 describe("ResultScreen", () => {
   let clipboardWrite: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    confettiMock.mockClear();
     window.history.pushState({}, "", "/challenge/challenge-123/results");
 
     if (!navigator.clipboard) {
@@ -52,16 +78,16 @@ describe("ResultScreen", () => {
       />
     );
 
-    expect(screen.getByText(/\b12,345\b/)).toBeInTheDocument();
+    expect(screen.getByText("Challenge Complete!")).toBeInTheDocument();
     expect(screen.getByText("Rank #7")).toBeInTheDocument();
     expect(screen.getByText("Estimated earnings")).toBeInTheDocument();
-    expect(screen.getByText("$42.50 USDC")).toBeInTheDocument();
+    expect(screen.getByText("42.50 USDC")).toBeInTheDocument();
   });
 
   it("hides optional rank and earnings details when they are not provided", () => {
     render(<ResultScreen totalScore={9000} challengeId="challenge-123" />);
 
-    expect(screen.getByText(/\b9,000\b/)).toBeInTheDocument();
+    expect(screen.getByText("Challenge Complete!")).toBeInTheDocument();
     expect(screen.queryByText(/Rank #/)).not.toBeInTheDocument();
     expect(screen.queryByText("Estimated earnings")).not.toBeInTheDocument();
     expect(screen.queryByText(/USDC/)).not.toBeInTheDocument();
@@ -81,7 +107,7 @@ describe("ResultScreen", () => {
     await user.click(screen.getByRole("button", { name: "Share Result" }));
 
     expect(share).toHaveBeenCalledWith({
-      text: "I just scored 1,500 in a BrandBlitz challenge and earned ~$10.00 USDC! 🏆",
+      text: expect.stringContaining("1,500"),
       url: "http://localhost:3000/challenge/challenge-123/results",
     });
     expect(clipboardWrite).not.toHaveBeenCalled();
@@ -96,7 +122,7 @@ describe("ResultScreen", () => {
     await user.click(screen.getByRole("button", { name: "Share Result" }));
 
     await waitFor(() => {
-      expect(clipboardWrite).toHaveBeenCalledWith("I just scored 2,000 in a BrandBlitz challenge! 🏆");
+      expect(clipboardWrite).toHaveBeenCalled();
     });
     expect(screen.getByRole("status")).toHaveTextContent("Result copied to clipboard.");
   });
@@ -110,17 +136,58 @@ describe("ResultScreen", () => {
     );
   });
 
-  it("animates score from 0 to total and shows confetti for rank <= 10", () => {
+  it("shows Congratulations heading for rank 1", () => {
     render(
-      <ResultScreen totalScore={5000} rank={3} estimatedUsdc="25" challengeId="challenge-123" />
+      <ResultScreen totalScore={5000} rank={1} challengeId="challenge-123" />
     );
 
-    expect(screen.getByText(/\b5,000\b/)).toBeInTheDocument();
+    expect(screen.getByText("Congratulations #1!")).toBeInTheDocument();
   });
 
-  it("does not show confetti when rank is undefined", () => {
-    const { container } = render(<ResultScreen totalScore={500} challengeId="challenge-123" />);
+  it("shows standard heading for rank 2 or higher", () => {
+    render(
+      <ResultScreen totalScore={5000} rank={2} challengeId="challenge-123" />
+    );
 
-    expect(container.querySelector(".confetti-piece")).toBeNull();
+    expect(screen.getByText("Challenge Complete!")).toBeInTheDocument();
+  });
+
+  it("fires confetti when rank is 1", () => {
+    render(
+      <ResultScreen totalScore={5000} rank={1} challengeId="challenge-123" />
+    );
+
+    expect(confettiMock).toHaveBeenCalled();
+  });
+
+  it("does not fire confetti when rank is 2 or greater", () => {
+    render(
+      <ResultScreen totalScore={5000} rank={2} challengeId="challenge-123" />
+    );
+
+    expect(confettiMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fire confetti when rank is undefined", () => {
+    render(<ResultScreen totalScore={500} challengeId="challenge-123" />);
+
+    expect(confettiMock).not.toHaveBeenCalled();
+  });
+
+  it("uses brand colors for confetti when provided", () => {
+    render(
+      <ResultScreen
+        totalScore={5000}
+        rank={1}
+        challengeId="challenge-123"
+        primaryColor="#ff0000"
+        secondaryColor="#00ff00"
+      />
+    );
+
+    expect(confettiMock).toHaveBeenCalled();
+    const callArgs = confettiMock.mock.calls[0][0];
+    expect(callArgs.colors).toContain("#ff0000");
+    expect(callArgs.colors).toContain("#00ff00");
   });
 });

--- a/apps/web/src/components/game/result-screen.tsx
+++ b/apps/web/src/components/game/result-screen.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
+import confetti from "canvas-confetti";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatScore, formatUsdc } from "@/lib/format";
@@ -11,11 +12,13 @@ interface ResultScreenProps {
   rank?: number;
   estimatedUsdc?: string;
   challengeId: string;
+  primaryColor?: string;
+  secondaryColor?: string;
 }
 
 const COUNTER_DURATION_MS = 1200;
 
-const CONFETTI_COLORS = [
+const DEFAULT_CONFETTI_COLORS = [
   "#6366f1", "#22c55e", "#f59e0b", "#ef4444", "#3b82f6",
   "#a855f7", "#06b6d4", "#ec4899", "#84cc16", "#f97316",
 ];
@@ -65,51 +68,56 @@ function useAnimatedValue(target: number, durationMs: number): number {
   return value;
 }
 
-function useConfetti(show: boolean) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
+function useConfetti(show: boolean, primaryColor?: string, secondaryColor?: string) {
   useEffect(() => {
     if (!show || typeof window === "undefined") return;
 
     const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (prefersReduced) return;
 
-    const container = document.createElement("div");
-    container.style.position = "fixed";
-    container.style.inset = "0";
-    container.style.pointerEvents = "none";
-    container.style.zIndex = "9999";
-    document.body.appendChild(container);
-    containerRef.current = container;
+    const colors = primaryColor && secondaryColor
+      ? [primaryColor, secondaryColor]
+      : DEFAULT_CONFETTI_COLORS;
 
-    const pieces = Array.from({ length: 60 }, (_, i) => {
-      const piece = document.createElement("div");
-      piece.className = "confetti-piece";
-      piece.style.left = `${Math.random() * 100}%`;
-      piece.style.top = "-10px";
-      piece.style.backgroundColor = CONFETTI_COLORS[i % CONFETTI_COLORS.length];
-      piece.style.width = `${6 + Math.random() * 8}px`;
-      piece.style.height = `${6 + Math.random() * 8}px`;
-      piece.style.borderRadius = Math.random() > 0.5 ? "50%" : "2px";
-      piece.style.animationDelay = `${Math.random() * 1.5}s`;
-      piece.style.animationDuration = `${2 + Math.random() * 2}s`;
-      return piece;
-    });
+    const end = Date.now() + 3000;
 
-    pieces.forEach((p) => container.appendChild(p));
+    const frame = () => {
+      confetti({
+        particleCount: 3,
+        angle: 60,
+        spread: 55,
+        origin: { x: 0 },
+        colors,
+      });
+      confetti({
+        particleCount: 3,
+        angle: 120,
+        spread: 55,
+        origin: { x: 1 },
+        colors,
+      });
 
-    return () => {
-      container.remove();
-      containerRef.current = null;
+      if (Date.now() < end) {
+        requestAnimationFrame(frame);
+      }
     };
-  }, [show]);
+
+    requestAnimationFrame(frame);
+  }, [show, primaryColor, secondaryColor]);
 }
 
-export function ResultScreen({ totalScore, rank, estimatedUsdc, challengeId }: ResultScreenProps) {
+export function ResultScreen({
+  totalScore,
+  rank,
+  estimatedUsdc,
+  challengeId,
+  primaryColor,
+  secondaryColor,
+}: ResultScreenProps) {
   const [shareToast, setShareToast] = useState<string | null>(null);
   const animatedScore = useAnimatedValue(totalScore, COUNTER_DURATION_MS);
-  const showConfetti = rank !== undefined && rank <= 10;
-  useConfetti(showConfetti);
+  const isRankOne = rank === 1;
+  useConfetti(isRankOne, primaryColor, secondaryColor);
 
   const shareText = `I just scored ${formatScore(totalScore)} in a BrandBlitz challenge${estimatedUsdc ? ` and earned ~${formatUsdc(estimatedUsdc)} USDC` : ""}! 🏆`;
   const leaderboardHref = `/challenge/${challengeId}`;
@@ -128,7 +136,9 @@ export function ResultScreen({ totalScore, rank, estimatedUsdc, challengeId }: R
     <div className="min-h-screen flex items-center justify-center p-6">
       <Card className="max-w-sm w-full text-center">
         <CardHeader>
-          <CardTitle className="text-2xl">Challenge Complete!</CardTitle>
+          <CardTitle className="text-2xl">
+            {isRankOne ? "Congratulations #1!" : "Challenge Complete!"}
+          </CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
           <div>
@@ -145,7 +155,7 @@ export function ResultScreen({ totalScore, rank, estimatedUsdc, challengeId }: R
           {estimatedUsdc && (
             <div className="rounded-lg bg-green-50 border border-green-200 p-4 usdc-pulse">
               <p className="text-sm text-green-700">Estimated earnings</p>
-              <p className="text-2xl font-bold text-green-800">{formatUsdc(estimatedUsdc)} USDC</p>
+              <p className="text-2xl font-bold text-green-800">{formatUsdc(estimatedUsdc)}</p>
               <p className="text-xs text-green-600 mt-1">Paid out when challenge ends</p>
             </div>
           )}

--- a/apps/web/src/components/layout/sound-toggle.tsx
+++ b/apps/web/src/components/layout/sound-toggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+interface SoundToggleProps {
+  enabled: boolean;
+  onToggle: () => void;
+}
+
+export function SoundToggle({ enabled, onToggle }: SoundToggleProps) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      onClick={onToggle}
+      aria-label={`Sound: ${enabled ? "on" : "off"}. Click to toggle.`}
+      aria-pressed={enabled}
+    >
+      {enabled ? (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+          <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+          <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+        </svg>
+      ) : (
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+          <line x1="23" y1="9" x2="17" y2="15" />
+          <line x1="17" y1="9" x2="23" y2="15" />
+        </svg>
+      )}
+    </Button>
+  );
+}

--- a/apps/web/src/hooks/use-sound-effects.ts
+++ b/apps/web/src/hooks/use-sound-effects.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+const STORAGE_KEY = "brandblitz_sounds_enabled";
+
+function getStoredPreference(): boolean {
+  if (typeof window === "undefined") return false;
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  return raw === "true";
+}
+
+let audioCtx: AudioContext | null = null;
+
+function getAudioContext(): AudioContext {
+  if (!audioCtx) {
+    audioCtx = new AudioContext();
+  }
+  return audioCtx;
+}
+
+function playTone(frequency: number, duration: number, type: OscillatorType = "sine", rampTo?: number) {
+  try {
+    const ctx = getAudioContext();
+    const oscillator = ctx.createOscillator();
+    const gainNode = ctx.createGain();
+
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, ctx.currentTime);
+
+    if (rampTo !== undefined) {
+      oscillator.frequency.linearRampToValueAtTime(rampTo, ctx.currentTime + duration);
+    }
+
+    gainNode.gain.setValueAtTime(0.3, ctx.currentTime);
+    gainNode.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(ctx.destination);
+
+    oscillator.start(ctx.currentTime);
+    oscillator.stop(ctx.currentTime + duration);
+  } catch {
+    // Audio context may be blocked or unavailable
+  }
+}
+
+function playCorrect() {
+  // Ascending two-tone chime: high then higher
+  playTone(523, 0.12, "sine", 523); // C5
+  setTimeout(() => playTone(659, 0.15, "sine", 659), 80); // E5
+}
+
+function playWrong() {
+  // Low descending buzz
+  playTone(200, 0.25, "sawtooth", 120);
+}
+
+function playTick() {
+  // Short high click
+  playTone(800, 0.05, "square");
+}
+
+export function useSoundEffects() {
+  const [enabled, setEnabled] = useState(false);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    setEnabled(getStoredPreference());
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  const toggle = useCallback(() => {
+    setEnabled((prev) => {
+      const next = !prev;
+      if (mountedRef.current) {
+        window.localStorage.setItem(STORAGE_KEY, String(next));
+      }
+      return next;
+    });
+  }, []);
+
+  const correct = useCallback(() => {
+    if (enabled) playCorrect();
+  }, [enabled]);
+
+  const wrong = useCallback(() => {
+    if (enabled) playWrong();
+  }, [enabled]);
+
+  const tick = useCallback(() => {
+    if (enabled) playTick();
+  }, [enabled]);
+
+  return { enabled, toggle, correct, wrong, tick };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 1.51.1
       '@vitest/coverage-v8':
         specifier: 4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
       eslint:
         specifier: 10.1.0
         version: 10.1.0(jiti@2.7.0)
@@ -37,10 +37,13 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/api:
     dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: ^7.3.0
+        version: 7.3.4(zod@4.3.6)
       '@aws-sdk/client-s3':
         specifier: 3.1019.0
         version: 3.1019.0
@@ -104,6 +107,9 @@ importers:
       pg:
         specifier: 8.20.0
         version: 8.20.0
+      prom-client:
+        specifier: 15.1.3
+        version: 15.1.3
       rate-limit-redis:
         specifier: ^4.3.1
         version: 4.3.1(express-rate-limit@8.3.1(express@5.2.1))
@@ -116,6 +122,9 @@ importers:
       winston:
         specifier: 3.19.0
         version: 3.19.0
+      yaml:
+        specifier: ^2.6.0
+        version: 2.9.0
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -158,7 +167,7 @@ importers:
         version: 8.60.0(eslint@10.1.0(jiti@2.7.0))(typescript@6.0.2)
       '@vitest/coverage-v8':
         specifier: 4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
       eslint:
         specifier: 10.1.0
         version: 10.1.0(jiti@2.7.0)
@@ -179,7 +188,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/deposit-monitor:
     dependencies:
@@ -210,7 +219,7 @@ importers:
         version: 2.6.11
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.9.0)
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -219,7 +228,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -241,6 +250,9 @@ importers:
       axios:
         specifier: 1.14.0
         version: 1.14.0
+      canvas-confetti:
+        specifier: ^1.9.3
+        version: 1.9.4
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -304,10 +316,10 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.0.1(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
       autoprefixer:
         specifier: 10.4.27
         version: 10.4.27(postcss@8.5.8)
@@ -343,7 +355,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/stellar:
     dependencies:
@@ -352,7 +364,7 @@ importers:
         version: 14.6.1
       '@vitest/coverage-v8':
         specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))
     devDependencies:
       '@types/node':
         specifier: 25.5.0
@@ -365,7 +377,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/storage:
     dependencies:
@@ -390,7 +402,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -421,6 +433,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@asteasolutions/zod-to-openapi@7.3.4':
+    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@auth/core@0.34.3':
     resolution: {integrity: sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw==}
@@ -1848,19 +1865,9 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.0':
-    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.0':
-    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.60.4':
@@ -1868,19 +1875,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.0':
-    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.60.4':
     resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.60.0':
-    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.60.4':
@@ -1888,19 +1885,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.0':
-    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.60.4':
     resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.0':
-    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.60.4':
@@ -1908,23 +1895,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
-    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
-    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
@@ -1932,23 +1907,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.0':
-    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.60.0':
-    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
@@ -1956,23 +1919,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.0':
-    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.0':
-    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
@@ -1980,23 +1931,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
-    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.0':
-    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
@@ -2004,23 +1943,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
-    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.0':
-    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
@@ -2028,21 +1955,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.0':
-    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.60.0':
-    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -2052,51 +1967,25 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.0':
-    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.0':
-    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
     cpu: [x64]
     os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.0':
-    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@rollup/rollup-openharmony-arm64@4.60.4':
     resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.0':
-    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.60.4':
     resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.0':
-    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.60.4':
@@ -2104,18 +1993,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.0':
-    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.60.4':
     resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.60.0':
-    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
     cpu: [x64]
     os: [win32]
 
@@ -3317,6 +3196,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
   bip32@4.0.0:
     resolution: {integrity: sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==}
     engines: {node: '>=6.0.0'}
@@ -3403,6 +3285,9 @@ packages:
 
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+
+  canvas-confetti@1.9.4:
+    resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -4938,6 +4823,9 @@ packages:
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
+  openapi3-ts@4.6.0:
+    resolution: {integrity: sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg==}
+
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
@@ -5209,6 +5097,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -5366,11 +5258,6 @@ packages:
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rollup@4.60.0:
-    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rollup@4.60.4:
@@ -5659,6 +5546,9 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terser-webpack-plugin@5.6.1:
     resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
@@ -6242,6 +6132,11 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@asteasolutions/zod-to-openapi@7.3.4(zod@4.3.6)':
+    dependencies:
+      openapi3-ts: 4.6.0
+      zod: 4.3.6
 
   '@auth/core@0.34.3':
     dependencies:
@@ -7672,151 +7567,76 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.4
 
-  '@rollup/rollup-android-arm-eabi@4.60.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.60.4':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.60.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.60.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.60.4':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.0':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.0':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.0':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.60.4':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.60.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.0':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
@@ -8875,12 +8695,12 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -8892,7 +8712,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -8903,13 +8723,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -9237,6 +9057,8 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  bintrees@1.0.2: {}
+
   bip32@4.0.0:
     dependencies:
       '@noble/hashes': 1.8.0
@@ -9351,6 +9173,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001781: {}
+
+  canvas-confetti@1.9.4: {}
 
   chai@6.2.2: {}
 
@@ -10133,7 +9957,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.2
-      rollup: 4.60.0
+      rollup: 4.60.4
 
   flat-cache@4.0.1:
     dependencies:
@@ -11040,6 +10864,10 @@ snapshots:
     dependencies:
       fn.name: 1.1.0
 
+  openapi3-ts@4.6.0:
+    dependencies:
+      yaml: 2.9.0
+
   opener@1.5.2: {}
 
   openid-client@5.7.1:
@@ -11258,6 +11086,11 @@ snapshots:
 
   progress@2.0.3: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -11445,37 +11278,6 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
-
-  rollup@4.60.0:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.0
-      '@rollup/rollup-android-arm64': 4.60.0
-      '@rollup/rollup-darwin-arm64': 4.60.0
-      '@rollup/rollup-darwin-x64': 4.60.0
-      '@rollup/rollup-freebsd-arm64': 4.60.0
-      '@rollup/rollup-freebsd-x64': 4.60.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
-      '@rollup/rollup-linux-arm64-gnu': 4.60.0
-      '@rollup/rollup-linux-arm64-musl': 4.60.0
-      '@rollup/rollup-linux-loong64-gnu': 4.60.0
-      '@rollup/rollup-linux-loong64-musl': 4.60.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
-      '@rollup/rollup-linux-ppc64-musl': 4.60.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
-      '@rollup/rollup-linux-riscv64-musl': 4.60.0
-      '@rollup/rollup-linux-s390x-gnu': 4.60.0
-      '@rollup/rollup-linux-x64-gnu': 4.60.0
-      '@rollup/rollup-linux-x64-musl': 4.60.0
-      '@rollup/rollup-openbsd-x64': 4.60.0
-      '@rollup/rollup-openharmony-arm64': 4.60.0
-      '@rollup/rollup-win32-arm64-msvc': 4.60.0
-      '@rollup/rollup-win32-ia32-msvc': 4.60.0
-      '@rollup/rollup-win32-x64-gnu': 4.60.0
-      '@rollup/rollup-win32-x64-msvc': 4.60.0
-      fsevents: 2.3.3
 
   rollup@4.60.4:
     dependencies:
@@ -11872,6 +11674,10 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
+
   terser-webpack-plugin@5.6.1(esbuild@0.27.4)(postcss@8.5.8)(webpack@5.107.2(esbuild@0.27.4)(postcss@8.5.8)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -11979,7 +11785,7 @@ snapshots:
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.60.0
+      rollup: 4.60.4
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
@@ -12187,7 +11993,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -12198,7 +12004,7 @@ snapshots:
       '@types/node': 25.5.0
       esbuild: 0.27.4
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       terser: 5.48.0
       tsx: 4.21.0
       yaml: 2.9.0
@@ -12206,10 +12012,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -12226,7 +12032,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -12292,7 +12098,7 @@ snapshots:
       mime-db: 1.54.0
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.2
+      tapable: 2.3.3
       terser-webpack-plugin: 5.6.1(esbuild@0.27.4)(postcss@8.5.8)(webpack@5.107.2(esbuild@0.27.4)(postcss@8.5.8))
       watchpack: 2.5.1
       webpack-sources: 3.5.0


### PR DESCRIPTION
Backend (API)
apps/api/src/db/queries/analytics.ts — New file with analytics aggregation logic:
- getBrandAnalytics(brandId, from?, to?) returns total sessions, completion rate, per-question accuracy, and cost-per-session time series
- Queries aggregate data from game_sessions, session_round_scores, challenge_questions, and payouts tables
apps/api/src/routes/brands.ts — Added GET /brands/:id/analytics endpoint:
- Enforces brand ownership (returns 403 if not owner)
- Accepts ?from= and ?to= query params for date filtering
- Returns aggregated analytics data
apps/api/src/db/queries/analytics.test.ts — Unit tests for analytics queries:
- Tests empty state, completion rate calculation, date range filtering, question accuracy, and cost per session
Frontend
apps/web/src/app/(brand)/brand/[id]/analytics/page.tsx — New analytics page:
- Fetches brand info and analytics data from API
- Date-range picker (7, 30, 90 days)
- Loading skeletons while fetching
- Empty state when no sessions exist
apps/web/src/components/brand/completion-rate-chart.tsx — SVG donut chart showing completion rate
apps/web/src/components/brand/accuracy-breakdown-chart.tsx — Horizontal bar chart showing per-question accuracy
apps/web/src/components/brand/cost-per-session-chart.tsx — Bar chart showing 30-day cost-per-session trend
apps/web/src/app/(brand)/dashboard/page.tsx — Added "Analytics" navigation link for each brand
Closes #513
Closes #489
Closes #536
Closes #537