### PR TITLE
feat: add keyboard shortcuts for A/B/C/D answer selection

### DIFF
--- a/apps/web/src/app/(game)/challenge/[id]/challenge-page.tsx
+++ b/apps/web/src/app/(game)/challenge/[id]/challenge-page.tsx
@@ -87,6 +87,7 @@ export function ChallengePage({ params }: Props) {
   const [answerError, setAnswerError] = React.useState<string | null>(null);
   const [answerState, setAnswerState] = React.useState<ChallengeAnswerState | null>(null);
   const [recoverySession, setRecoverySession] = React.useState<RecoverySessionResponse | null>(null);
+  const [showTooltip, setShowTooltip] = React.useState(false);
 
   const mountedRef = React.useRef(true);
   const currentRoundRef = React.useRef(currentRound);
@@ -167,6 +168,33 @@ export function ChallengePage({ params }: Props) {
       cancelled = true;
     };
   }, [apiToken, challengeId, router, status]);
+
+  React.useEffect(() => {
+    if (phase !== "challenge") return;
+    if (typeof window === "undefined") return;
+    const dismissed = window.localStorage.getItem("brandblitz:keyboard-tooltip-dismissed");
+    if (!dismissed) {
+      setShowTooltip(true);
+    }
+  }, [phase]);
+
+  React.useEffect(() => {
+    if (!showTooltip) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setShowTooltip(false);
+        try { window.localStorage.setItem("brandblitz:keyboard-tooltip-dismissed", "1"); } catch {}
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [showTooltip]);
+
+  const dismissTooltip = React.useCallback(() => {
+    setShowTooltip(false);
+    try { window.localStorage.setItem("brandblitz:keyboard-tooltip-dismissed", "1"); } catch {}
+  }, []);
 
   const handleWarmupComplete = async (challengeToken: string) => {
     if (!apiToken) return;
@@ -357,6 +385,23 @@ export function ChallengePage({ params }: Props) {
 
     return (
       <div className="min-h-screen p-6 pt-16">
+        {showTooltip && (
+          <div
+            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--background)] px-5 py-3 shadow-lg text-sm"
+            role="tooltip"
+            aria-label="Keyboard shortcut hint"
+          >
+            <kbd className="hidden md:inline-flex h-5 w-5 items-center justify-center rounded border border-[var(--border)] bg-[var(--muted)] text-xs font-bold text-[var(--muted-foreground)]" aria-hidden="true">⌨</kbd>
+            <span>Use <kbd className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded border border-[var(--border)] bg-[var(--muted)] px-1 text-xs font-bold" aria-hidden="true">A</kbd>/<kbd className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded border border-[var(--border)] bg-[var(--muted)] px-1 text-xs font-bold" aria-hidden="true">B</kbd>/<kbd className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded border border-[var(--border)] bg-[var(--muted)] px-1 text-xs font-bold" aria-hidden="true">C</kbd>/<kbd className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded border border-[var(--border)] bg-[var(--muted)] px-1 text-xs font-bold" aria-hidden="true">D</kbd> keys to answer faster</span>
+            <button
+              onClick={dismissTooltip}
+              className="ml-2 rounded-md p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)] transition-colors"
+              aria-label="Dismiss"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+          </div>
+        )}
         <OfflineBanner blocking />
         <ChallengeRound
           question={question}

--- a/apps/web/src/components/game/answer-option.tsx
+++ b/apps/web/src/components/game/answer-option.tsx
@@ -41,7 +41,7 @@ export function AnswerOption({
       aria-label={`${option}: ${label}`}
       aria-pressed={selected}
     >
-      <kbd className="mr-3 inline-flex h-6 min-w-6 items-center justify-center rounded border border-[var(--border)] bg-[var(--muted)] px-1 font-bold text-[var(--muted-foreground)]">
+      <kbd className="mr-3 inline-flex h-6 min-w-6 items-center justify-center rounded border border-[var(--border)] bg-[var(--muted)] px-1 font-bold text-[var(--muted-foreground)] max-md:hidden" aria-hidden="true">
         {option}
       </kbd>
       <span className="min-w-0 flex-1 truncate">{label}</span>

--- a/apps/web/src/components/game/challenge-round.tsx
+++ b/apps/web/src/components/game/challenge-round.tsx
@@ -7,6 +7,7 @@ import { CountdownTimer } from "./countdown-timer";
 import { ROUND_SECONDS } from "./constants";
 import type { ChallengeQuestion } from "@/lib/api";
 import { AnswerOption, type AnswerOptionKey } from "./answer-option";
+import { useKeyboardAnswers } from "@/hooks/use-keyboard-answers";
 
 export interface ChallengeAnswerState {
   selectedOption: AnswerOptionKey | null;
@@ -77,35 +78,10 @@ export function ChallengeRound({
     onAnswer(option, reactionTimeMs);
   }, [answered, disabled, onAnswer]);
 
-  useEffect(() => {
-    if (answered) return;
-
-    const keyToOption: Record<string, "A" | "B" | "C" | "D" | undefined> = {
-      a: "A",
-      b: "B",
-      c: "C",
-      d: "D",
-      1: "A",
-      2: "B",
-      3: "C",
-      4: "D",
-    };
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
-      const tag = target?.tagName?.toLowerCase();
-      if (tag === "input" || tag === "textarea" || target?.isContentEditable) return;
-
-      const opt = keyToOption[event.key.toLowerCase()];
-      if (!opt) return;
-
-      event.preventDefault();
-      handleSelect(opt);
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [answered, handleSelect]);
+  useKeyboardAnswers({
+    onAnswer: handleSelect,
+    disabled: answered || disabled,
+  });
 
   const handleTimeExpire = () => {
     if (!answered && !disabled) {

--- a/apps/web/src/hooks/use-keyboard-answers.test.ts
+++ b/apps/web/src/hooks/use-keyboard-answers.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useKeyboardAnswers } from "./use-keyboard-answers";
+
+describe("useKeyboardAnswers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("calls onAnswer with 'A' when A key is pressed", () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardAnswers({ onAnswer }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    expect(onAnswer).toHaveBeenCalledWith("A");
+  });
+
+  it("calls onAnswer with 'B' when B key is pressed", () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardAnswers({ onAnswer }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "b" }));
+    expect(onAnswer).toHaveBeenCalledWith("B");
+  });
+
+  it("calls onAnswer with 'C' when C key is pressed", () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardAnswers({ onAnswer }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "c" }));
+    expect(onAnswer).toHaveBeenCalledWith("C");
+  });
+
+  it("calls onAnswer with 'D' when D key is pressed", () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardAnswers({ onAnswer }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "d" }));
+    expect(onAnswer).toHaveBeenCalledWith("D");
+  });
+
+  it("calls onAnswer with numeric keys 1-4 mapped to A-D", () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardAnswers({ onAnswer }));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "1" }));
+    expect(onAnswer).toHaveBeenCalledWith("A");
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "2" }));
+    expect(onAnswer).toHaveBeenCalledWith("B");
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "3" }));
+    expect(onAnswer).toHaveBeenCalledWith("C");
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "4" }));
+    expect(onAnswer).toHaveBeenCalledWith("D");
+  });
+
+  it("does not call onAnswer when disabled is true", () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardAnswers({ onAnswer, disabled: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+
+  it("does not call onAnswer for non-answer keys", () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardAnswers({ onAnswer }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "e" }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+
+  it("does not call onAnswer when an input field is focused", () => {
+    const onAnswer = vi.fn();
+    renderHook(() => useKeyboardAnswers({ onAnswer }));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    expect(onAnswer).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+  });
+
+  it("calls the latest onAnswer callback when handler is captured by ref", () => {
+    const onAnswer1 = vi.fn();
+    const onAnswer2 = vi.fn();
+    const { rerender } = renderHook(
+      ({ onAnswer }) => useKeyboardAnswers({ onAnswer }),
+      { initialProps: { onAnswer: onAnswer1 } }
+    );
+
+    rerender({ onAnswer: onAnswer2 });
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    expect(onAnswer1).not.toHaveBeenCalled();
+    expect(onAnswer2).toHaveBeenCalledWith("A");
+  });
+});

--- a/apps/web/src/hooks/use-keyboard-answers.ts
+++ b/apps/web/src/hooks/use-keyboard-answers.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { AnswerOptionKey } from "@/components/game/answer-option";
+
+interface UseKeyboardAnswersOptions {
+  onAnswer: (option: AnswerOptionKey) => void;
+  disabled?: boolean;
+}
+
+export function useKeyboardAnswers({ onAnswer, disabled = false }: UseKeyboardAnswersOptions) {
+  const onAnswerRef = useRef(onAnswer);
+  onAnswerRef.current = onAnswer;
+
+  useEffect(() => {
+    if (disabled) return;
+
+    const keyToOption: Record<string, AnswerOptionKey | undefined> = {
+      a: "A",
+      b: "B",
+      c: "C",
+      d: "D",
+      1: "A",
+      2: "B",
+      3: "C",
+      4: "D",
+    };
+
+    const handler = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      if (tag === "input" || tag === "textarea" || target?.isContentEditable) return;
+
+      const option = keyToOption[event.key.toLowerCase()];
+      if (!option) return;
+
+      event.preventDefault();
+      onAnswerRef.current(option);
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [disabled]);
+}


### PR DESCRIPTION
## Description
Adds keyboard shortcuts for desktop power users - pressing A/B/C/D or 1/2/3/4 selects the corresponding answer option.

## Changes
- **useKeyboardAnswers hook**: Encapsulates A/B/C/D + 1/2/3/4 key binding with input focus guard and ref-based callback freshness
- **ChallengeRound**: Replaced inline keydown logic with useKeyboardAnswers hook
- **AnswerOption**: Badges have aria-hidden=true and hide on mobile via max-md:hidden
- **First-run tooltip**: 'Use A/B/C/D keys to answer faster' appears once, stored in localStorage, dismissible via X or Escape
- **Vitest tests**: 9 tests covering all keys, disabled state, input focus guard, and ref-based callback

Closes #533