### PR TITLE
feat(cache,gamification): Redis caching for leaderboard/challenges/badges and badge unlock modal

### DIFF
--- a/apps/api/src/lib/cache-tags.ts
+++ b/apps/api/src/lib/cache-tags.ts
@@ -1,0 +1,15 @@
+import { redis } from "./redis";
+
+export async function invalidateLeaderboardCache(): Promise<void> {
+  const keys = await redis.keys("leaderboard:*");
+  if (keys.length > 0) {
+    await redis.del(...keys);
+  }
+}
+
+export async function invalidateChallengesCache(): Promise<void> {
+  const keys = await redis.keys("challenges:active:*");
+  if (keys.length > 0) {
+    await redis.del(...keys);
+  }
+}

--- a/apps/api/src/routes/badges.cache.test.ts
+++ b/apps/api/src/routes/badges.cache.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockRedisGet = jest.fn();
+const mockRedisSet = jest.fn();
+const mockRedisDel = jest.fn();
+
+jest.mock("../lib/redis", () => ({
+  redis: {
+    get: mockRedisGet,
+    set: mockRedisSet,
+    del: mockRedisDel,
+  },
+}));
+
+const mockQuery = jest.fn();
+jest.mock("../db/index", () => ({ query: mockQuery }));
+
+jest.mock("../middleware/authenticate", () => ({
+  authenticate: (_req: any, _res: any, next: any) => {
+    _req.user = { sub: "admin-user", role: "admin" };
+    next();
+  },
+}));
+
+jest.mock("../middleware/require-admin", () => ({
+  requireAdmin: (req: any, _res: any, next: any) => {
+    if (!req.user || req.user.role !== "admin") {
+      const err: any = new Error("Forbidden");
+      err.status = 403;
+      throw err;
+    }
+    next();
+  },
+}));
+
+import express from "express";
+import request from "supertest";
+import router from "./badges";
+
+const app = express();
+app.use(express.json());
+app.use("/badges", router);
+
+// Admin app with admin user
+const adminApp = express();
+adminApp.use(express.json());
+adminApp.use("/badges", router);
+
+// Non-admin app
+const noAuthApp = express();
+noAuthApp.use(express.json());
+noAuthApp.use((req: any, _res: any, next: any) => {
+  req.user = { sub: "user-1", role: "user" };
+  next();
+});
+noAuthApp.use("/badges", router);
+
+const fakeBadges = [
+  { id: "b1", slug: "first-win", name: "First Win", description: "Win first challenge", iconUrl: null },
+];
+
+describe("badges cache", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("skips DB on second request within TTL (cache HIT)", async () => {
+    mockRedisGet.mockResolvedValueOnce(JSON.stringify(fakeBadges));
+
+    const res = await request(app).get("/badges");
+    expect(res.status).toBe(200);
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(res.headers["x-cache"]).toBe("HIT");
+    expect(res.body.badges).toHaveLength(1);
+  });
+
+  it("calls DB on cache MISS and caches the result", async () => {
+    mockRedisGet.mockResolvedValueOnce(null);
+    mockQuery.mockResolvedValueOnce({ rows: fakeBadges });
+    mockRedisSet.mockResolvedValueOnce("OK");
+
+    const res = await request(app).get("/badges");
+    expect(res.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockRedisSet).toHaveBeenCalledWith("badges:definitions", JSON.stringify(fakeBadges), "EX", 86400);
+    expect(res.headers["x-cache"]).toBe("MISS");
+  });
+
+  it("flush endpoint returns 204 and calls redis.del", async () => {
+    mockRedisDel.mockResolvedValueOnce(1);
+
+    const res = await request(adminApp).post("/badges/flush");
+    expect(res.status).toBe(204);
+    expect(mockRedisDel).toHaveBeenCalledWith("badges:definitions");
+  });
+
+  it("flush endpoint returns 403 for non-admin", async () => {
+    const res = await request(noAuthApp).post("/badges/flush");
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/api/src/routes/badges.ts
+++ b/apps/api/src/routes/badges.ts
@@ -1,0 +1,54 @@
+import { Router } from "express";
+import { redis } from "../lib/redis";
+import { authenticate } from "../middleware/authenticate";
+import { requireAdmin } from "../middleware/require-admin";
+
+const router = Router();
+
+const BADGES_CACHE_TTL_SEC = 86400;
+const BADGES_CACHE_KEY = "badges:definitions";
+
+interface BadgeDefinition {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  iconUrl?: string;
+}
+
+async function fetchBadgeDefinitionsFromDb(): Promise<BadgeDefinition[]> {
+  const { query } = await import("../db/index");
+  const result = await query<BadgeDefinition>(
+    `SELECT id, slug, name, description, icon_url AS "iconUrl" FROM badge_definitions ORDER BY name ASC`
+  );
+  return result.rows;
+}
+
+/**
+ * GET /api/badges
+ * Returns badge definitions. Cached in Redis for 24h.
+ */
+router.get("/", async (_req, res) => {
+  const cached = await redis.get(BADGES_CACHE_KEY);
+  if (cached !== null) {
+    res.setHeader("X-Cache", "HIT");
+    res.json({ badges: JSON.parse(cached) });
+    return;
+  }
+
+  const badges = await fetchBadgeDefinitionsFromDb();
+  await redis.set(BADGES_CACHE_KEY, JSON.stringify(badges), "EX", BADGES_CACHE_TTL_SEC);
+  res.setHeader("X-Cache", "MISS");
+  res.json({ badges });
+});
+
+/**
+ * POST /api/admin/cache/badges/flush
+ * Admin-only: flush the badges definitions cache.
+ */
+router.post("/flush", authenticate, requireAdmin, async (_req, res) => {
+  await redis.del(BADGES_CACHE_KEY);
+  res.status(204).send();
+});
+
+export default router;

--- a/apps/api/src/routes/challenges.cache.test.ts
+++ b/apps/api/src/routes/challenges.cache.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockRedisGet = jest.fn();
+const mockRedisSet = jest.fn();
+const mockRedisDel = jest.fn();
+const mockRedisKeys = jest.fn().mockResolvedValue([]);
+
+jest.mock("../lib/redis", () => ({
+  redis: {
+    get: mockRedisGet,
+    set: mockRedisSet,
+    del: mockRedisDel,
+    keys: mockRedisKeys,
+    exists: jest.fn().mockResolvedValue(0),
+  },
+}));
+
+jest.mock("../lib/metrics", () => ({ metrics: { inc: jest.fn() } }));
+
+const mockGetActiveChallengesCursor = jest.fn();
+jest.mock("../db/queries/challenges", () => ({
+  getActiveChallenges: jest.fn().mockResolvedValue([]),
+  getActiveChallengesCursor: mockGetActiveChallengesCursor,
+  getChallengeByIdAny: jest.fn(),
+  getChallengesByBrandId: jest.fn().mockResolvedValue([]),
+  getChallengeQuestions: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("../db/queries/brands", () => ({
+  getBrandById: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("../db/queries/sessions", () => ({
+  getLeaderboard: jest.fn().mockResolvedValue([]),
+  getArchivedLeaderboard: jest.fn().mockResolvedValue([]),
+  LEADERBOARD_SORTS: ["score", "earned"],
+}));
+
+jest.mock("../middleware/authenticate", () => ({
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+  authenticate: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock("../middleware/error", () => ({
+  createError: jest.fn((msg: string, code: number) => {
+    const e = new Error(msg) as any;
+    e.status = code;
+    return e;
+  }),
+}));
+
+jest.mock("../lib/cache", () => ({
+  withCoalescing: jest.fn((_key: string, _ttl: number, loader: () => Promise<unknown>) => loader()),
+}));
+
+jest.mock("../lib/config", () => ({ config: { HOT_WALLET_PUBLIC_KEY: "GTEST" } }));
+jest.mock("../db/index", () => ({ query: jest.fn().mockResolvedValue({ rows: [] }) }));
+
+import express from "express";
+import request from "supertest";
+import router from "./challenges";
+import { invalidateChallengesCache } from "../lib/cache-tags";
+
+const app = express();
+app.use(express.json());
+app.use("/challenges", router);
+
+describe("challenges cache", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetActiveChallengesCursor.mockResolvedValue({ challenges: [], nextCursor: null });
+  });
+
+  it("does not query DB when cache has a value (HIT)", async () => {
+    const cached = { challenges: [{ id: "c1" }], nextCursor: null };
+    mockRedisGet.mockResolvedValueOnce(JSON.stringify(cached));
+    (require("../lib/cache").withCoalescing as jest.Mock).mockImplementationOnce(
+      async (_key: string, _ttl: number, _loader: () => Promise<unknown>) => cached
+    );
+
+    const res = await request(app).get("/challenges");
+    expect(res.status).toBe(200);
+    expect(res.headers["x-cache"]).toBe("HIT");
+  });
+
+  it("queries DB on cache MISS", async () => {
+    mockRedisGet.mockResolvedValueOnce(null);
+
+    const res = await request(app).get("/challenges");
+    expect(res.status).toBe(200);
+    expect(mockGetActiveChallengesCursor).toHaveBeenCalled();
+    expect(res.headers["x-cache"]).toBe("MISS");
+  });
+
+  it("invalidateChallengesCache deletes all challenges:active:* keys", async () => {
+    mockRedisKeys.mockResolvedValueOnce(["challenges:active:global:start:20"]);
+    mockRedisDel.mockResolvedValueOnce(1);
+
+    await invalidateChallengesCache();
+    expect(mockRedisDel).toHaveBeenCalledWith("challenges:active:global:start:20");
+  });
+});

--- a/apps/api/src/routes/challenges.ts
+++ b/apps/api/src/routes/challenges.ts
@@ -17,10 +17,13 @@ import {
 import { optionalAuth, authenticate } from "../middleware/authenticate";
 import { createError } from "../middleware/error";
 import { withCoalescing } from "../lib/cache";
+import { redis } from "../lib/redis";
 import { config } from "../lib/config";
 import { query } from "../db/index";
 
 const router = Router();
+
+const CHALLENGES_CACHE_TTL_SEC = 10;
 
 const LeaderboardSortSchema = z.enum(LEADERBOARD_SORTS).default("score");
 
@@ -75,16 +78,16 @@ router.get("/", optionalAuth, async (req, res) => {
     return;
   }
 
-  const cacheKey = cursor
-    ? `challenges:cursor:${cursor}:${limit}`
-    : `challenges:cursor:first:${limit}`;
+  const cacheKey = `challenges:active:global:${cursor ?? 'start'}:${limit}`;
 
+  const cacheHit = await redis.get(cacheKey);
   const result = await withCoalescing(
     cacheKey,
-    60,
+    CHALLENGES_CACHE_TTL_SEC,
     () => getActiveChallengesCursor(cursor, limit)
   );
 
+  res.setHeader("X-Cache", cacheHit !== null ? "HIT" : "MISS");
   res.json({ data: result.challenges, nextCursor: result.nextCursor });
 });
 

--- a/apps/api/src/routes/leaderboard.cache.test.ts
+++ b/apps/api/src/routes/leaderboard.cache.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockRedisGet = jest.fn();
+const mockRedisSet = jest.fn();
+const mockRedisDel = jest.fn();
+
+jest.mock("../lib/redis", () => ({
+  redis: {
+    get: mockRedisGet,
+    set: mockRedisSet,
+    del: mockRedisDel,
+    keys: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+jest.mock("../lib/metrics", () => ({ metrics: { inc: jest.fn() } }));
+jest.mock("../lib/cache", () => ({
+  withCoalescing: jest.fn((_key: string, _ttl: number, loader: () => Promise<unknown>) => loader()),
+}));
+
+const mockGetLeaderboard = jest.fn();
+jest.mock("../db/queries/sessions", () => ({
+  getLeaderboard: mockGetLeaderboard,
+  getTopSessionsPerChallenge: jest.fn().mockResolvedValue([]),
+  getGlobalLeaderboardFromView: jest.fn().mockResolvedValue([]),
+  LEADERBOARD_SORTS: ["score", "earned"],
+}));
+
+jest.mock("../db/queries/challenges", () => ({
+  getActiveChallenges: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("../middleware/error", () => ({
+  createError: jest.fn((msg: string, code: number) => {
+    const e = new Error(msg) as any;
+    e.status = code;
+    return e;
+  }),
+}));
+
+import express from "express";
+import request from "supertest";
+import router from "./leaderboard";
+
+const app = express();
+app.use(express.json());
+app.use("/leaderboard", router);
+
+const fakeSession = {
+  id: "s1",
+  user_id: "u1",
+  username: "alice",
+  display_name: "Alice",
+  league: "gold",
+  avatar_url: null,
+  total_score: 300,
+  total_earned_usdc: "1.0",
+  completed_at: null,
+};
+
+describe("leaderboard cache", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns cached response and does not call DB on cache HIT", async () => {
+    const cached = {
+      sessions: [{ rank: 1, userId: "u1", username: "alice", displayName: "Alice", league: "gold", avatarUrl: null, totalScore: 300, totalEarned: "1.0", endedAt: null }],
+      data: [],
+      nextCursor: null,
+    };
+    mockRedisGet.mockResolvedValueOnce(JSON.stringify(cached));
+
+    const res = await request(app).get("/leaderboard/challenge-1");
+    expect(res.status).toBe(200);
+    expect(mockGetLeaderboard).not.toHaveBeenCalled();
+    expect(res.headers["x-cache"]).toBe("HIT");
+  });
+
+  it("calls DB on cache MISS and stores result", async () => {
+    mockRedisGet.mockResolvedValueOnce(null);
+    mockRedisSet.mockResolvedValueOnce("OK");
+    mockGetLeaderboard.mockResolvedValueOnce([fakeSession]);
+
+    const res = await request(app).get("/leaderboard/challenge-1");
+    expect(res.status).toBe(200);
+    expect(mockGetLeaderboard).toHaveBeenCalledTimes(1);
+    expect(mockRedisSet).toHaveBeenCalled();
+    expect(res.headers["x-cache"]).toBe("MISS");
+  });
+
+  it("sets X-Cache: HIT header on cache hit", async () => {
+    const cached = { sessions: [], data: [], nextCursor: null };
+    mockRedisGet.mockResolvedValueOnce(JSON.stringify(cached));
+
+    const res = await request(app).get("/leaderboard/challenge-99");
+    expect(res.headers["x-cache"]).toBe("HIT");
+  });
+});

--- a/apps/api/src/routes/leaderboard.ts
+++ b/apps/api/src/routes/leaderboard.ts
@@ -9,9 +9,12 @@ import {
   type LeaderboardSort,
 } from "../db/queries/sessions";
 import { withCoalescing } from "../lib/cache";
+import { redis } from "../lib/redis";
 import { createError } from "../middleware/error";
 
 const router = Router();
+
+const LEADERBOARD_CACHE_TTL_SEC = 30;
 
 // Keep leaderboard ORDER BY clauses static or selected from this allowlist only.
 // User query params must never be concatenated directly into SQL strings.
@@ -187,6 +190,16 @@ router.get("/:challengeId", async (req, res) => {
     cursor: z.string().optional(),
   }).parse(req.query);
 
+  const cacheKey = `leaderboard:${sortBy}:${req.params.challengeId}:${limit}:${offset}`;
+
+  // Check cache first
+  const cachedValue = await redis.get(cacheKey);
+  if (cachedValue !== null) {
+    res.setHeader("X-Cache", "HIT");
+    res.json(JSON.parse(cachedValue));
+    return;
+  }
+
   // cursor is last seen total_score,encoded as just the score value
   // We fetch limit+1 to detect if there are more
   let cursorScore: number | undefined;
@@ -203,8 +216,8 @@ router.get("/:challengeId", async (req, res) => {
   let filtered = sessions;
   if (cursorScore !== undefined && cursorId !== undefined) {
     filtered = sessions.filter(s =>
-      s.total_score < cursorScore ||
-      (s.total_score === cursorScore && s.id > cursorId)
+      s.total_score < cursorScore! ||
+      (s.total_score === cursorScore && s.id > cursorId!)
     );
   }
 
@@ -226,11 +239,15 @@ router.get("/:challengeId", async (req, res) => {
     endedAt: s.completed_at,
   }));
 
-  res.json({
+  const responseBody = {
     sessions: mappedSessions,
     data: mappedSessions,
     nextCursor: hasMore ? nextCursor : null,
-  });
+  };
+
+  await redis.set(cacheKey, JSON.stringify(responseBody), "EX", LEADERBOARD_CACHE_TTL_SEC);
+  res.setHeader("X-Cache", "MISS");
+  res.json(responseBody);
 });
 
 export default router;

--- a/apps/web/src/components/gamification/badge-unlock-modal.test.tsx
+++ b/apps/web/src/components/gamification/badge-unlock-modal.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BadgeUnlockModal, type Badge } from "./badge-unlock-modal";
+
+// Mock sessionStorage
+const sessionStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    clear: () => { store = {}; },
+  };
+})();
+Object.defineProperty(window, "sessionStorage", { value: sessionStorageMock });
+
+const badge1: Badge = { id: "b1", name: "First Win", description: "You won your first challenge!", iconUrl: undefined };
+const badge2: Badge = { id: "b2", name: "Streak Master", description: "7-day streak!", iconUrl: undefined };
+
+describe("BadgeUnlockModal", () => {
+  beforeEach(() => {
+    sessionStorageMock.clear();
+  });
+
+  it("does not render when badges is empty", () => {
+    const { container } = render(<BadgeUnlockModal badges={[]} onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders badge name and description", () => {
+    render(<BadgeUnlockModal badges={[badge1]} onClose={() => {}} />);
+    expect(screen.getByText("First Win")).toBeTruthy();
+    expect(screen.getByText("You won your first challenge!")).toBeTruthy();
+  });
+
+  it("share link uses correct badge name", () => {
+    render(<BadgeUnlockModal badges={[badge1]} onClose={() => {}} />);
+    const link = screen.getByRole("link", { name: /Share on X/i });
+    expect(link.getAttribute("href")).toContain(encodeURIComponent("First Win"));
+    expect(link.getAttribute("href")).toContain("x.com/intent/tweet");
+  });
+
+  it("onClose called on close button click", () => {
+    const onClose = vi.fn();
+    vi.useFakeTimers();
+    render(<BadgeUnlockModal badges={[badge1]} onClose={onClose} />);
+    const closeBtn = screen.getByRole("button", { name: /close/i });
+    fireEvent.click(closeBtn);
+    vi.advanceTimersByTime(400);
+    expect(onClose).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/components/gamification/badge-unlock-modal.tsx
+++ b/apps/web/src/components/gamification/badge-unlock-modal.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import * as React from "react";
+
+export interface Badge {
+  id: string;
+  name: string;
+  description: string;
+  iconUrl?: string;
+}
+
+interface BadgeUnlockModalProps {
+  badges: Badge[];
+  onClose: () => void;
+}
+
+function isAlreadyDismissed(badgeId: string): boolean {
+  try {
+    return sessionStorage.getItem(`dismissed_badges_${badgeId}`) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function markDismissed(badgeId: string): void {
+  try {
+    sessionStorage.setItem(`dismissed_badges_${badgeId}`, "true");
+  } catch {
+    // ignore
+  }
+}
+
+export function BadgeUnlockModal({ badges, onClose }: BadgeUnlockModalProps) {
+  const [currentIndex, setCurrentIndex] = React.useState(0);
+  const [visible, setVisible] = React.useState(false);
+
+  // Filter out already-dismissed badges
+  const undismissed = React.useMemo(
+    () => badges.filter((b) => !isAlreadyDismissed(b.id)),
+    [badges]
+  );
+
+  React.useEffect(() => {
+    if (undismissed.length > 0) {
+      // Small delay to allow CSS transition
+      const t = setTimeout(() => setVisible(true), 10);
+      return () => clearTimeout(t);
+    }
+  }, [undismissed.length]);
+
+  React.useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") handleClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  });
+
+  function handleClose() {
+    undismissed.forEach((b) => markDismissed(b.id));
+    setVisible(false);
+    setTimeout(onClose, 310);
+  }
+
+  if (undismissed.length === 0) return null;
+
+  const badge = undismissed[currentIndex];
+
+  function goPrev() {
+    setCurrentIndex((i) => Math.max(0, i - 1));
+  }
+
+  function goNext() {
+    setCurrentIndex((i) => Math.min(undismissed.length - 1, i + 1));
+  }
+
+  const shareUrl = `https://x.com/intent/tweet?text=I+just+earned+${encodeURIComponent(badge.name)}+on+StreamFi!`;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        onClick={handleClose}
+        style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(0,0,0,0.5)",
+          zIndex: 999,
+        }}
+      />
+      {/* Modal */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Badge unlocked"
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          zIndex: 1000,
+          background: "#fff",
+          borderRadius: "16px 16px 0 0",
+          padding: "24px",
+          transform: visible ? "translateY(0)" : "translateY(100%)",
+          transition: "transform 300ms ease-out",
+          textAlign: "center",
+        }}
+      >
+        <button
+          aria-label="Close"
+          onClick={handleClose}
+          style={{
+            position: "absolute",
+            top: 12,
+            right: 12,
+            background: "none",
+            border: "none",
+            fontSize: 20,
+            cursor: "pointer",
+          }}
+        >
+          ×
+        </button>
+
+        <h2 style={{ marginBottom: 8 }}>Badge Unlocked!</h2>
+
+        {badge.iconUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={badge.iconUrl}
+            alt={badge.name}
+            style={{ width: 80, height: 80, margin: "0 auto 12px", display: "block" }}
+          />
+        ) : (
+          <div
+            aria-label={badge.name}
+            style={{
+              width: 80,
+              height: 80,
+              background: "#e2e8f0",
+              borderRadius: "50%",
+              margin: "0 auto 12px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 32,
+            }}
+          >
+            🏅
+          </div>
+        )}
+
+        <h3 style={{ margin: "8px 0 4px" }}>{badge.name}</h3>
+        <p style={{ margin: "0 0 16px", color: "#666" }}>{badge.description}</p>
+
+        <a
+          href={shareUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            display: "inline-block",
+            padding: "10px 20px",
+            background: "#000",
+            color: "#fff",
+            borderRadius: 8,
+            textDecoration: "none",
+            marginBottom: 12,
+          }}
+        >
+          Share on X
+        </a>
+
+        {undismissed.length > 1 && (
+          <div style={{ display: "flex", justifyContent: "center", gap: 12, marginTop: 8 }}>
+            <button onClick={goPrev} disabled={currentIndex === 0} aria-label="Previous badge">
+              ‹ Prev
+            </button>
+            <span>
+              {currentIndex + 1} / {undismissed.length}
+            </span>
+            <button onClick={goNext} disabled={currentIndex === undismissed.length - 1} aria-label="Next badge">
+              Next ›
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Redis read-through caching for three high-traffic endpoints and a badge unlock modal component.

## Changes

### #539 — Leaderboard Redis cache (30s TTL)
- `apps/api/src/routes/leaderboard.ts`: cache key encodes `sortBy:challengeId:limit:offset`; `X-Cache: HIT/MISS` header; 30s TTL via `LEADERBOARD_CACHE_TTL_SEC`
- `apps/api/src/lib/cache-tags.ts`: `invalidateLeaderboardCache()` deletes all `leaderboard:*` keys
- `apps/api/src/routes/leaderboard.cache.test.ts`: 3 tests (HIT path, MISS path, header)

### #540 — Challenges list Redis cache (10s TTL)
- `apps/api/src/routes/challenges.ts`: cache key `challenges:active:*`; TTL reduced to `CHALLENGES_CACHE_TTL_SEC = 10`; `X-Cache` header added
- `apps/api/src/lib/cache-tags.ts`: `invalidateChallengesCache()` for status-change invalidation
- `apps/api/src/routes/challenges.cache.test.ts`: 3 tests

### #541 — Badge definitions Redis cache (24h TTL)
- `apps/api/src/routes/badges.ts`: `GET /api/badges` with `badges:definitions` key and 86400s TTL; `POST /api/admin/cache/badges/flush` (admin-only, 204)
- `apps/api/src/routes/badges.cache.test.ts`: 4 tests (HIT, MISS, flush 204, flush 403)

### #538 — Badge unlock modal
- `apps/web/src/components/gamification/badge-unlock-modal.tsx`: bottom-sheet slide-in (300ms ease-out), carousel for multiple badges, Share on X deep link, Escape/backdrop dismiss, sessionStorage dismissed tracking
- `apps/web/src/components/gamification/badge-unlock-modal.test.tsx`: 4 tests

closes #539
closes #540
closes #541
closes #538