### PR TITLE
feat: cookie hardening, DNS prefetch control, CSP nonce enforcement, and challenge discovery page

### DIFF
--- a/apps/api/src/db/queries/challenges.ts
+++ b/apps/api/src/db/queries/challenges.ts
@@ -180,6 +180,64 @@ export async function getActiveChallenges(
   return { challenges, nextCursor };
 }
 
+export async function getFilteredChallenges(opts: {
+  status?: "active" | "upcoming" | "ended";
+  minPoolUsdc?: number;
+  endBefore?: string;
+  cursor?: string;
+  limit?: number;
+}): Promise<{ challenges: Challenge[]; nextCursor: string | null }> {
+  const { status, minPoolUsdc, endBefore, cursor, limit = 20 } = opts;
+
+  const conditions: string[] = ["c.deleted_at IS NULL", "b.deleted_at IS NULL"];
+  const params: unknown[] = [];
+
+  if (status === "active") {
+    conditions.push("c.status = 'active'");
+  } else if (status === "upcoming") {
+    conditions.push("c.status = 'pending_deposit'");
+  } else if (status === "ended") {
+    conditions.push("c.status IN ('ended', 'settled', 'payout_failed', 'cancelled', 'refunded')");
+  } else {
+    conditions.push(
+      "c.status IN ('active', 'pending_deposit', 'ended', 'settled', 'payout_failed', 'cancelled', 'refunded')"
+    );
+  }
+
+  if (minPoolUsdc !== undefined) {
+    params.push(String(Math.round(minPoolUsdc * 10_000_000)));
+    conditions.push(`c.pool_amount_stroops >= $${params.length}`);
+  }
+
+  if (endBefore) {
+    params.push(endBefore);
+    conditions.push(`c.ends_at < $${params.length}`);
+  }
+
+  if (cursor) {
+    params.push(cursor);
+    conditions.push(`c.id > $${params.length}::uuid`);
+  }
+
+  params.push(limit + 1);
+
+  const result = await query<Challenge>(
+    `SELECT c.*, (c.pool_amount_stroops::numeric / 10000000)::numeric(20,7)::text AS pool_amount_usdc,
+            b.name AS brand_name, b.logo_url, b.primary_color, b.secondary_color
+     FROM challenges c
+     JOIN brands b ON c.brand_id = b.id
+     WHERE ${conditions.join(" AND ")}
+     ORDER BY c.pool_amount_stroops DESC, c.id DESC
+     LIMIT $${params.length}`,
+    params
+  );
+
+  const hasMore = result.rows.length > limit;
+  const challenges = result.rows.slice(0, limit);
+  const nextCursor = hasMore && challenges.length > 0 ? challenges[challenges.length - 1].id : null;
+  return { challenges, nextCursor };
+}
+
 export async function getChallengesByBrandId(
   brandId: string,
   limit = 20,

--- a/apps/api/src/lib/cookies.lint.test.ts
+++ b/apps/api/src/lib/cookies.lint.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative } from "path";
+
+function collectTsFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...collectTsFiles(full));
+    } else if (full.endsWith(".ts") || full.endsWith(".tsx")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const SRC_DIR = join(__dirname, "..");
+const HELPER_PATH = join(__dirname, "cookies.ts");
+
+describe("cookie security lint", () => {
+  it("no raw res.cookie() calls exist outside lib/cookies.ts", () => {
+    const violations: string[] = [];
+
+    for (const file of collectTsFiles(SRC_DIR)) {
+      if (file === HELPER_PATH) continue;
+
+      const src = readFileSync(file, "utf-8");
+      if (/res\.cookie\s*\(/.test(src)) {
+        violations.push(relative(SRC_DIR, file));
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/api/src/lib/cookies.ts
+++ b/apps/api/src/lib/cookies.ts
@@ -1,0 +1,26 @@
+import type { Response, CookieOptions } from "express";
+
+type SecureCookieOptions = Omit<CookieOptions, "secure" | "sameSite"> & {
+  httpOnly?: boolean;
+  sameSite?: "strict" | "none";
+};
+
+/**
+ * Set a response cookie with Secure and SameSite=Strict enforced.
+ * httpOnly defaults to true; pass false only when JS read access is required
+ * and the call site documents the reason.
+ */
+export function setCookieSecure(
+  res: Response,
+  name: string,
+  value: string,
+  options: SecureCookieOptions = {}
+): void {
+  const { httpOnly = true, sameSite = "strict", ...rest } = options;
+  res.cookie(name, value, {
+    ...rest,
+    secure: true,
+    httpOnly,
+    sameSite,
+  });
+}

--- a/apps/api/src/middleware/referral-attribution.ts
+++ b/apps/api/src/middleware/referral-attribution.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from "express";
 import { redis } from "../lib/redis";
 import { computeFingerprint } from "../lib/fingerprint";
+import { setCookieSecure } from "../lib/cookies";
 
 const PENDING_REFERRAL_TTL_SECONDS = 30 * 24 * 60 * 60;
 
@@ -43,11 +44,8 @@ export async function referralAttributionMiddleware(
       "EX",
       PENDING_REFERRAL_TTL_SECONDS,
     );
-    res.cookie("ref", code, {
-      httpOnly: true,
-      sameSite: "lax",
+    setCookieSecure(res, "ref", code, {
       maxAge: PENDING_REFERRAL_TTL_SECONDS * 1000,
-      secure: req.secure,
     });
 
     next();

--- a/apps/api/src/routes/challenges.ts
+++ b/apps/api/src/routes/challenges.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   getActiveChallenges,
   getActiveChallengesCursor,
+  getFilteredChallenges,
   getChallengeByIdAny,
   getChallengesByBrandId,
   getChallengeQuestions,
@@ -49,20 +50,26 @@ async function getRequiredConfirmations(): Promise<number> {
   return result.rows[0]?.value?.confirmations ?? 5;
 }
 
+const ChallengeFilterSchema = CursorQuerySchema.extend({
+  brandId: z.string().uuid().optional(),
+  status: z.enum(["active", "upcoming", "ended"]).optional(),
+  min_pool: z.coerce.number().min(0).optional(),
+  end_before: z.string().datetime({ offset: true }).optional(),
+});
+
 /**
  * GET /challenges
- * List active challenges (public). Supports keyset cursor pagination via ?cursor.
+ * List challenges (public). Supports keyset cursor pagination via ?cursor.
+ * Optional filters: ?status=, ?min_pool= (USDC), ?end_before= (ISO datetime).
  * Legacy ?offset parameter is accepted but ignored; clients should migrate to ?cursor.
  */
 router.get("/", optionalAuth, async (req, res) => {
-  const parsed = CursorQuerySchema.extend({
-    brandId: z.string().uuid().optional(),
-  }).safeParse(req.query);
+  const parsed = ChallengeFilterSchema.safeParse(req.query);
   if (!parsed.success) {
     throw createError("Invalid query parameters", 400, "INVALID_QUERY");
   }
 
-  const { brandId, limit, cursor } = parsed.data;
+  const { brandId, limit, cursor, status, min_pool, end_before } = parsed.data;
 
   if (brandId) {
     const { challenges, nextCursor } = await getChallengesByBrandId(brandId, limit, cursor);
@@ -70,17 +77,29 @@ router.get("/", optionalAuth, async (req, res) => {
     return;
   }
 
-  const cacheKey = `challenges:active:global:${cursor ?? 'start'}:${limit}`;
+  const hasFilters = status !== undefined || min_pool !== undefined || end_before !== undefined;
 
-  const cacheHit = await redis.get(cacheKey);
-  const result = await withCoalescing(
-    cacheKey,
-    CHALLENGES_CACHE_TTL_SEC,
-    () => getActiveChallengesCursor(cursor, limit)
-  );
+  if (!hasFilters) {
+    const cacheKey = `challenges:active:global:${cursor ?? "start"}:${limit}`;
+    const cacheHit = await redis.get(cacheKey);
+    const result = await withCoalescing(
+      cacheKey,
+      CHALLENGES_CACHE_TTL_SEC,
+      () => getActiveChallengesCursor(cursor, limit)
+    );
+    res.setHeader("X-Cache", cacheHit !== null ? "HIT" : "MISS");
+    res.json({ data: result.challenges, nextCursor: result.nextCursor });
+    return;
+  }
 
-  res.setHeader("X-Cache", cacheHit !== null ? "HIT" : "MISS");
-  res.json({ data: result.challenges, nextCursor: result.nextCursor });
+  const { challenges, nextCursor } = await getFilteredChallenges({
+    status,
+    minPoolUsdc: min_pool,
+    endBefore: end_before,
+    cursor,
+    limit,
+  });
+  res.json({ data: challenges, nextCursor });
 });
 
 /**

--- a/apps/web/src/app/(game)/challenges/loading.tsx
+++ b/apps/web/src/app/(game)/challenges/loading.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function ChallengesLoading() {
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-12">
+      <div className="h-9 w-56 rounded bg-[var(--muted)] mb-2 animate-pulse" />
+      <div className="h-5 w-80 rounded bg-[var(--muted)] mb-8 animate-pulse" />
+      <div className="mb-6 flex flex-wrap gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-10 w-28 rounded bg-[var(--muted)] animate-pulse" />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="animate-pulse">
+            <CardHeader>
+              <div className="h-12 w-32 rounded bg-[var(--muted)] mb-2" />
+              <div className="h-5 w-40 rounded bg-[var(--muted)]" />
+            </CardHeader>
+            <CardContent>
+              <div className="h-4 w-24 rounded bg-[var(--muted)] mb-3" />
+              <div className="h-10 w-full rounded bg-[var(--muted)]" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/(game)/challenges/page.tsx
+++ b/apps/web/src/app/(game)/challenges/page.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { api } from "@/lib/api";
+import { formatUsdc } from "@/lib/utils";
+import { generateColoredBlurPlaceholder } from "@/lib/blur-placeholder";
+import type { Challenge } from "@/lib/api";
+
+const PAGE_SIZE = 20;
+
+type StatusFilter = "all" | "active" | "upcoming" | "ended";
+
+function timeRemaining(endsAt: string | null): string {
+  if (!endsAt) return "";
+  const ms = new Date(endsAt).getTime() - Date.now();
+  if (ms <= 0) return "Ended";
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  return h > 0 ? `${h}h ${m}m left` : `${m}m left`;
+}
+
+function statusBadgeVariant(status: string): "default" | "secondary" | "outline" {
+  if (status === "active") return "default";
+  if (status === "pending_deposit") return "secondary";
+  return "outline";
+}
+
+function statusLabel(status: string): string {
+  if (status === "active") return "Active";
+  if (status === "pending_deposit") return "Upcoming";
+  return "Ended";
+}
+
+export default function ChallengesDiscoveryPage() {
+  const [challenges, setChallenges] = useState<Challenge[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [minPool, setMinPool] = useState("");
+  const [endBefore, setEndBefore] = useState("");
+
+  const buildParams = useCallback(
+    (cursor?: string) => {
+      const p = new URLSearchParams({ limit: String(PAGE_SIZE) });
+      if (statusFilter !== "all") p.set("status", statusFilter);
+      if (minPool) p.set("min_pool", minPool);
+      if (endBefore) p.set("end_before", new Date(endBefore).toISOString());
+      if (cursor) p.set("cursor", cursor);
+      return p;
+    },
+    [statusFilter, minPool, endBefore]
+  );
+
+  const loadPage = useCallback(
+    async (cursor?: string) => {
+      const res = await api.get(`/challenges?${buildParams(cursor).toString()}`);
+      return {
+        page: res.data.data as Challenge[],
+        nextCursor: res.data.nextCursor as string | null,
+      };
+    },
+    [buildParams]
+  );
+
+  const loadInitial = useCallback(async () => {
+    setLoading(true);
+    setFailed(false);
+    try {
+      const { page, nextCursor: nc } = await loadPage();
+      setChallenges(page);
+      setNextCursor(nc);
+    } catch {
+      setFailed(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadPage]);
+
+  useEffect(() => {
+    void loadInitial();
+  }, [loadInitial]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !nextCursor) return;
+    setLoadingMore(true);
+    try {
+      const { page, nextCursor: nc } = await loadPage(nextCursor);
+      setChallenges((prev) => [...prev, ...page]);
+      setNextCursor(nc);
+    } catch {
+      /* ignore incremental failures */
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadingMore, nextCursor, loadPage]);
+
+  function clearFilters() {
+    setStatusFilter("all");
+    setMinPool("");
+    setEndBefore("");
+  }
+
+  const hasFilters = statusFilter !== "all" || minPool !== "" || endBefore !== "";
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-12">
+      <h1 className="mb-2 text-3xl font-bold">Challenges</h1>
+      <p className="mb-8 text-[var(--muted-foreground)]">
+        Browse and filter brand challenges — earn USDC by topping the leaderboard
+      </p>
+
+      {/* Filter controls */}
+      <div className="mb-6 flex flex-wrap items-end gap-3">
+        <div className="flex gap-2">
+          {(["all", "active", "upcoming", "ended"] as StatusFilter[]).map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`rounded-full border px-3 py-1 text-sm capitalize transition-colors ${
+                statusFilter === s
+                  ? "border-[var(--primary)] bg-[var(--primary)] text-white"
+                  : "border-[var(--border)] hover:border-[var(--primary)]"
+              }`}
+            >
+              {s === "all" ? "All" : s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-1">
+          <label className="text-sm text-[var(--muted-foreground)]">Min pool (USDC)</label>
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            value={minPool}
+            onChange={(e) => setMinPool(e.target.value)}
+            placeholder="e.g. 100"
+            className="w-28 rounded border border-[var(--border)] bg-transparent px-2 py-1 text-sm"
+          />
+        </div>
+
+        <div className="flex items-center gap-1">
+          <label className="text-sm text-[var(--muted-foreground)]">Ends before</label>
+          <input
+            type="date"
+            value={endBefore}
+            onChange={(e) => setEndBefore(e.target.value)}
+            className="rounded border border-[var(--border)] bg-transparent px-2 py-1 text-sm"
+          />
+        </div>
+
+        {hasFilters && (
+          <button
+            onClick={clearFilters}
+            className="text-sm text-[var(--muted-foreground)] underline hover:text-[var(--foreground)]"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Results */}
+      {loading ? (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="animate-pulse">
+              <CardHeader>
+                <div className="h-12 w-32 rounded bg-[var(--muted)] mb-2" />
+                <div className="h-5 w-40 rounded bg-[var(--muted)]" />
+              </CardHeader>
+              <CardContent>
+                <div className="h-10 w-full rounded bg-[var(--muted)]" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : failed && challenges.length === 0 ? (
+        <div className="text-center py-16">
+          <p className="mb-4 text-[var(--muted-foreground)]">Couldn&apos;t load challenges. Refresh and try again.</p>
+          <Button variant="outline" onClick={loadInitial}>Retry</Button>
+        </div>
+      ) : challenges.length === 0 ? (
+        <div className="text-center py-16">
+          <p className="mb-4 text-[var(--muted-foreground)]">No challenges match the active filters.</p>
+          {hasFilters && (
+            <Button variant="outline" onClick={clearFilters}>Clear filters</Button>
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {challenges.map((c, index) => {
+              const remaining = timeRemaining(c.ends_at ?? null);
+              return (
+                <Card key={c.id} className="transition-shadow hover:shadow-lg">
+                  <CardHeader>
+                    <div className="flex items-center justify-between">
+                      {c.logo_url ? (
+                        <Image
+                          src={c.logo_url}
+                          alt={c.brand_name ?? "Brand logo"}
+                          width={160}
+                          height={48}
+                          sizes="160px"
+                          className="h-12 w-auto object-contain"
+                          loading={index < 3 ? "eager" : "lazy"}
+                          placeholder="blur"
+                          blurDataURL={generateColoredBlurPlaceholder(c.primary_color)}
+                          priority={index < 3}
+                        />
+                      ) : (
+                        <div
+                          className="h-12 w-12 rounded-lg"
+                          style={{ backgroundColor: c.primary_color ?? "var(--primary)" }}
+                        />
+                      )}
+                      <Badge variant={statusBadgeVariant(c.status)}>
+                        {statusLabel(c.status)}
+                      </Badge>
+                    </div>
+                    <CardTitle>{c.brand_name ?? "Untitled brand"}</CardTitle>
+                    <CardDescription>
+                      Prize pool: {formatUsdc(c.pool_amount_usdc)} USDC
+                      {c.participant_count !== undefined && (
+                        <> · {c.participant_count} players</>
+                      )}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    {remaining && (
+                      <p className="mb-3 text-sm text-[var(--muted-foreground)]">{remaining}</p>
+                    )}
+                    <Link href={`/challenge/${c.id}`}>
+                      <Button
+                        className="w-full"
+                        style={{ backgroundColor: c.primary_color ?? undefined }}
+                        disabled={c.status !== "active"}
+                      >
+                        {c.status === "active" ? "Accept Challenge" : statusLabel(c.status)}
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+
+          {nextCursor && (
+            <div className="mt-8 flex justify-center">
+              <Button variant="outline" onClick={loadMore} disabled={loadingMore}>
+                {loadingMore ? "Loading…" : "Load more"}
+              </Button>
+            </div>
+          )}
+
+          {!nextCursor && challenges.length > 0 && (
+            <p className="mt-8 text-center text-sm text-[var(--muted-foreground)]">
+              You&apos;ve seen all {challenges.length} challenge{challenges.length !== 1 ? "s" : ""}
+            </p>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -90,6 +90,10 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   // Inject nonce into response headers for use in layout/components
   response.headers.set("x-nonce", nonce);
 
+  // Prevent browsers from pre-resolving hostnames found in page content.
+  // DNS prefetch can leak back-end infrastructure topology to network observers.
+  response.headers.set("X-DNS-Prefetch-Control", "off");
+
   // Set CSP header in Report-Only mode
   // After 7 days of monitoring violations, switch to enforce mode by removing "-Report-Only"
   const cspHeader = buildCSPHeader(nonce);

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -32,7 +32,7 @@ function buildCSPHeader(nonce: string): string {
 
   return [
     `default-src 'self'`,
-    `script-src 'self' 'nonce-${nonce}'`,
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
     `img-src 'self' data: https://${cdnHost}`,
     `font-src 'self' https://fonts.gstatic.com`,
     `style-src 'self' https://fonts.googleapis.com 'unsafe-inline'`,
@@ -94,10 +94,8 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   // DNS prefetch can leak back-end infrastructure topology to network observers.
   response.headers.set("X-DNS-Prefetch-Control", "off");
 
-  // Set CSP header in Report-Only mode
-  // After 7 days of monitoring violations, switch to enforce mode by removing "-Report-Only"
   const cspHeader = buildCSPHeader(nonce);
-  response.headers.set("Content-Security-Policy-Report-Only", cspHeader);
+  response.headers.set("Content-Security-Policy", cspHeader);
 
   return response;
 }

--- a/e2e/tests/challenges-discovery.spec.ts
+++ b/e2e/tests/challenges-discovery.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+test("challenges discovery page renders and filter controls are visible", async ({ page }) => {
+  await page.goto("/challenges");
+
+  await expect(page.getByRole("heading", { name: "Challenges" })).toBeVisible();
+
+  await expect(page.getByRole("button", { name: "Active" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Upcoming" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Ended" })).toBeVisible();
+});
+
+test("active filter shows only active challenges", async ({ page }) => {
+  await page.goto("/challenges");
+
+  await page.getByRole("button", { name: "Active" }).click();
+
+  const cards = page.locator('[data-slot="card"]');
+  const count = await cards.count();
+
+  if (count > 0) {
+    const badges = page.getByText("Active");
+    await expect(badges.first()).toBeVisible();
+  } else {
+    await expect(page.getByText("No challenges match the active filters.")).toBeVisible();
+  }
+});
+
+test("clear filters button resets state", async ({ page }) => {
+  await page.goto("/challenges");
+
+  await page.getByRole("button", { name: "Ended" }).click();
+  await expect(page.getByRole("button", { name: "Clear filters" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Clear filters" }).click();
+  await expect(page.getByRole("button", { name: "Clear filters" })).not.toBeVisible();
+});

--- a/e2e/tests/cookie-attributes.spec.ts
+++ b/e2e/tests/cookie-attributes.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+test("referral tracking cookie carries Secure; HttpOnly; SameSite=Strict", async ({ request }) => {
+  const response = await request.get("/?ref=ABC123");
+
+  const setCookie = response.headers()["set-cookie"] ?? "";
+  const cookies = (Array.isArray(setCookie) ? setCookie : [setCookie]).filter(Boolean);
+
+  const refCookie = cookies.find((c) => c.startsWith("ref="));
+  if (refCookie) {
+    expect(refCookie.toLowerCase()).toContain("secure");
+    expect(refCookie.toLowerCase()).toContain("httponly");
+    expect(refCookie.toLowerCase()).toContain("samesite=strict");
+  }
+});

--- a/e2e/tests/csp-nonce.spec.ts
+++ b/e2e/tests/csp-nonce.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("home page Content-Security-Policy header contains nonce and lacks unsafe-inline in script-src", async ({
+  page,
+}) => {
+  const response = await page.goto("/");
+  const csp = response?.headers()["content-security-policy"] ?? "";
+
+  expect(csp).toBeTruthy();
+
+  const scriptSrc = csp
+    .split(";")
+    .map((d) => d.trim())
+    .find((d) => d.startsWith("script-src"));
+
+  expect(scriptSrc).toBeDefined();
+  expect(scriptSrc).toMatch(/nonce-[A-Za-z0-9+/=]+/);
+  expect(scriptSrc).not.toContain("'unsafe-inline'");
+  expect(scriptSrc).toContain("'strict-dynamic'");
+});

--- a/e2e/tests/dns-prefetch.spec.ts
+++ b/e2e/tests/dns-prefetch.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("web page responses include X-DNS-Prefetch-Control: off", async ({ page }) => {
+  const response = await page.goto("/");
+  expect(response?.headers()["x-dns-prefetch-control"]).toBe("off");
+});
+
+test("API health endpoint includes X-DNS-Prefetch-Control: off", async ({ request }) => {
+  const response = await request.get(
+    `${process.env.PLAYWRIGHT_API_URL ?? "http://localhost:3001"}/health`
+  );
+  expect(response.headers()["x-dns-prefetch-control"]).toBe("off");
+});


### PR DESCRIPTION
Closes #507
Closes #510
Closes #512
Closes #514

## What changed

**#507 — Cookie security (Secure; HttpOnly; SameSite=Strict)**
- Added `apps/api/src/lib/cookies.ts` with `setCookieSecure()` helper that enforces `Secure=true`, `HttpOnly=true`, and `SameSite=Strict` on every call
- Migrated `referral-attribution.ts` from raw `res.cookie()` to the helper — upgrades `SameSite` from `lax` to `strict` and removes the conditional `secure: req.secure`
- Added `cookies.lint.test.ts` (Vitest) that scans `apps/api/src/` and asserts no raw `res.cookie()` calls exist outside the helper
- Added `e2e/tests/cookie-attributes.spec.ts` Playwright test checking Set-Cookie attributes on the referral cookie

**#510 — X-DNS-Prefetch-Control: off**
- Added `X-DNS-Prefetch-Control: off` to every Next.js response in `apps/web/src/middleware.ts`; the API already sends this via Helmet's `xDnsPrefetchControl`
- Added `e2e/tests/dns-prefetch.spec.ts` Playwright test asserting the header is present on both web and API responses

**#512 — Per-request CSP nonce, remove unsafe-inline**
- Switched `Content-Security-Policy-Report-Only` to enforced `Content-Security-Policy` in `apps/web/src/middleware.ts`
- Added `'strict-dynamic'` to `script-src` to allow dynamically loaded modules; `'unsafe-inline'` is absent from `script-src`
- The nonce is already generated per-request and forwarded to `layout.tsx` via `x-nonce` header and `getCspNonce()`
- Added `e2e/tests/csp-nonce.spec.ts` Playwright test asserting the CSP header contains `nonce-`, `strict-dynamic`, and not `unsafe-inline`

**#514 — Challenge discovery page with filters**
- New page `apps/web/src/app/(game)/challenges/page.tsx` with filter controls for status (all / active / upcoming / ended), min pool in USDC, and end-before date picker
- New `loading.tsx` Suspense skeleton for fast perceived load
- Extended `GET /challenges` in `apps/api/src/routes/challenges.ts` to accept `?status=`, `?min_pool=`, and `?end_before=` query parameters; filtered requests bypass the cache, unfiltered requests continue to use the existing coalescing cache
- Added `getFilteredChallenges()` to `apps/api/src/db/queries/challenges.ts` with safe parameterised SQL for all three filter dimensions
- Added `e2e/tests/challenges-discovery.spec.ts` Playwright tests for filter controls and empty state

## How to test

- Cookie: start API and navigate to `/?ref=ABC123`; inspect Set-Cookie header — must show `Secure; HttpOnly; SameSite=Strict`
- DNS prefetch: load any web page or API endpoint and inspect response headers for `X-DNS-Prefetch-Control: off`
- CSP: load any web page, inspect `Content-Security-Policy` response header — must contain `nonce-<value>` and `strict-dynamic`, must not contain `unsafe-inline` in `script-src`
- Discovery page: navigate to `/challenges`; verify cards appear, status filters change results, min-pool input narrows the list, and "Clear filters" resets all controls