### PR TITLE
feat(api,web): build admin audit log viewer

### DIFF
--- a/apps/api/src/routes/admin/audit-log.ts
+++ b/apps/api/src/routes/admin/audit-log.ts
@@ -1,0 +1,104 @@
+import { Router } from "express";
+import { z } from "zod";
+import { query } from "../../db";
+import { createError } from "../../middleware/error";
+
+const router = Router();
+
+export interface AuditLogEntry {
+  id: string;
+  actor_id: string | null;
+  actor_username: string | null;
+  action: string;
+  entity: string;
+  entity_key: string | null;
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  created_at: string;
+}
+
+const QuerySchema = z.object({
+  action: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  search: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+router.get("/", async (req, res) => {
+  const { action, from, to, search, page, pageSize } = QuerySchema.parse(req.query);
+
+  let whereConditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (action) {
+    params.push(action);
+    whereConditions.push(`al.action = $${params.length}`);
+  }
+
+  if (from) {
+    params.push(from);
+    whereConditions.push(`al.created_at >= $${params.length}::timestamp`);
+  }
+
+  if (to) {
+    params.push(to);
+    whereConditions.push(`al.created_at <= $${params.length}::timestamp`);
+  }
+
+  if (search) {
+    params.push(`%${search}%`);
+    whereConditions.push(
+      `(u.username ILIKE $${params.length} OR al.entity_key ILIKE $${params.length})`
+    );
+  }
+
+  const whereClause = whereConditions.length > 0 ? `WHERE ${whereConditions.join(" AND ")}` : "";
+
+  const countResult = await query<{ count: number }>(
+    `SELECT COUNT(*)::int as count FROM audit_log al
+     LEFT JOIN users u ON u.id = al.actor_id
+     ${whereClause}`,
+    params
+  );
+
+  const total = countResult.rows[0]?.count ?? 0;
+  const totalPages = Math.ceil(total / pageSize);
+  const offset = (page - 1) * pageSize;
+
+  params.push(pageSize);
+  params.push(offset);
+
+  const result = await query<AuditLogEntry>(
+    `SELECT
+       al.id,
+       al.actor_id,
+       u.username as actor_username,
+       al.action,
+       al.entity,
+       al.entity_key,
+       al.before,
+       al.after,
+       al.created_at
+     FROM audit_log al
+     LEFT JOIN users u ON u.id = al.actor_id
+     ${whereClause}
+     ORDER BY al.created_at DESC
+     LIMIT $${params.length - 1}
+     OFFSET $${params.length}`,
+    params
+  );
+
+  res.json({
+    entries: result.rows,
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages,
+    },
+  });
+});
+
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -13,6 +13,7 @@ import adminUsersRoutes from "./admin/users";
 import adminFraudRoutes from "./admin/fraud";
 import adminChallengesRoutes from "./admin/challenges";
 import adminEscrowRoutes from "./admin/escrow";
+import adminAuditLogRoutes from "./admin/audit-log";
 import adminRoutes from "./admin";
 import deleteAccountRoutes from "./me/delete-account";
 import docsRoutes from "./docs";
@@ -43,6 +44,7 @@ export function registerRoutes(app: Express): void {
   app.use("/admin/fraud-flags", adminFraudRoutes);
   app.use("/admin/challenges", adminChallengesRoutes);
   app.use("/admin/escrow", adminEscrowRoutes);
+  app.use("/admin/audit-log", adminAuditLogRoutes);
   // General admin endpoints (archive inspection, dead-letter queue triage).
   // Mounted after the more specific /admin/* routers; its own routes
   // (/admin/dlq, /admin/archive/...) do not overlap with them.

--- a/apps/web/src/app/admin/audit-log/page.tsx
+++ b/apps/web/src/app/admin/audit-log/page.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface AuditLogEntry {
+  id: string;
+  actor_id: string | null;
+  actor_username: string | null;
+  action: string;
+  entity: string;
+  entity_key: string | null;
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  created_at: string;
+}
+
+interface Pagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+export default function AdminAuditLogPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const apiToken = (session as { apiToken?: string } | null)?.apiToken;
+  const userRole = (session?.user as { role?: string } | undefined)?.role;
+
+  const [entries, setEntries] = useState<AuditLogEntry[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({
+    page: 1,
+    pageSize: 50,
+    total: 0,
+    totalPages: 1,
+  });
+  const [loading, setLoading] = useState(true);
+  const [action, setAction] = useState(searchParams.get("action") || "");
+  const [fromDate, setFromDate] = useState(searchParams.get("from") || "");
+  const [toDate, setToDate] = useState(searchParams.get("to") || "");
+  const [search, setSearch] = useState(searchParams.get("search") || "");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const refreshIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+    }
+    if (status === "authenticated" && userRole !== "admin") {
+      router.push("/");
+    }
+  }, [status, userRole, router]);
+
+  const loadEntries = useCallback(
+    async (page = 1) => {
+      if (status !== "authenticated" || !apiToken) return;
+
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        params.set("page", String(page));
+        params.set("pageSize", "50");
+        if (action) params.set("action", action);
+        if (fromDate) params.set("from", fromDate);
+        if (toDate) params.set("to", toDate);
+        if (search) params.set("search", search);
+
+        const api = createApiClient(apiToken);
+        const response = await api.get(`/admin/audit-log?${params}`);
+        const data = response.data;
+
+        setEntries(data.entries || []);
+        setPagination(data.pagination || { page: 1, pageSize: 50, total: 0, totalPages: 1 });
+      } catch (error) {
+        console.error("Failed to load audit log entries", error);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [status, apiToken, action, fromDate, toDate, search]
+  );
+
+  useEffect(() => {
+    const url = new URLSearchParams();
+    if (action) url.set("action", action);
+    if (fromDate) url.set("from", fromDate);
+    if (toDate) url.set("to", toDate);
+    if (search) url.set("search", search);
+    router.push(`/admin/audit-log?${url.toString()}`);
+  }, [action, fromDate, toDate, search, router]);
+
+  useEffect(() => {
+    loadEntries(pagination.page);
+
+    refreshIntervalRef.current = setInterval(() => {
+      loadEntries(pagination.page);
+    }, 30000);
+
+    return () => {
+      if (refreshIntervalRef.current) clearInterval(refreshIntervalRef.current);
+    };
+  }, [loadEntries, pagination.page]);
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  if (status !== "authenticated") return null;
+  if (userRole !== "admin") return null;
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-12">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">Audit Log</h1>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          View and search all admin actions
+        </p>
+      </div>
+
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <label className="mb-2 block text-sm font-medium">Action Type</label>
+              <Input
+                type="text"
+                placeholder="e.g., update, suspend_user"
+                value={action}
+                onChange={(e) => setAction(e.target.value)}
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium">From Date</label>
+              <Input
+                type="date"
+                value={fromDate}
+                onChange={(e) => setFromDate(e.target.value)}
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium">To Date</label>
+              <Input
+                type="date"
+                value={toDate}
+                onChange={(e) => setToDate(e.target.value)}
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium">Search</label>
+              <Input
+                type="text"
+                placeholder="Username or entity ID"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex gap-2">
+            <Button
+              onClick={() => loadEntries(1)}
+              disabled={loading}
+            >
+              {loading ? "Refreshing..." : "Refresh"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setAction("");
+                setFromDate("");
+                setToDate("");
+                setSearch("");
+              }}
+            >
+              Clear Filters
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            Entries ({pagination.total})
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {entries.length > 0 ? (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-[var(--border)]">
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                        Actor
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                        Action
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                        Entity
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                        Target
+                      </th>
+                      <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                        Date
+                      </th>
+                      <th className="px-6 py-3 text-center text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                        Details
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {entries.map((entry) => (
+                      <tr
+                        key={entry.id}
+                        className="border-b border-[var(--border)] last:border-0"
+                      >
+                        <td className="px-6 py-3 font-medium">
+                          {entry.actor_username ? (
+                            <Badge variant="secondary">{entry.actor_username}</Badge>
+                          ) : (
+                            <span className="text-[var(--muted-foreground)]">System</span>
+                          )}
+                        </td>
+                        <td className="px-6 py-3">
+                          <Badge variant="default">{entry.action}</Badge>
+                        </td>
+                        <td className="px-6 py-3 text-[var(--muted-foreground)]">
+                          {entry.entity}
+                        </td>
+                        <td className="px-6 py-3 text-[var(--muted-foreground)]">
+                          {entry.entity_key || "—"}
+                        </td>
+                        <td className="px-6 py-3 text-right text-[var(--muted-foreground)]">
+                          {formatDate(entry.created_at)}
+                        </td>
+                        <td className="px-6 py-3 text-center">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() =>
+                              setExpandedId(expandedId === entry.id ? null : entry.id)
+                            }
+                          >
+                            {expandedId === entry.id ? "Hide" : "Show"}
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {expandedId && (
+                <Dialog open={expandedId !== null} onOpenChange={() => setExpandedId(null)}>
+                  <DialogContent className="max-w-2xl">
+                    <DialogHeader>
+                      <DialogTitle>
+                        {entries.find((e) => e.id === expandedId)?.action} Details
+                      </DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-6">
+                      {entries.find((e) => e.id === expandedId)?.before && (
+                        <div>
+                          <h3 className="mb-2 font-semibold">Before</h3>
+                          <pre className="rounded bg-slate-900 p-4 text-xs text-white overflow-auto max-h-64">
+                            {JSON.stringify(
+                              entries.find((e) => e.id === expandedId)?.before,
+                              null,
+                              2
+                            )}
+                          </pre>
+                        </div>
+                      )}
+                      {entries.find((e) => e.id === expandedId)?.after && (
+                        <div>
+                          <h3 className="mb-2 font-semibold">After</h3>
+                          <pre className="rounded bg-slate-900 p-4 text-xs text-white overflow-auto max-h-64">
+                            {JSON.stringify(
+                              entries.find((e) => e.id === expandedId)?.after,
+                              null,
+                              2
+                            )}
+                          </pre>
+                        </div>
+                      )}
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              )}
+            </>
+          ) : (
+            <div className="px-6 py-12 text-center">
+              <p className="text-[var(--muted-foreground)]">No audit log entries found</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {pagination.totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-between">
+          <div className="text-sm text-[var(--muted-foreground)]">
+            Page {pagination.page} of {pagination.totalPages}
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => loadEntries(Math.max(1, pagination.page - 1))}
+              disabled={pagination.page === 1 || loading}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => loadEntries(Math.min(pagination.totalPages, pagination.page + 1))}
+              disabled={pagination.page === pagination.totalPages || loading}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## What

Adds a real-time audit log viewer at /admin/audit-log where admins can browse, filter, and inspect all audit log entries with expandable JSON payloads for detailed investigation.

## Why

Admins need a UI to investigate incidents and trace user actions without querying the database directly. The audit_log table captures all admin and system actions, but without a viewer, it's inaccessible to non-technical team members.

## How

- Add GET /admin/audit-log endpoint with filtering by action type, date range, and free-text search
- Support pagination with 50 entries per page and previous/next controls
- Create /admin/audit-log page displaying actor username, action type, target entity, and timestamp
- Each row is expandable to show full JSON payload (before/after states)
- URL query params reflect active filters for shareable links (e.g., ?action=suspend_user&from=2025-01-01)
- Auto-refresh every 30 seconds with manual refresh button
- Admin-only access with redirect to / for non-admins

## Test plan

- [ ] Unit tests for API endpoint pass (filtering, pagination, query parameter handling)
- [ ] Manual smoke test: Visit /admin/audit-log and verify entries load correctly
- [ ] Filter test: Apply action type, date range, and search filters; verify results are correct
- [ ] Pagination test: Navigate between pages and verify entries are different
- [ ] Expandable payload test: Click "Show" on a row and verify JSON is displayed correctly
- [ ] URL sharing test: Copy filtered URL and verify filters are restored on page load

## Checklist

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (manual check needed)

Closes #521