### PR TITLE
feat(api,web): build referral hub with link display and bonus tracker

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -9,9 +9,10 @@ import {
   updateUserProfile,
   getUserPublicProfileByUsername,
 } from "../db/queries/users";
-import { getReferralStats } from "../services/referrals";
+import { getReferralStats, ensureUserReferralCode } from "../services/referrals";
 import { stroopsToUsdc } from "../lib/usdc";
 import { getStreak, repairStreak } from "../services/streaks";
+import { query } from "../db";
 import {
   sendVerificationCode,
   hashPhoneNumber,
@@ -88,6 +89,64 @@ router.get("/me/referrals/stats", authenticate, async (req, res) => {
     conversions: stats.conversions,
     totalEarned: stroopsToUsdc(stats.totalEarnedStroops),
     totalEarnedUsdc: stroopsToUsdc(stats.totalEarnedStroops),
+  });
+});
+
+router.get("/me/referrals", authenticate, async (req, res) => {
+  const userId = req.user!.sub;
+  const referralCode = await ensureUserReferralCode(userId);
+
+  const referredResult = await query<{
+    id: string;
+    username: string;
+    display_name: string;
+    avatar_url: string | null;
+    created_at: string;
+    paid: boolean;
+  }>(
+    `SELECT
+       u.id,
+       u.username,
+       u.display_name,
+       u.avatar_url,
+       u.created_at,
+       COALESCE(rp.status = 'sent', FALSE) AS paid
+     FROM referrals r
+     JOIN users u ON r.referred_id = u.id
+     LEFT JOIN referral_payouts rp ON r.id = rp.referral_id AND rp.status = 'sent'
+     WHERE r.referrer_id = $1 AND u.deleted_at IS NULL
+     ORDER BY u.created_at DESC`,
+    [userId]
+  );
+
+  const totalsResult = await query<{
+    pending_stroops: string;
+    confirmed_stroops: string;
+  }>(
+    `SELECT
+       COALESCE(SUM(CASE WHEN referrer_id = $1 AND status = 'pending' THEN referrer_amount_stroops ELSE 0 END), 0)::text AS pending_stroops,
+       COALESCE(SUM(CASE WHEN referrer_id = $1 AND status = 'sent' THEN referrer_amount_stroops ELSE 0 END), 0)::text AS confirmed_stroops
+     FROM referral_payouts
+     WHERE referrer_id = $1`,
+    [userId]
+  );
+
+  const totals = totalsResult.rows[0] || { pending_stroops: "0", confirmed_stroops: "0" };
+
+  res.json({
+    referralCode,
+    referredUsers: referredResult.rows.map((row) => ({
+      id: row.id,
+      username: row.username,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      joinedAt: row.created_at,
+      bonusPaid: row.paid,
+    })),
+    bonusStatus: {
+      pendingUsdc: stroopsToUsdc(BigInt(totals.pending_stroops)),
+      confirmedUsdc: stroopsToUsdc(BigInt(totals.confirmed_stroops)),
+    },
   });
 });
 

--- a/apps/web/src/app/profile/referrals/page.tsx
+++ b/apps/web/src/app/profile/referrals/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { createApiClient } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { formatUsdc } from "@/lib/format";
+
+interface ReferredUser {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  joinedAt: string;
+  bonusPaid: boolean;
+}
+
+interface BonusStatus {
+  pendingUsdc: string;
+  confirmedUsdc: string;
+}
+
+interface ReferralData {
+  referralCode: string;
+  referredUsers: ReferredUser[];
+  bonusStatus: BonusStatus;
+}
+
+export default function ReferralsPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const apiToken = (session as { apiToken?: string } | null)?.apiToken;
+
+  const [data, setData] = useState<ReferralData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+    }
+  }, [status, router]);
+
+  useEffect(() => {
+    if (status !== "authenticated" || !apiToken) return;
+
+    const loadReferralData = async () => {
+      try {
+        const api = createApiClient(apiToken);
+        const response = await api.get("/users/me/referrals");
+        setData(response.data);
+      } catch (error) {
+        console.error("Failed to load referral data", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadReferralData();
+  }, [status, apiToken]);
+
+  if (status !== "authenticated") return null;
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-12">
+        <div className="text-center">Loading referral data...</div>
+      </main>
+    );
+  }
+
+  if (!data) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-12">
+        <EmptyState
+          title="Failed to load referral hub"
+          description="We couldn't load your referral data. Please try again."
+        />
+      </main>
+    );
+  }
+
+  const referralUrl = typeof window !== "undefined" ? `${window.location.origin}?ref=${data.referralCode}` : "";
+  const twitterShareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+    `Join me on BrandBlitz! Use my referral link: ${referralUrl}`
+  )}`;
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(referralUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">Referral Hub</h1>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          Invite friends and earn bonuses
+        </p>
+      </div>
+
+      {/* Referral Link */}
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle>Your Referral Link</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={referralUrl}
+              readOnly
+              className="flex-1 rounded border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm"
+            />
+            <Button onClick={handleCopyLink} variant="outline" size="sm">
+              {copied ? "Copied!" : "Copy"}
+            </Button>
+            <a href={twitterShareUrl} target="_blank" rel="noopener noreferrer">
+              <Button variant="outline" size="sm">
+                Share on X
+              </Button>
+            </a>
+          </div>
+          <p className="mt-2 text-xs text-[var(--muted-foreground)]">
+            Code: <span className="font-mono font-semibold">{data.referralCode}</span>
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Bonus Tracker */}
+      <div className="mb-8 grid grid-cols-2 gap-4">
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-[var(--muted-foreground)]">Pending</p>
+            <p className="text-2xl font-bold text-[var(--primary)]">
+              {formatUsdc(data.bonusStatus.pendingUsdc)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-[var(--muted-foreground)]">Confirmed</p>
+            <p className="text-2xl font-bold text-[var(--primary)]">
+              {formatUsdc(data.bonusStatus.confirmedUsdc)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Referred Users List */}
+      {data.referredUsers.length > 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Referred Users ({data.referredUsers.length})</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--border)]">
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                    User
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                    Joined
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.referredUsers.map((user) => (
+                  <tr
+                    key={user.id}
+                    className="border-b border-[var(--border)] last:border-0"
+                  >
+                    <td className="px-6 py-3">
+                      <div className="flex items-center gap-3">
+                        {user.avatarUrl ? (
+                          <Image
+                            src={user.avatarUrl}
+                            alt={user.displayName}
+                            width={32}
+                            height={32}
+                            className="h-8 w-8 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--primary)]/10 text-xs font-semibold">
+                            {user.displayName.charAt(0).toUpperCase()}
+                          </div>
+                        )}
+                        <div>
+                          <p className="font-medium">{user.displayName}</p>
+                          <p className="text-xs text-[var(--muted-foreground)]">
+                            @{user.username}
+                          </p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-3 text-[var(--muted-foreground)]">
+                      {new Date(user.joinedAt).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    </td>
+                    <td className="px-6 py-3">
+                      {user.bonusPaid ? (
+                        <Badge variant="default">Bonus Paid</Badge>
+                      ) : (
+                        <Badge variant="secondary">Pending</Badge>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent>
+            <EmptyState
+              title="No referrals yet"
+              description="Share your referral link to start earning bonuses when your friends join."
+              action={
+                <Button onClick={handleCopyLink}>
+                  Copy Referral Link
+                </Button>
+              }
+            />
+          </CardContent>
+        </Card>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## What

Adds a referral hub at /profile/referrals where authenticated users can view their unique referral link, see who they've referred, and track pending or paid bonus status.

## Why

The referral system is fully implemented in the API but lacks a user-facing hub page. Users currently have no way to access their referral link or see referred users, limiting the referral program's effectiveness.

## How

- Add GET /users/me/referrals endpoint returning:
  - User's unique referral code (auto-generated if not present)
  - List of referred users with avatar, username, join date, and bonus status
  - Bonus tracker showing total pending and confirmed USDC earned
- Create /profile/referrals page with:
  - Referral link display with one-click copy button
  - Twitter/X share button for social sharing
  - Referred users table showing avatar, username, join date, and bonus paid status
  - Bonus status tracker (pending vs confirmed USDC)
  - Empty state when user has no referrals yet
- Ensure referral code is auto-generated via ensureUserReferralCode if not present
- Protect page with authenticate middleware and redirect unauthenticated users to /login

## Test plan

- [ ] Unit tests for referral endpoint pass (data aggregation, bonus calculation)
- [ ] Manual smoke test: Visit /profile/referrals as authenticated user
- [ ] Copy link test: Click "Copy" button and verify referral link is copied to clipboard
- [ ] Share test: Click "Share on X" button and verify Twitter compose window opens with correct message
- [ ] Verify referred users are displayed correctly with join dates and bonus status
- [ ] Verify bonus tracker shows pending and confirmed amounts
- [ ] Empty state test: Create new user with no referrals and verify empty state displays

## Checklist

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes (manual check needed)

Closes #518