### PR TITLE
feat: question preview, admin payout/stats dashboards, SVG sanitization

### DIFF
--- a/apps/api/src/db/queries/challenges.ts
+++ b/apps/api/src/db/queries/challenges.ts
@@ -347,6 +347,28 @@ export async function getChallengeQuestions(challengeId: string): Promise<Challe
   return result.rows;
 }
 
+export async function deleteChallengeQuestion(questionId: string): Promise<void> {
+  await query("DELETE FROM challenge_questions WHERE id = $1", [questionId]);
+}
+
+export async function insertChallengeQuestion(
+  question: Omit<ChallengeQuestion, "id">
+): Promise<ChallengeQuestion> {
+  const result = await query<ChallengeQuestion>(
+    `INSERT INTO challenge_questions
+       (challenge_id, round, question_type, prompt_type, question_text,
+        correct_answer, option_a, option_b, option_c, option_d, correct_option)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+     RETURNING *`,
+    [
+      question.challenge_id, question.round, question.question_type, question.prompt_type,
+      question.question_text, question.correct_answer,
+      question.option_a, question.option_b, question.option_c, question.option_d, question.correct_option,
+    ]
+  );
+  return result.rows[0];
+}
+
 /**
  * Increment deposit confirmations for a challenge.
  * Returns the updated confirmation count.

--- a/apps/api/src/lib/svg-sanitize.test.ts
+++ b/apps/api/src/lib/svg-sanitize.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeSvgText } from "./svg-sanitize";
+
+describe("sanitizeSvgText", () => {
+  it("escapes ampersands", () => {
+    expect(sanitizeSvgText("Ben & Jerry's")).toBe("Ben &amp; Jerry&apos;s");
+  });
+
+  it("escapes angle brackets", () => {
+    expect(sanitizeSvgText("<script>alert(1)</script>")).toBe(
+      "&lt;script&gt;alert(1)&lt;/script&gt;"
+    );
+  });
+
+  it("escapes double quotes", () => {
+    expect(sanitizeSvgText('He said "hello"')).toBe("He said &quot;hello&quot;");
+  });
+
+  it("escapes single quotes", () => {
+    expect(sanitizeSvgText("It's")).toBe("It&apos;s");
+  });
+
+  it("escapes all five XML entities simultaneously", () => {
+    const input = `Tom & Jerry's "show" <best>`;
+    const expected = `Tom &amp; Jerry&apos;s &quot;show&quot; &lt;best&gt;`;
+    expect(sanitizeSvgText(input)).toBe(expected);
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(sanitizeSvgText("Hello World")).toBe("Hello World");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeSvgText("")).toBe("");
+  });
+
+  it("handles string with only special characters", () => {
+    expect(sanitizeSvgText("<>&\"'")).toBe("&lt;&gt;&amp;&quot;&apos;");
+  });
+
+  it("does not double-encode already safe text", () => {
+    const safe = "Acme Corp - Best Products 2024";
+    expect(sanitizeSvgText(safe)).toBe(safe);
+  });
+});

--- a/apps/api/src/lib/svg-sanitize.ts
+++ b/apps/api/src/lib/svg-sanitize.ts
@@ -1,0 +1,18 @@
+const XML_ENTITIES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+const ENTITY_RE = /[&<>"']/g;
+
+/**
+ * Escape text for safe interpolation into an SVG text node.
+ * Converts the five XML special characters into their entity equivalents
+ * so they are rendered as visible characters, not parsed as markup.
+ */
+export function sanitizeSvgText(input: string): string {
+  return input.replace(ENTITY_RE, (ch) => XML_ENTITIES[ch] ?? ch);
+}

--- a/apps/api/src/routes/admin/payouts.ts
+++ b/apps/api/src/routes/admin/payouts.ts
@@ -1,0 +1,147 @@
+import { Router } from "express";
+import { z } from "zod";
+import { authenticate } from "../../middleware/authenticate";
+import { requireAdmin } from "../../middleware/require-admin";
+import { createError } from "../../middleware/error";
+import { query } from "../../db/index";
+import { enqueuePayoutJob } from "../../queues/payout.queue";
+import { logger } from "../../lib/logger";
+
+const router = Router();
+
+router.use(authenticate);
+router.use(requireAdmin);
+
+const ListPayoutsSchema = z.object({
+  status: z.enum(["all", "pending", "processing", "sent", "confirmed", "failed"]).default("all"),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+router.get("/", async (req, res) => {
+  const { status, page, pageSize } = ListPayoutsSchema.parse(req.query);
+
+  let whereConditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (status !== "all") {
+    params.push(status);
+    whereConditions.push(`p.status = $${params.length}`);
+  }
+
+  const whereClause = whereConditions.length > 0 ? `WHERE ${whereConditions.join(" AND ")}` : "";
+
+  const countResult = await query<{ count: number }>(
+    `SELECT COUNT(*)::int as count FROM payouts p ${whereClause}`,
+    params
+  );
+
+  const total = countResult.rows[0]?.count ?? 0;
+  const totalPages = Math.ceil(total / pageSize);
+  const offset = (page - 1) * pageSize;
+
+  params.push(pageSize, offset);
+
+  const result = await query<{
+    id: string;
+    challenge_id: string;
+    user_id: string;
+    username: string;
+    stellar_address: string;
+    amount_stroops: string;
+    amount_usdc: string;
+    tx_hash: string | null;
+    status: string;
+    error_message: string | null;
+    created_at: string;
+  }>(
+    `SELECT
+       p.id,
+       p.challenge_id,
+       p.user_id,
+       COALESCE(u.username, u.display_name, 'Unknown') AS username,
+       p.stellar_address,
+       p.amount_stroops,
+       (p.amount_stroops::numeric / 10000000)::numeric(20,7)::text AS amount_usdc,
+       p.tx_hash,
+       p.status,
+       p.error_message,
+       p.created_at
+     FROM payouts p
+     LEFT JOIN users u ON p.user_id = u.id
+     ${whereClause}
+     ORDER BY p.created_at DESC
+     LIMIT $${params.length - 1}
+     OFFSET $${params.length}`,
+    params
+  );
+
+  // Summary stats
+  const statsResult = await query<{
+    total_paid_usdc: string;
+    total_pending_usdc: string;
+    total_failed: number;
+  }>(
+    `SELECT
+       COALESCE(SUM(CASE WHEN status IN ('sent', 'confirmed') THEN amount_stroops ELSE 0 END) / 10000000, 0)::numeric(20,7)::text AS total_paid_usdc,
+       COALESCE(SUM(CASE WHEN status IN ('pending', 'processing') THEN amount_stroops ELSE 0 END) / 10000000, 0)::numeric(20,7)::text AS total_pending_usdc,
+       COUNT(*) FILTER (WHERE status = 'failed')::int AS total_failed
+     FROM payouts`
+  );
+
+  res.json({
+    payouts: result.rows,
+    pagination: { page, pageSize, total, totalPages },
+    stats: statsResult.rows[0],
+  });
+});
+
+router.post("/:id/retry", async (req, res) => {
+  const { id } = z.object({ id: z.string().uuid() }).parse(req.params);
+
+  const payout = await query<{
+    id: string;
+    challenge_id: string;
+    status: string;
+  }>(
+    "SELECT id, challenge_id, status FROM payouts WHERE id = $1",
+    [id]
+  );
+
+  if (!payout.rows[0]) throw createError("Payout not found", 404);
+
+  const record = payout.rows[0];
+  if (record.status !== "failed") {
+    throw createError("Only failed payouts can be retried", 400, "NOT_FAILED");
+  }
+
+  // Reset status to pending and clear error
+  await query(
+    "UPDATE payouts SET status = 'pending', error_message = NULL WHERE id = $1",
+    [id]
+  );
+
+  // Re-enqueue the payout job
+  await enqueuePayoutJob(record.challenge_id);
+
+  // Audit log
+  await query(
+    `INSERT INTO audit_log (actor_id, action, entity, entity_key, after)
+     VALUES ($1, 'payout_retry', 'payout', $2, $3::jsonb)`,
+    [
+      req.user!.sub,
+      id,
+      JSON.stringify({ payoutId: id, challengeId: record.challenge_id, previousStatus: "failed" }),
+    ]
+  );
+
+  logger.info("Payout retried by admin", {
+    payoutId: id,
+    challengeId: record.challenge_id,
+    adminId: req.user!.sub,
+  });
+
+  res.json({ success: true });
+});
+
+export default router;

--- a/apps/api/src/routes/admin/stats.ts
+++ b/apps/api/src/routes/admin/stats.ts
@@ -1,0 +1,82 @@
+import { Router } from "express";
+import { z } from "zod";
+import { authenticate } from "../../middleware/authenticate";
+import { requireAdmin } from "../../middleware/require-admin";
+import { query } from "../../db/index";
+
+const router = Router();
+
+router.use(authenticate);
+router.use(requireAdmin);
+
+const StatsQuerySchema = z.object({
+  days: z.coerce.number().int().min(1).max(90).default(30),
+});
+
+router.get("/", async (req, res) => {
+  const { days } = StatsQuerySchema.parse(req.query);
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  const [dauResult, usdcResult, topBrandsResult, summaryResult] = await Promise.all([
+    // DAU: unique users per day who completed at least one game_session
+    query<{ date: string; dau: number }>(
+      `SELECT DATE(completed_at) AS date, COUNT(DISTINCT user_id)::int AS dau
+       FROM game_sessions
+       WHERE completed_at IS NOT NULL AND completed_at >= $1
+       GROUP BY DATE(completed_at)
+       ORDER BY date ASC`,
+      [since]
+    ),
+
+    // USDC volume per day from payouts
+    query<{ date: string; total_usdc: string }>(
+      `SELECT DATE(created_at) AS date,
+              (SUM(amount_stroops) / 10000000)::numeric(20,7)::text AS total_usdc
+       FROM payouts
+       WHERE status IN ('sent', 'confirmed') AND created_at >= $1
+       GROUP BY DATE(created_at)
+       ORDER BY date ASC`,
+      [since]
+    ),
+
+    // Top 10 brands by completed sessions
+    query<{ brand_id: string; brand_name: string; completed_sessions: number }>(
+      `SELECT b.id AS brand_id, b.name AS brand_name,
+              COUNT(gs.id)::int AS completed_sessions
+       FROM game_sessions gs
+       JOIN challenges c ON gs.challenge_id = c.id
+       JOIN brands b ON c.brand_id = b.id
+       WHERE gs.status = 'completed' AND gs.completed_at >= $1
+       GROUP BY b.id, b.name
+       ORDER BY completed_sessions DESC
+       LIMIT 10`,
+      [since]
+    ),
+
+    // Summary stats
+    query<{
+      total_users: number;
+      total_paid_usdc: string;
+      total_completed_sessions: number;
+    }>(
+      `SELECT
+         (SELECT COUNT(*)::int FROM users WHERE deleted_at IS NULL) AS total_users,
+         COALESCE(
+           (SELECT (SUM(amount_stroops) / 10000000)::numeric(20,7)::text
+            FROM payouts WHERE status IN ('sent', 'confirmed')),
+           '0'
+         ) AS total_paid_usdc,
+         (SELECT COUNT(*)::int FROM game_sessions WHERE status = 'completed') AS total_completed_sessions`
+    ),
+  ]);
+
+  res.json({
+    dau: dauResult.rows,
+    usdcVolume: usdcResult.rows,
+    topBrands: topBrandsResult.rows,
+    summary: summaryResult.rows[0],
+    period: { days, since },
+  });
+});
+
+export default router;

--- a/apps/api/src/routes/brands.test.ts
+++ b/apps/api/src/routes/brands.test.ts
@@ -274,6 +274,40 @@ describe("Brands Routes Integration", () => {
     });
   });
 
+  describe("SVG sanitization", () => {
+    it("escapes XML entities in brand name before storage", async () => {
+      const payload = {
+        name: 'Ben & Jerry\'s <Brand>"',
+        tagline: "The <best> & most \"trusted\" brand",
+      };
+
+      const res = await request(app)
+        .post("/brands")
+        .set("Authorization", `Bearer ${testUser.token}`)
+        .send(payload);
+
+      expect(res.status).toBe(201);
+      expect(res.body.brand.name).toBe("Ben &amp; Jerry&apos;s &lt;Brand&gt;&quot;");
+      expect(res.body.brand.tagline).toBe("The &lt;best&gt; &amp; most &quot;trusted&quot; brand");
+    });
+
+    it("preserves plain text without XML entities", async () => {
+      const payload = {
+        name: "Acme Corp",
+        tagline: "Simply the best",
+      };
+
+      const res = await request(app)
+        .post("/brands")
+        .set("Authorization", `Bearer ${testUser.token}`)
+        .send(payload);
+
+      expect(res.status).toBe(201);
+      expect(res.body.brand.name).toBe("Acme Corp");
+      expect(res.body.brand.tagline).toBe("Simply the best");
+    });
+  });
+
   describe("Unauthenticated access", () => {
     it("returns 401 for GET /brands", async () => {
       const res = await request(app).get("/brands");

--- a/apps/api/src/routes/brands.ts
+++ b/apps/api/src/routes/brands.ts
@@ -16,6 +16,10 @@ import { getBrandAnalytics } from "../db/queries/analytics";
 import {
   createChallenge,
   insertChallengeQuestions,
+  getChallengeQuestions,
+  getChallengesByBrandId,
+  deleteChallengeQuestion,
+  insertChallengeQuestion,
 } from "../db/queries/challenges";
 import { generateChallengeQuestions } from "../services/questions";
 import { optimizeImage, StorageError } from "@brandblitz/storage";
@@ -26,6 +30,7 @@ import { logger } from "../lib/logger";
 import { config } from "../lib/config";
 import { MIN_POOL_STROOPS } from "@brandblitz/stellar";
 import { query } from "../db/index";
+import { sanitizeSvgText } from "../lib/svg-sanitize";
 
 const router = Router();
 
@@ -194,6 +199,86 @@ router.get("/:id/dashboard", authenticate, async (req, res) => {
 });
 
 /**
+ * GET /brands/:id/questions/preview
+ * Returns questions (with correct answers) for the latest challenge of a brand.
+ * Accessible only to the brand owner for previewing before launch.
+ */
+router.get("/:id/questions/preview", authenticate, async (req, res) => {
+  const brand = await getBrandById(req.params.id);
+  if (!brand) throw createError("Brand not found", 404);
+  if (brand.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
+
+  const { challenges } = await getChallengesByBrandId(brand.id, 1);
+  if (challenges.length === 0) {
+    res.json({ questions: [], challenge: null });
+    return;
+  }
+
+  const challenge = challenges[0];
+  const questions = await getChallengeQuestions(challenge.id);
+  res.json({ questions, challenge });
+});
+
+/**
+ * POST /brands/:id/questions/:questionId/regenerate
+ * Delete a question and regenerate it for the same round.
+ * Returns the new question with correct_answer.
+ */
+router.post("/:id/questions/:questionId/regenerate", authenticate, async (req, res) => {
+  const brand = await getBrandById(req.params.id);
+  if (!brand) throw createError("Brand not found", 404);
+  if (brand.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
+
+  const { questionId } = req.params;
+  const allQuestions = await query<{ id: string; challenge_id: string; round: 1 | 2 | 3 }>(
+    "SELECT id, challenge_id, round FROM challenge_questions WHERE id = $1",
+    [questionId]
+  );
+  const existing = allQuestions.rows[0];
+  if (!existing) throw createError("Question not found", 404);
+
+  const challenge = await getBrandById(brand.id);
+  if (!challenge) throw createError("Brand not found", 404);
+
+  const distractorBrands = await getActiveDistractorBrands(brand.id);
+  const regenerated = generateChallengeQuestions(existing.challenge_id, brand, distractorBrands);
+  const newDraft = regenerated.find((q) => q.round === existing.round) ?? regenerated[0];
+
+  await deleteChallengeQuestion(questionId);
+  const inserted = await insertChallengeQuestion({ ...newDraft, challenge_id: existing.challenge_id });
+
+  res.json({ question: inserted });
+});
+
+/**
+ * POST /brands/:id/questions/:questionId/approve
+ * Mark a question as approved.
+ */
+router.post("/:id/questions/:questionId/approve", authenticate, async (req, res) => {
+  const brand = await getBrandById(req.params.id);
+  if (!brand) throw createError("Brand not found", 404);
+  if (brand.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
+
+  const { questionId } = req.params;
+  await query("UPDATE challenge_questions SET approved = true WHERE id = $1", [questionId]);
+  res.json({ success: true });
+});
+
+/**
+ * POST /brands/:id/questions/:questionId/flag
+ * Mark a question as flagged for regeneration.
+ */
+router.post("/:id/questions/:questionId/flag", authenticate, async (req, res) => {
+  const brand = await getBrandById(req.params.id);
+  if (!brand) throw createError("Brand not found", 404);
+  if (brand.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
+
+  const { questionId } = req.params;
+  await query("UPDATE challenge_questions SET approved = false WHERE id = $1", [questionId]);
+  res.json({ success: true });
+});
+
+/**
  * POST /brands
  * Create a brand kit. Optimizes uploaded images immediately.
  */
@@ -229,11 +314,11 @@ router.post("/", authenticate, async (req, res) => {
 
   const brand = await createBrand({
     owner_user_id: userId,
-    name: body.name,
+    name: sanitizeSvgText(body.name),
     logo_url: logoUrl ?? null,
     primary_color: body.primaryColor ?? null,
     secondary_color: body.secondaryColor ?? null,
-    tagline: body.tagline ?? null,
+    tagline: body.tagline ? sanitizeSvgText(body.tagline) : null,
     brand_story: body.brandStory ?? null,
     usp: body.usp ?? null,
     product_image_keys: productImageKeys,

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -14,6 +14,8 @@ import adminFraudRoutes from "./admin/fraud";
 import adminChallengesRoutes from "./admin/challenges";
 import adminEscrowRoutes from "./admin/escrow";
 import adminAuditLogRoutes from "./admin/audit-log";
+import adminPayoutsRoutes from "./admin/payouts";
+import adminStatsRoutes from "./admin/stats";
 import adminRoutes from "./admin";
 import deleteAccountRoutes from "./me/delete-account";
 import docsRoutes from "./docs";
@@ -45,6 +47,8 @@ export function registerRoutes(app: Express): void {
   app.use("/admin/challenges", adminChallengesRoutes);
   app.use("/admin/escrow", adminEscrowRoutes);
   app.use("/admin/audit-log", adminAuditLogRoutes);
+  app.use("/admin/payouts", adminPayoutsRoutes);
+  app.use("/admin/stats", adminStatsRoutes);
   // General admin endpoints (archive inspection, dead-letter queue triage).
   // Mounted after the more specific /admin/* routers; its own routes
   // (/admin/dlq, /admin/archive/...) do not overlap with them.

--- a/apps/web/src/app/(brand)/brand/[id]/questions/preview/page.tsx
+++ b/apps/web/src/app/(brand)/brand/[id]/questions/preview/page.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { createApiClient } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+import { toast } from "@/lib/toast";
+
+interface PreviewQuestion {
+  id: string;
+  challenge_id: string;
+  round: 1 | 2 | 3;
+  question_type: string;
+  prompt_type: string;
+  question_text: string;
+  correct_answer: string;
+  option_a: string;
+  option_b: string;
+  option_c: string;
+  option_d: string;
+  correct_option: "A" | "B" | "C" | "D";
+  approved: boolean | null;
+}
+
+interface BrandInfo {
+  id: string;
+  name: string;
+  logo_url: string | null;
+  tagline: string | null;
+}
+
+export default function QuestionPreviewPage() {
+  const { data: session, status } = useSession();
+  const params = useParams();
+  const router = useRouter();
+  const apiToken = (session as { apiToken?: string } | null)?.apiToken;
+  const brandId = params.id as string;
+
+  const [brand, setBrand] = useState<BrandInfo | null>(null);
+  const [questions, setQuestions] = useState<PreviewQuestion[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [regenerating, setRegenerating] = useState(false);
+  const [approving, setApproving] = useState(false);
+
+  useEffect(() => {
+    if (status === "unauthenticated") router.push("/login");
+  }, [status, router]);
+
+  const loadData = useCallback(async () => {
+    if (!apiToken) return;
+    setLoading(true);
+    try {
+      const api = createApiClient(apiToken);
+      const [brandRes, previewRes] = await Promise.all([
+        api.get(`/brands/${brandId}`),
+        api.get(`/brands/${brandId}/questions/preview`),
+      ]);
+      setBrand(brandRes.data.brand);
+      setQuestions(previewRes.data.questions ?? []);
+    } catch {
+      toast.error("Failed to load questions. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [apiToken, brandId]);
+
+  useEffect(() => {
+    if (status === "authenticated") void loadData();
+  }, [loadData, status]);
+
+  const handleApprove = async () => {
+    if (!apiToken || !questions[currentIndex]) return;
+    setApproving(true);
+    try {
+      const api = createApiClient(apiToken);
+      await api.post(`/brands/${brandId}/questions/${questions[currentIndex].id}/approve`);
+      setQuestions((prev) =>
+        prev.map((q, i) => (i === currentIndex ? { ...q, approved: true } : q))
+      );
+      toast.success("Question approved!");
+    } catch {
+      toast.error("Failed to approve question.");
+    } finally {
+      setApproving(false);
+    }
+  };
+
+  const handleFlag = async () => {
+    if (!apiToken || !questions[currentIndex]) return;
+    setRegenerating(true);
+    try {
+      const api = createApiClient(apiToken);
+      const res = await api.post(
+        `/brands/${brandId}/questions/${questions[currentIndex].id}/regenerate`
+      );
+      const newQuestion = res.data.question;
+      setQuestions((prev) =>
+        prev.map((q, i) => (i === currentIndex ? { ...newQuestion } : q))
+      );
+      toast.success("Question regenerated!");
+    } catch {
+      toast.error("Failed to regenerate question.");
+    } finally {
+      setRegenerating(false);
+    }
+  };
+
+  if (status === "loading" || loading) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-12 space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+        <div className="flex gap-3">
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-24" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!brand) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-12">
+        <p className="text-[var(--muted-foreground)]">Brand not found.</p>
+      </main>
+    );
+  }
+
+  const question = questions[currentIndex];
+  const reviewedCount = questions.filter((q) => q.approved !== null).length;
+  const allApproved = questions.length > 0 && questions.every((q) => q.approved === true);
+  const progressPercent = questions.length > 0 ? (reviewedCount / questions.length) * 100 : 0;
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {brand.logo_url ? (
+            <Image
+              src={brand.logo_url}
+              alt={brand.name}
+              width={48}
+              height={48}
+              className="h-12 w-12 rounded-lg object-contain"
+            />
+          ) : (
+            <div className="h-12 w-12 rounded-lg bg-[var(--primary)]" />
+          )}
+          <div>
+            <h1 className="text-2xl font-bold">{brand.name}</h1>
+            <p className="text-sm text-[var(--muted-foreground)]">Question Preview</p>
+          </div>
+        </div>
+        <Link href={`/brand/${brandId}`}>
+          <Button variant="outline" size="sm">
+            Back to Brand
+          </Button>
+        </Link>
+      </div>
+
+      <div className="mb-6">
+        <div className="mb-2 flex items-center justify-between text-sm">
+          <span className="text-[var(--muted-foreground)]">
+            {reviewedCount} of {questions.length} reviewed
+          </span>
+          <span className="text-[var(--muted-foreground)]">
+            {allApproved ? "All approved" : "Pending review"}
+          </span>
+        </div>
+        <Progress value={progressPercent} />
+      </div>
+
+      {questions.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <p className="text-[var(--muted-foreground)]">
+              No questions found. Create a challenge first to generate questions.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <Card className="mb-6">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle>Round {question.round} of 3</CardTitle>
+                <Badge
+                  variant={
+                    question.approved === true
+                      ? "default"
+                      : question.approved === false
+                      ? "destructive"
+                      : "secondary"
+                  }
+                >
+                  {question.approved === true
+                    ? "Approved"
+                    : question.approved === false
+                    ? "Flagged"
+                    : "Pending"}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-center text-lg font-semibold">{question.question_text}</p>
+
+              <div className="grid grid-cols-1 gap-2">
+                {(["A", "B", "C", "D"] as const).map((opt) => {
+                  const key = `option_${opt.toLowerCase()}` as keyof PreviewQuestion;
+                  const text = question[key] as string;
+                  const isCorrect = opt === question.correct_option;
+                  return (
+                    <div
+                      key={opt}
+                      className={`rounded-lg border px-4 py-3 text-sm ${
+                        isCorrect
+                          ? "border-green-500 bg-green-50 text-green-900"
+                          : "border-[var(--border)]"
+                      }`}
+                    >
+                      <span className="mr-2 font-bold">{opt}.</span>
+                      {text}
+                      {isCorrect && (
+                        <Badge variant="default" className="ml-2">
+                          Correct
+                        </Badge>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex items-center justify-between">
+            <Button
+              variant="outline"
+              disabled={currentIndex === 0}
+              onClick={() => setCurrentIndex((i) => i - 1)}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-[var(--muted-foreground)]">
+              {currentIndex + 1} / {questions.length}
+            </span>
+            <Button
+              variant="outline"
+              disabled={currentIndex === questions.length - 1}
+              onClick={() => setCurrentIndex((i) => i + 1)}
+            >
+              Next
+            </Button>
+          </div>
+
+          <div className="mt-6 flex gap-3">
+            <Button
+              onClick={handleApprove}
+              disabled={approving || question.approved === true}
+              className="flex-1"
+            >
+              {question.approved === true ? "Approved" : approving ? "Approving..." : "Approve"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleFlag}
+              disabled={regenerating}
+              className="flex-1"
+            >
+              {regenerating ? "Regenerating..." : "Flag for Regeneration"}
+            </Button>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/admin/payouts/page.tsx
+++ b/apps/web/src/app/admin/payouts/page.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { createApiClient } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface Payout {
+  id: string;
+  challenge_id: string;
+  user_id: string;
+  username: string;
+  stellar_address: string;
+  amount_usdc: string;
+  tx_hash: string | null;
+  status: string;
+  error_message: string | null;
+  created_at: string;
+}
+
+interface PayoutStats {
+  total_paid_usdc: string;
+  total_pending_usdc: string;
+  total_failed: number;
+}
+
+interface Pagination {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}
+
+type StatusFilter = "all" | "pending" | "processing" | "sent" | "confirmed" | "failed";
+
+function statusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+  if (status === "failed") return "destructive";
+  if (status === "sent" || status === "confirmed") return "default";
+  if (status === "pending" || status === "processing") return "secondary";
+  return "outline";
+}
+
+export default function AdminPayoutsPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const apiToken = (session as { apiToken?: string } | null)?.apiToken;
+  const userRole = (session?.user as { role?: string } | undefined)?.role;
+
+  const [payouts, setPayouts] = useState<Payout[]>([]);
+  const [stats, setStats] = useState<PayoutStats | null>(null);
+  const [pagination, setPagination] = useState<Pagination>({
+    page: 1,
+    pageSize: 20,
+    total: 0,
+    totalPages: 1,
+  });
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [retryingIds, setRetryingIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+    } else if (status === "authenticated" && userRole !== "admin") {
+      router.push("/dashboard");
+    }
+  }, [status, userRole, router]);
+
+  const loadPayouts = useCallback(
+    async (page = 1) => {
+      if (!apiToken) return;
+      setLoading(true);
+      try {
+        const api = createApiClient(apiToken);
+        const params: Record<string, string | number> = { page, pageSize: 20 };
+        if (statusFilter !== "all") params.status = statusFilter;
+
+        const res = await api.get("/admin/payouts", { params });
+        setPayouts(res.data.payouts);
+        setPagination(res.data.pagination);
+        setStats(res.data.stats);
+      } catch {
+        setPayouts([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [apiToken, statusFilter]
+  );
+
+  useEffect(() => {
+    if (status === "authenticated" && userRole === "admin") {
+      void loadPayouts(1);
+    }
+  }, [loadPayouts, status, userRole]);
+
+  const handleRetry = async (payoutId: string) => {
+    if (!apiToken) return;
+    setRetryingIds((prev) => new Set(prev).add(payoutId));
+    try {
+      const api = createApiClient(apiToken);
+      await api.post(`/admin/payouts/${payoutId}/retry`);
+      await loadPayouts(pagination.page);
+    } catch {
+      // error toast already handled by api client
+    } finally {
+      setRetryingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(payoutId);
+        return next;
+      });
+    }
+  };
+
+  if (status === "loading" || (status === "authenticated" && userRole !== "admin")) {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Payout Management</h1>
+        <span className="text-sm text-gray-500">{pagination.total} total payouts</span>
+      </div>
+
+      {stats && (
+        <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-3xl font-bold text-green-600">
+                {Number(stats.total_paid_usdc).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 })} USDC
+              </p>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">Total Paid</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-3xl font-bold text-amber-600">
+                {Number(stats.total_pending_usdc).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 })} USDC
+              </p>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">Total Pending</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-3xl font-bold text-red-600">{stats.total_failed}</p>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">Failed Payouts</p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      <Card className="mb-6">
+        <CardContent className="pt-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm font-medium">Status:</span>
+            {(["all", "pending", "processing", "sent", "confirmed", "failed"] as StatusFilter[]).map(
+              (s) => (
+                <Button
+                  key={s}
+                  variant={statusFilter === s ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setStatusFilter(s)}
+                >
+                  {s.charAt(0).toUpperCase() + s.slice(1)}
+                </Button>
+              )
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Payouts</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="py-12 text-center text-sm text-gray-500">Loading...</div>
+          ) : payouts.length === 0 ? (
+            <div className="py-12 text-center text-sm text-gray-500">No payouts found.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-gray-50 text-left text-xs font-medium text-gray-500">
+                    <th className="px-4 py-3">User</th>
+                    <th className="px-4 py-3">Amount (USDC)</th>
+                    <th className="px-4 py-3">Stellar TX</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">Error</th>
+                    <th className="px-4 py-3">Date</th>
+                    <th className="px-4 py-3">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {payouts.map((payout) => (
+                    <tr key={payout.id} className="border-b hover:bg-gray-50">
+                      <td className="px-4 py-3">
+                        <div className="font-medium">{payout.username}</div>
+                        <div className="max-w-[150px] truncate font-mono text-xs text-gray-500">
+                          {payout.stellar_address}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 font-medium">
+                        {Number(payout.amount_usdc).toLocaleString(undefined, {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 7,
+                        })}
+                      </td>
+                      <td className="px-4 py-3">
+                        {payout.tx_hash ? (
+                          <a
+                            href={`https://stellar.expert/explorer/public/tx/${payout.tx_hash}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:underline"
+                          >
+                            {payout.tx_hash.slice(0, 8)}...
+                          </a>
+                        ) : (
+                          <span className="text-gray-400">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge variant={statusVariant(payout.status)}>{payout.status}</Badge>
+                      </td>
+                      <td className="max-w-[200px] px-4 py-3">
+                        {payout.error_message ? (
+                          <span
+                            className="cursor-help text-xs text-red-600"
+                            title={payout.error_message}
+                          >
+                            {payout.error_message.slice(0, 40)}...
+                          </span>
+                        ) : (
+                          <span className="text-gray-400">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500">
+                        {new Date(payout.created_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3">
+                        {payout.status === "failed" && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={retryingIds.has(payout.id)}
+                            onClick={() => void handleRetry(payout.id)}
+                          >
+                            {retryingIds.has(payout.id) ? "Retrying..." : "Retry"}
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {pagination.totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <span className="text-gray-500">
+            Page {pagination.page} of {pagination.totalPages}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={pagination.page <= 1}
+              onClick={() => void loadPayouts(pagination.page - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={pagination.page >= pagination.totalPages}
+              onClick={() => void loadPayouts(pagination.page + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/stats/page.tsx
+++ b/apps/web/src/app/admin/stats/page.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { createApiClient } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface DauEntry {
+  date: string;
+  dau: number;
+}
+
+interface UsdcEntry {
+  date: string;
+  total_usdc: string;
+}
+
+interface TopBrand {
+  brand_id: string;
+  brand_name: string;
+  completed_sessions: number;
+}
+
+interface Summary {
+  total_users: number;
+  total_paid_usdc: string;
+  total_completed_sessions: number;
+}
+
+type DateRange = "7" | "30" | "90";
+
+function formatShortDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+function LineChart({ data, label }: { data: { x: string; y: number }[]; label: string }) {
+  if (data.length === 0) return <div className="py-8 text-center text-sm text-gray-400">No data</div>;
+  const maxVal = Math.max(...data.map((d) => d.y), 1);
+  const width = 600;
+  const height = 200;
+  const padding = { top: 10, right: 10, bottom: 30, left: 40 };
+  const chartW = width - padding.left - padding.right;
+  const chartH = height - padding.top - padding.bottom;
+
+  const points = data.map((d, i) => {
+    const x = padding.left + (i / Math.max(data.length - 1, 1)) * chartW;
+    const y = padding.top + chartH - (d.y / maxVal) * chartH;
+    return `${x},${y}`;
+  });
+
+  const tickCount = Math.min(data.length, 7);
+  const tickStep = Math.max(1, Math.floor(data.length / tickCount));
+  const ticks = data.filter((_, i) => i % tickStep === 0 || i === data.length - 1);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full" role="img" aria-label={label}>
+      <text x={padding.left - 5} y={padding.top + 4} className="fill-current text-xs" textAnchor="end">
+        {maxVal}
+      </text>
+      <text x={padding.left - 5} y={padding.top + chartH + 4} className="fill-current text-xs" textAnchor="end">
+        0
+      </text>
+      <polyline
+        points={points.join(" ")}
+        fill="none"
+        stroke="var(--primary)"
+        strokeWidth="2"
+        strokeLinejoin="round"
+      />
+      {ticks.map((d, i) => {
+        const idx = data.indexOf(d);
+        const x = padding.left + (idx / Math.max(data.length - 1, 1)) * chartW;
+        return (
+          <text key={i} x={x} y={height - 5} className="fill-current text-[10px]" textAnchor="middle">
+            {formatShortDate(d.x)}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}
+
+function BarChart({ data, label }: { data: { x: string; y: number }[]; label: string }) {
+  if (data.length === 0) return <div className="py-8 text-center text-sm text-gray-400">No data</div>;
+  const maxVal = Math.max(...data.map((d) => d.y), 1);
+  const width = 600;
+  const height = 200;
+  const padding = { top: 10, right: 10, bottom: 30, left: 50 };
+  const chartW = width - padding.left - padding.right;
+  const chartH = height - padding.top - padding.bottom;
+  const barWidth = Math.max(4, chartW / data.length - 2);
+
+  const tickCount = Math.min(data.length, 7);
+  const tickStep = Math.max(1, Math.floor(data.length / tickCount));
+  const ticks = data.filter((_, i) => i % tickStep === 0 || i === data.length - 1);
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-full" role="img" aria-label={label}>
+      <text x={padding.left - 5} y={padding.top + 4} className="fill-current text-xs" textAnchor="end">
+        {maxVal.toFixed(1)}
+      </text>
+      <text x={padding.left - 5} y={padding.top + chartH + 4} className="fill-current text-xs" textAnchor="end">
+        0
+      </text>
+      {data.map((d, i) => {
+        const x = padding.left + (i / data.length) * chartW + 1;
+        const barH = (d.y / maxVal) * chartH;
+        const y = padding.top + chartH - barH;
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={y}
+            width={barWidth}
+            height={barH}
+            fill="var(--primary)"
+            rx="2"
+          />
+        );
+      })}
+      {ticks.map((d, i) => {
+        const idx = data.indexOf(d);
+        const x = padding.left + (idx / data.length) * chartW + barWidth / 2 + 1;
+        return (
+          <text key={i} x={x} y={height - 5} className="fill-current text-[10px]" textAnchor="middle">
+            {formatShortDate(d.x)}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}
+
+export default function AdminStatsPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const apiToken = (session as { apiToken?: string } | null)?.apiToken;
+  const userRole = (session?.user as { role?: string } | undefined)?.role;
+
+  const [dau, setDau] = useState<DauEntry[]>([]);
+  const [usdcVolume, setUsdcVolume] = useState<UsdcEntry[]>([]);
+  const [topBrands, setTopBrands] = useState<TopBrand[]>([]);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [dateRange, setDateRange] = useState<DateRange>("30");
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+    } else if (status === "authenticated" && userRole !== "admin") {
+      router.push("/dashboard");
+    }
+  }, [status, userRole, router]);
+
+  const loadStats = useCallback(
+    async (days: DateRange) => {
+      if (!apiToken) return;
+      setLoading(true);
+      setError(false);
+      try {
+        const api = createApiClient(apiToken);
+        const res = await api.get("/admin/stats", { params: { days: Number(days) } });
+        setDau(res.data.dau);
+        setUsdcVolume(res.data.usdcVolume);
+        setTopBrands(res.data.topBrands);
+        setSummary(res.data.summary);
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [apiToken]
+  );
+
+  useEffect(() => {
+    if (status === "authenticated" && userRole === "admin") {
+      void loadStats(dateRange);
+    }
+  }, [loadStats, status, userRole, dateRange]);
+
+  if (status === "loading" || (status === "authenticated" && userRole !== "admin")) {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Platform Stats</h1>
+        <div className="flex gap-2">
+          {(["7", "30", "90"] as DateRange[]).map((range) => (
+            <Button
+              key={range}
+              variant={dateRange === range ? "default" : "outline"}
+              size="sm"
+              onClick={() => setDateRange(range)}
+            >
+              {range} days
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-28 w-full" />
+            ))}
+          </div>
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      ) : error ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <p className="text-[var(--muted-foreground)]">Failed to load stats.</p>
+            <Button className="mt-4" onClick={() => void loadStats(dateRange)}>
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {summary && (
+            <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <Card>
+                <CardContent className="pt-6">
+                  <p className="text-3xl font-bold text-[var(--primary)]">
+                    {summary.total_users.toLocaleString()}
+                  </p>
+                  <p className="mt-1 text-sm text-[var(--muted-foreground)]">Total Users</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <p className="text-3xl font-bold text-green-600">
+                    {Number(summary.total_paid_usdc).toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}{" "}
+                    USDC
+                  </p>
+                  <p className="mt-1 text-sm text-[var(--muted-foreground)]">Total USDC Paid</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <p className="text-3xl font-bold text-[var(--primary)]">
+                    {summary.total_completed_sessions.toLocaleString()}
+                  </p>
+                  <p className="mt-1 text-sm text-[var(--muted-foreground)]">Completed Sessions</p>
+                </CardContent>
+              </Card>
+            </div>
+          )}
+
+          <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Daily Active Users</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <LineChart
+                  data={dau.map((d) => ({ x: d.date, y: d.dau }))}
+                  label="DAU"
+                />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">USDC Payout Volume</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <BarChart
+                  data={usdcVolume.map((d) => ({ x: d.date, y: Number(d.total_usdc) }))}
+                  label="USDC Volume"
+                />
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Top Brands</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              {topBrands.length === 0 ? (
+                <div className="py-8 text-center text-sm text-gray-400">No brand data</div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-gray-50 text-left text-xs font-medium text-gray-500">
+                        <th className="px-4 py-3">#</th>
+                        <th className="px-4 py-3">Brand</th>
+                        <th className="px-4 py-3">Completed Sessions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {topBrands.map((brand, i) => (
+                        <tr key={brand.brand_id} className="border-b hover:bg-gray-50">
+                          <td className="px-4 py-3 font-medium">{i + 1}</td>
+                          <td className="px-4 py-3 font-medium">{brand.brand_name}</td>
+                          <td className="px-4 py-3">{brand.completed_sessions.toLocaleString()}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/migrations/020_question_preview_approved.sql
+++ b/migrations/020_question_preview_approved.sql
@@ -1,0 +1,3 @@
+-- Add `approved` column to challenge_questions for question preview workflow.
+-- NULL = not yet reviewed, true = approved, false = flagged for regeneration.
+ALTER TABLE challenge_questions ADD COLUMN IF NOT EXISTS approved BOOLEAN DEFAULT NULL;


### PR DESCRIPTION
## Summary
- New API routes in apps/api/src/routes/brands.ts:
  - GET /brands/:id/questions/preview — returns questions with correct answers for the brand owner
  - POST /brands/:id/questions/:questionId/regenerate — deletes and regenerates a question for the same round
  - POST /brands/:id/questions/:questionId/approve — marks a question as approved
  - POST /brands/:id/questions/:questionId/flag — marks a question as flagged
- New DB functions in apps/api/src/db/queries/challenges.ts: deleteChallengeQuestion, insertChallengeQuestion
- Migration 020_question_preview_approved.sql — adds approved BOOLEAN DEFAULT NULL to challenge_questions
- Frontend page at apps/web/src/app/(brand)/brand/[id]/questions/preview/page.tsx — card-based UI with Previous/Next navigation, Approve/Flag buttons, progress bar, in-place regeneration
Issue #520 — Admin Payout Management Page
- New API route apps/api/src/routes/admin/payouts.ts:
  - GET /admin/payouts — paginated list with status filter tabs, summary stats (total paid, total pending, failed count)
  - POST /admin/payouts/:id/retry — resets failed payout to pending, re-enqueues BullMQ job, writes audit log
- Route registered in apps/api/src/routes/index.ts
- Frontend page at apps/web/src/app/admin/payouts/page.tsx — filter tabs, summary stat cards, table with user/amount/Stellar TX/status/error columns, retry button disabled while in-progress, Stellar Expert links
Issue #508 — SVG Sanitization
- New utility apps/api/src/lib/svg-sanitize.ts — sanitizeSvgText() escapes & < > " ' XML entities
- Applied to brand name and tagline at creation time in apps/api/src/routes/brands.ts
- Unit tests in apps/api/src/lib/svg-sanitize.test.ts — 9 test cases covering all entity types
- Integration tests in apps/api/src/routes/brands.test.ts — verifies Ben & Jerry's <Brand>" is correctly escaped, and plain text passes through unchanged
Issue #522 — Admin Platform Stats Dashboard
- New API route apps/api/src/routes/admin/stats.ts:
  - GET /admin/stats?days=30 — returns DAU line chart data, USDC volume bar chart data, top 10 brands, summary stats
- Route registered in apps/api/src/routes/index.ts
- Frontend page at apps/web/src/app/admin/stats/page.tsx — date range picker (7/30/90 days), DAU line chart (inline SVG), USDC volume bar chart, top brands table, summary cards (total users, total USDC paid, completed sessions), skeleton loading states, error boundary
Files Changed
Modified (4):
- apps/api/src/db/queries/challenges.ts — added deleteChallengeQuestion, insertChallengeQuestion
- apps/api/src/routes/brands.ts — SVG sanitization + 4 new routes
- apps/api/src/routes/brands.test.ts — sanitization regression tests
- apps/api/src/routes/index.ts — registered payouts and stats routes
New (7):
- apps/api/src/lib/svg-sanitize.ts
- apps/api/src/lib/svg-sanitize.test.ts
- apps/api/src/routes/admin/payouts.ts
- apps/api/src/routes/admin/stats.ts
- apps/web/src/app/(brand)/brand/[id]/questions/preview/page.tsx
- apps/web/src/app/admin/payouts/page.tsx
- apps/web/src/app/admin/stats/page.tsx
- migrations/020_question_preview_approved.sql

closes #520 
closes #522 
closes #523 
closes #508 