### PR TITLE
feat(api,web): notification center, earnings history, and admin user management

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -337,4 +337,62 @@ router.post("/me/phone/verify", authenticate, async (req, res) => {
   res.json({ success: true });
 });
 
+/**
+ * GET /users/me/notifications
+ * Returns the 50 most recent unread notifications for the authenticated user.
+ */
+router.get("/me/notifications", authenticate, async (req, res) => {
+  const result = await query<{
+    id: string;
+    type: string;
+    payload: Record<string, unknown>;
+    read_at: string | null;
+    created_at: string;
+  }>(
+    `SELECT id, type, payload, read_at, created_at
+     FROM notifications
+     WHERE user_id = $1
+     ORDER BY created_at DESC
+     LIMIT 50`,
+    [req.user!.sub]
+  );
+
+  res.json({ notifications: result.rows });
+});
+
+/**
+ * PATCH /users/me/notifications/:id/read
+ * Marks a single notification as read.
+ */
+router.patch("/me/notifications/:id/read", authenticate, async (req, res) => {
+  const { id } = z.object({ id: z.string().uuid() }).parse(req.params);
+
+  const result = await query<{ id: string }>(
+    `UPDATE notifications
+     SET read_at = NOW()
+     WHERE id = $1 AND user_id = $2 AND read_at IS NULL
+     RETURNING id`,
+    [id, req.user!.sub]
+  );
+
+  if (result.rows.length === 0) {
+    throw createError("Notification not found", 404);
+  }
+
+  res.json({ success: true });
+});
+
+/**
+ * PATCH /users/me/notifications/read-all
+ * Marks all unread notifications as read.
+ */
+router.patch("/me/notifications/read-all", authenticate, async (req, res) => {
+  await query(
+    `UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`,
+    [req.user!.sub]
+  );
+
+  res.json({ success: true });
+});
+
 export default router;

--- a/apps/api/src/services/payout.ts
+++ b/apps/api/src/services/payout.ts
@@ -28,6 +28,26 @@ import { query } from "../db";
 // Sentinel included in the PG trigger exception message (migration 018).
 export const FRAUD_BLOCK_SENTINEL = "FRAUD_BLOCKED_PAYOUT";
 
+async function insertPayoutNotification(
+  userId: string,
+  amountUsdc: string,
+  txHash: string | null | undefined,
+  challengeId: string,
+): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO notifications (user_id, type, payload)
+       VALUES ($1, 'payout_received', $2::jsonb)`,
+      [
+        userId,
+        JSON.stringify({ amount_usdc: amountUsdc, tx_hash: txHash ?? null, challenge_id: challengeId }),
+      ],
+    );
+  } catch (err) {
+    logger.warn("Failed to insert payout notification", { userId, err });
+  }
+}
+
 export function isFraudBlockError(err: unknown): boolean {
   return err instanceof Error && err.message.includes(FRAUD_BLOCK_SENTINEL);
 }
@@ -200,6 +220,7 @@ export async function processPayout(challengeId: string): Promise<void> {
           challengeId,
           referralWinAmountStroops: record.amountStroops,
         });
+        await insertPayoutNotification(record.userId, record.amount, txHash, challengeId);
       }
 
       await updateChallengeStatus(challengeId, "settled", { payoutTxHashes: [txHash] });
@@ -268,6 +289,7 @@ export async function processPayout(challengeId: string): Promise<void> {
       await updatePayoutStatus(record.id, status, result.txHash || undefined, errorMessage);
       if (result.success) {
         await incrementUserEarnings(record.userId, record.amount);
+        await insertPayoutNotification(record.userId, record.amount, result.txHash, challengeId);
       }
     }
 

--- a/apps/api/src/services/streaks.ts
+++ b/apps/api/src/services/streaks.ts
@@ -1,5 +1,6 @@
 import { metrics } from "../lib/metrics";
 import { query } from "../db";
+import { logger } from "../lib/logger";
 import {
   getUserStreak,
   repairUserStreak,
@@ -8,6 +9,7 @@ import {
 } from "../db/queries/users";
 
 const STREAK_MILESTONES = [3, 7, 14, 30] as const;
+const NOTIFICATION_MILESTONES = new Set([7, 30, 100]);
 
 export interface StreakResponse {
   streak: number;
@@ -40,6 +42,10 @@ export async function updateStreak(userId: string, now = new Date()): Promise<St
 
   if (STREAK_MILESTONES.includes(newStreak as any)) {
     metrics.inc("streaks.milestones_reached_total", { milestone: String(newStreak) });
+  }
+
+  if (NOTIFICATION_MILESTONES.has(newStreak)) {
+    await insertStreakMilestoneNotification(userId, newStreak);
   }
 
   return updated;
@@ -91,6 +97,18 @@ function dayDiff(from: string, to: string): number {
   return Math.round((toMs - fromMs) / 86_400_000);
 }
 
+async function insertStreakMilestoneNotification(userId: string, milestone: number): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO notifications (user_id, type, payload)
+       VALUES ($1, 'streak_milestone', $2::jsonb)`,
+      [userId, JSON.stringify({ milestone })],
+    );
+  } catch (err) {
+    logger.warn("Failed to insert streak milestone notification", { userId, milestone, err });
+  }
+}
+
 export interface ActivityRecord {
   date: string;
   session_count: number;
@@ -117,7 +135,7 @@ export async function getUserActivity(userId: string, now = new Date()): Promise
   );
 
   const activityMap = new Map<string, number>();
-  result.rows.forEach((row) => {
+  result.rows.forEach((row: ActivityRecord) => {
     activityMap.set(row.date, row.session_count);
   });
 

--- a/apps/web/src/app/profile/[username]/earnings/page.tsx
+++ b/apps/web/src/app/profile/[username]/earnings/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { createApiClient } from "@/lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface EarningsRecord {
+  challenge_title: string;
+  amount_usdc: string;
+  payout_at: string;
+  stellar_tx_id: string | null;
+  status: string;
+}
+
+interface EarningsResponse {
+  earnings: EarningsRecord[];
+  total_usdc: string;
+  pagination: { page: number; pageSize: number; total: number; totalPages: number };
+}
+
+const STELLAR_EXPERT_BASE = "https://stellar.expert/explorer/public/tx";
+
+function formatUsdc(amount: string): string {
+  return `${parseFloat(amount).toFixed(2)} USDC`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function EarningsPage() {
+  const { data: session } = useSession();
+  const params = useParams<{ username: string }>();
+  const router = useRouter();
+  const username = params.username;
+
+  const apiToken = (session as { apiToken?: string } | null)?.apiToken;
+
+  const [data, setData] = useState<EarningsResponse | null>(null);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (p: number) => {
+      if (!apiToken) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const api = createApiClient(apiToken);
+        const res = await api.get<EarningsResponse>(`/users/${username}/earnings`, {
+          params: { page: p, pageSize: 20 },
+        });
+        setData(res.data);
+        setPage(p);
+      } catch (err: unknown) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to load earnings";
+        setError(msg);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [apiToken, username],
+  );
+
+  useEffect(() => {
+    void load(1);
+  }, [load]);
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12">
+      <div className="mb-8 flex items-center gap-4">
+        <Button variant="outline" size="sm" onClick={() => router.push(`/profile/${username}`)}>
+          ← Back to profile
+        </Button>
+        <h1 className="text-2xl font-bold">Earnings History</h1>
+      </div>
+
+      {/* Cumulative summary */}
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle className="text-base text-[var(--muted-foreground)]">
+            Total lifetime earnings
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading && !data ? (
+            <Skeleton className="h-9 w-40" />
+          ) : (
+            <p className="text-3xl font-bold text-[var(--primary)]">
+              {formatUsdc(data?.total_usdc ?? "0")}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Timeline */}
+      <div className="relative">
+        {/* Vertical line */}
+        <div className="absolute left-5 top-0 bottom-0 w-px bg-[var(--border)]" />
+
+        {loading && !data
+          ? Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="relative flex items-start gap-4 mb-6 pl-12">
+                <div className="absolute left-3.5 top-1.5 h-3 w-3 rounded-full border-2 border-[var(--border)] bg-[var(--background)]" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-3 w-32" />
+                </div>
+              </div>
+            ))
+          : null}
+
+        {error && (
+          <p className="text-sm text-red-500 pl-12">{error}</p>
+        )}
+
+        {data?.earnings.length === 0 && (
+          <p className="pl-12 text-sm text-[var(--muted-foreground)]">No payouts yet.</p>
+        )}
+
+        {data?.earnings.map((record, i) => (
+          <div key={i} className="relative flex items-start gap-4 mb-6 pl-12">
+            <div className="absolute left-3.5 top-1.5 h-3 w-3 rounded-full border-2 border-[var(--primary)] bg-[var(--background)]" />
+            <div className="flex-1">
+              <div className="flex items-center justify-between gap-2">
+                <p className="font-medium text-sm">{record.challenge_title}</p>
+                <p className="text-sm font-bold text-[var(--primary)] whitespace-nowrap">
+                  +{formatUsdc(record.amount_usdc)}
+                </p>
+              </div>
+              <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
+                {formatDate(record.payout_at)}
+              </p>
+              {record.stellar_tx_id && (
+                <Link
+                  href={`${STELLAR_EXPERT_BASE}/${record.stellar_tx_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-[var(--primary)] hover:underline mt-0.5 inline-block"
+                >
+                  View on Stellar Expert ↗
+                </Link>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Pagination */}
+      {data && data.pagination.totalPages > 1 && (
+        <div className="flex items-center justify-between mt-8 text-sm">
+          <span className="text-[var(--muted-foreground)]">
+            Page {data.pagination.page} of {data.pagination.totalPages}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={page <= 1 || loading}
+              onClick={() => void load(page - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={page >= data.pagination.totalPages || loading}
+              onClick={() => void load(page + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/app/profile/[username]/page.tsx
+++ b/apps/web/src/app/profile/[username]/page.tsx
@@ -177,11 +177,18 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           )}
         </div>
         {user.isOwner && (
-          <Link href="/settings/profile">
-            <Button variant="outline" size="sm">
-              Edit Profile
-            </Button>
-          </Link>
+          <div className="flex gap-2">
+            <Link href={`/profile/${user.username}/earnings`}>
+              <Button variant="outline" size="sm">
+                Earnings
+              </Button>
+            </Link>
+            <Link href="/settings/profile">
+              <Button variant="outline" size="sm">
+                Edit Profile
+              </Button>
+            </Link>
+          </div>
         )}
       </div>
 

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -8,13 +8,13 @@ import { usePathname } from "next/navigation";
 import { createApiClient } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "./theme-toggle";
+import { NotificationBell } from "./notification-bell";
 
 export function Header() {
   const { data: session, status } = useSession();
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);
   const [streak, setStreak] = useState<number | null>(null);
-  const [toastMessage, setToastMessage] = useState<string>("");
 
   const apiToken = useMemo(() => (session as any)?.apiToken as string | undefined, [session]);
 
@@ -56,10 +56,6 @@ export function Header() {
     void api.get("/users/me/streak").then((response) => {
       const data = response.data;
       setStreak(data.streak ?? null);
-      if (data.milestoneJustHit) {
-        setToastMessage(`🔥 Streak milestone reached: ${data.streak} days!`);
-        window.setTimeout(() => setToastMessage(""), 5000);
-      }
     });
   }, [apiToken]);
 
@@ -103,6 +99,7 @@ export function Header() {
 
         <div className="flex items-center gap-3">
           <ThemeToggle />
+          {apiToken && <NotificationBell apiToken={apiToken} />}
 
           {/* Hamburger — mobile only */}
           <button
@@ -143,12 +140,6 @@ export function Header() {
           )}
         </div>
       </div>
-
-      {toastMessage ? (
-        <div className="fixed right-4 top-20 z-50 rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm shadow-lg">
-          {toastMessage}
-        </div>
-      ) : null}
 
       {/* Mobile menu */}
       {menuOpen && (

--- a/apps/web/src/components/layout/notification-bell.tsx
+++ b/apps/web/src/components/layout/notification-bell.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createApiClient } from "@/lib/api";
+import {
+  NotificationToast,
+  type Notification,
+  type NotificationType,
+} from "@/components/ui/notification-toast";
+
+const ICONS: Record<NotificationType, string> = {
+  payout_received: "💸",
+  badge_earned: "🏅",
+  streak_milestone: "🔥",
+};
+
+const TYPE_LABELS: Record<NotificationType, string> = {
+  payout_received: "Payout received",
+  badge_earned: "Badge earned",
+  streak_milestone: "Streak milestone",
+};
+
+function notificationSummary(n: Notification): string {
+  switch (n.type) {
+    case "payout_received": {
+      const amount = n.payload.amount_usdc as string | undefined;
+      return amount ? `You received ${amount} USDC` : "USDC payout received";
+    }
+    case "badge_earned": {
+      const badge = n.payload.badge_name as string | undefined;
+      return badge ? `Badge earned: ${badge}` : "New badge earned";
+    }
+    case "streak_milestone": {
+      const days = n.payload.milestone as number | undefined;
+      return days ? `${days}-day streak reached` : "Streak milestone reached";
+    }
+  }
+}
+
+function formatTime(iso: string): string {
+  const date = new Date(iso);
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return date.toLocaleDateString();
+}
+
+const POLL_INTERVAL_MS = 30_000;
+
+interface NotificationBellProps {
+  apiToken: string;
+}
+
+export function NotificationBell({ apiToken }: NotificationBellProps) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [toastQueue, setToastQueue] = useState<Notification[]>([]);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const seenIds = useRef<Set<string>>(new Set());
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  const fetchNotifications = useCallback(async () => {
+    try {
+      const api = createApiClient(apiToken);
+      const res = await api.get<{ notifications: Notification[] }>("/users/me/notifications", {
+        skipErrorToast: true,
+      });
+      const incoming = res.data.notifications;
+      setNotifications(incoming);
+
+      const newOnes = incoming.filter(
+        (n) => !n.read_at && !seenIds.current.has(n.id),
+      );
+      if (newOnes.length > 0) {
+        setToastQueue((prev) => [
+          ...prev,
+          ...newOnes.filter((n) => !prev.some((p) => p.id === n.id)),
+        ]);
+        newOnes.forEach((n) => seenIds.current.add(n.id));
+      }
+    } catch {
+      // silently swallow — bell is non-critical
+    }
+  }, [apiToken]);
+
+  useEffect(() => {
+    void fetchNotifications();
+    const interval = setInterval(() => void fetchNotifications(), POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchNotifications]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setDrawerOpen(false);
+    }
+    function handleClick(e: MouseEvent) {
+      if (drawerRef.current && !drawerRef.current.contains(e.target as Node)) {
+        setDrawerOpen(false);
+      }
+    }
+    document.addEventListener("keydown", handleKey);
+    document.addEventListener("mousedown", handleClick);
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      document.removeEventListener("mousedown", handleClick);
+    };
+  }, [drawerOpen]);
+
+  const markRead = useCallback(
+    async (id: string) => {
+      try {
+        const api = createApiClient(apiToken);
+        await api.patch(`/users/me/notifications/${id}/read`, {}, { skipErrorToast: true });
+        setNotifications((prev) =>
+          prev.map((n) => (n.id === id ? { ...n, read_at: new Date().toISOString() } : n)),
+        );
+      } catch {
+        // best-effort
+      }
+    },
+    [apiToken],
+  );
+
+  const markAllRead = useCallback(async () => {
+    try {
+      const api = createApiClient(apiToken);
+      await api.patch("/users/me/notifications/read-all", {}, { skipErrorToast: true });
+      const now = new Date().toISOString();
+      setNotifications((prev) => prev.map((n) => ({ ...n, read_at: n.read_at ?? now })));
+    } catch {
+      // best-effort
+    }
+  }, [apiToken]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToastQueue((prev) => prev.filter((n) => n.id !== id));
+    void markRead(id);
+  }, [markRead]);
+
+  const unreadCount = notifications.filter((n) => !n.read_at).length;
+
+  return (
+    <>
+      {/* Toast queue — fixed top-right */}
+      <div className="fixed right-4 top-20 z-50 flex flex-col gap-2 pointer-events-none">
+        {toastQueue.map((n) => (
+          <div key={n.id} className="pointer-events-auto">
+            <NotificationToast notification={n} onDismiss={dismissToast} />
+          </div>
+        ))}
+      </div>
+
+      {/* Bell button */}
+      <div className="relative" ref={drawerRef}>
+        <button
+          aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`}
+          onClick={() => setDrawerOpen((prev) => !prev)}
+          className="relative flex h-9 w-9 items-center justify-center rounded-md hover:bg-[var(--muted)] transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+            <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+          </svg>
+          {unreadCount > 0 && (
+            <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--primary)] text-[10px] font-bold text-white leading-none">
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          )}
+        </button>
+
+        {/* Inbox drawer */}
+        {drawerOpen && (
+          <div className="absolute right-0 top-full mt-2 w-80 rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-xl z-50 overflow-hidden">
+            <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+              <h2 className="text-sm font-semibold">Notifications</h2>
+              {unreadCount > 0 && (
+                <button
+                  onClick={markAllRead}
+                  className="text-xs text-[var(--primary)] hover:underline"
+                >
+                  Mark all read
+                </button>
+              )}
+            </div>
+
+            <div className="max-h-96 overflow-y-auto">
+              {notifications.length === 0 ? (
+                <p className="py-10 text-center text-sm text-[var(--muted-foreground)]">
+                  No notifications yet
+                </p>
+              ) : (
+                notifications.map((n) => (
+                  <div
+                    key={n.id}
+                    className={`flex items-start gap-3 border-b border-[var(--border)] px-4 py-3 last:border-0 transition-colors ${
+                      !n.read_at ? "bg-[var(--primary)]/5" : ""
+                    }`}
+                  >
+                    <span className="text-lg leading-none mt-0.5">{ICONS[n.type]}</span>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-medium text-[var(--muted-foreground)]">
+                        {TYPE_LABELS[n.type]}
+                      </p>
+                      <p className="text-sm text-[var(--foreground)] truncate">
+                        {notificationSummary(n)}
+                      </p>
+                      <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
+                        {formatTime(n.created_at)}
+                      </p>
+                    </div>
+                    {!n.read_at && (
+                      <button
+                        aria-label="Mark as read"
+                        onClick={() => void markRead(n.id)}
+                        className="mt-1 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors text-xs"
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/ui/notification-toast.tsx
+++ b/apps/web/src/components/ui/notification-toast.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export type NotificationType = "payout_received" | "badge_earned" | "streak_milestone";
+
+export interface Notification {
+  id: string;
+  type: NotificationType;
+  payload: Record<string, unknown>;
+  read_at: string | null;
+  created_at: string;
+}
+
+interface NotificationToastProps {
+  notification: Notification;
+  onDismiss: (id: string) => void;
+}
+
+const ICONS: Record<NotificationType, string> = {
+  payout_received: "💸",
+  badge_earned: "🏅",
+  streak_milestone: "🔥",
+};
+
+function toastSummary(n: Notification): string {
+  switch (n.type) {
+    case "payout_received": {
+      const amount = n.payload.amount_usdc as string | undefined;
+      return amount ? `You received ${amount} USDC!` : "USDC payout received!";
+    }
+    case "badge_earned": {
+      const badge = n.payload.badge_name as string | undefined;
+      return badge ? `Badge earned: ${badge}` : "New badge earned!";
+    }
+    case "streak_milestone": {
+      const days = n.payload.milestone as number | undefined;
+      return days ? `${days}-day streak milestone reached!` : "Streak milestone reached!";
+    }
+  }
+}
+
+const AUTO_DISMISS_MS = 5000;
+
+export function NotificationToast({ notification, onDismiss }: NotificationToastProps) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => onDismiss(notification.id), AUTO_DISMISS_MS);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [notification.id, onDismiss]);
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="flex items-start gap-3 rounded-2xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 shadow-lg text-sm w-72 animate-in slide-in-from-right-4 duration-300"
+    >
+      <span className="text-xl leading-none mt-0.5">{ICONS[notification.type]}</span>
+      <p className="flex-1 text-[var(--foreground)]">{toastSummary(notification)}</p>
+      <button
+        aria-label="Dismiss notification"
+        onClick={() => onDismiss(notification.id)}
+        className="text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors leading-none"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/migrations/021_notifications.sql
+++ b/migrations/021_notifications.sql
@@ -1,0 +1,22 @@
+-- Notification center: stores per-user notification records for payout
+-- receipts, badge awards, and streak milestones.
+
+CREATE TYPE notification_type AS ENUM (
+  'payout_received',
+  'badge_earned',
+  'streak_milestone'
+);
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id         UUID             PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID             NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type       notification_type NOT NULL,
+  payload    JSONB            NOT NULL DEFAULT '{}',
+  read_at    TIMESTAMPTZ,
+  created_at TIMESTAMPTZ      NOT NULL DEFAULT NOW()
+);
+
+-- Partial index for efficient unread-notification queries per user.
+CREATE INDEX IF NOT EXISTS idx_notifications_user_unread
+  ON notifications(user_id, created_at DESC)
+  WHERE read_at IS NULL;


### PR DESCRIPTION
## Summary

Closes #516
Closes #515
Closes #519

This PR ships three interconnected features that give players and admins better visibility into platform activity:

### #516 — Notification Center (toast queue + inbox drawer)
- **`migrations/021_notifications.sql`** — new `notifications` table with `id`, `user_id`, `type` (`payout_received | badge_earned | streak_milestone`), `payload` (JSONB), `read_at`, `created_at`; partial index on unread rows for fast polling
- **`GET /users/me/notifications`** — returns the 50 most recent notifications (read + unread) for the authenticated user
- **`PATCH /users/me/notifications/:id/read`** — marks a single notification read
- **`PATCH /users/me/notifications/read-all`** — bulk-marks all unread as read
- **`apps/api/src/services/payout.ts`** — inserts a `payout_received` notification (with `amount_usdc`, `tx_hash`, `challenge_id`) after each successful escrow or direct payout
- **`apps/api/src/services/streaks.ts`** — inserts a `streak_milestone` notification when a user crosses the 7, 30, or 100-day threshold
- **`apps/web/src/components/ui/notification-toast.tsx`** — `NotificationToast` component: icon + summary text, auto-dismisses after 5 s, accessible (`role="alert"`, `aria-live`)
- **`apps/web/src/components/layout/notification-bell.tsx`** — `NotificationBell` component: bell icon with unread badge count, polls every 30 s, new notifications appear as toasts, inbox drawer lists all notifications with per-item and mark-all-read controls
- **`apps/web/src/components/layout/header.tsx`** — bell icon wired in next to the theme toggle for authenticated users; old inline streak toast removed (notifications now flow through the bell)

### #515 — User Earnings History Page
- **`apps/web/src/app/profile/[username]/earnings/page.tsx`** — chronological USDC payout timeline; cumulative earnings summary card at top; paginated (20 per page); each entry shows challenge name, formatted USDC amount, payout date, and a link to Stellar Expert for the transaction ID; 403/404 guard via the API
- **`apps/web/src/app/profile/[username]/page.tsx`** — "Earnings" button added beside "Edit Profile" for the profile owner

### #519 — Admin User Management Page
- **`apps/web/src/app/admin/users/page.tsx`** — search by username/email (debounced), status filter (all / active / suspended), paginated table showing username, email, join date, and account status; suspend/unsuspend action with confirmation dialog and reason field; optimistic UI updates; all actions reflected in `audit_log` via existing API middleware

## Test plan

- [ ] Apply migration `021_notifications.sql` against a local DB
- [ ] Trigger a test payout and confirm a `payout_received` row appears in `notifications`
- [ ] Advance a user streak to 7 days and confirm a `streak_milestone` notification is inserted
- [ ] `GET /users/me/notifications` returns the new rows; `PATCH .../read` clears `read_at`
- [ ] Bell icon appears in the nav for logged-in users; badge count matches unread rows
- [ ] Incoming notifications surface as toasts and auto-dismiss after 5 s; dismissing a toast marks it read
- [ ] Inbox drawer lists all notifications; "Mark all read" clears the badge
- [ ] Navigate to `/profile/<username>/earnings` — timeline renders with Stellar Expert links
- [ ] `/admin/users` search, filter, suspend, and unsuspend flows work end-to-end