### PR TITLE
Fix/issues 342 347 505 509 security and perf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ REDIS_URL=redis://localhost:6379
 # PostgreSQL superuser password. Rotate every 90 days via runbook.
 POSTGRES_PASSWORD=brandblitz_dev
 
+# Session-start brute-force lockout (apps/api/src/middleware/anti-cheat.ts).
+# Locks an account for the window after this many failed session-start attempts.
+# Also tunable at runtime via the app_config key `session_start_lockout`.
+SESSION_START_LOCKOUT_THRESHOLD=10
+SESSION_START_LOCKOUT_WINDOW_SECONDS=3600
+
 # === Auth & Frontend ===
 # Minimum 32 characters for JWT security. Used by apps/api for session signing.
 # Rotate every 90 days via docs/runbooks/secrets-rotation.md.

--- a/.github/workflows/db-dual-path.yml
+++ b/.github/workflows/db-dual-path.yml
@@ -86,6 +86,22 @@ jobs:
           grep -v '^--' /tmp/schema_migration.sql | sort > /tmp/migration_sorted.sql
           diff /tmp/fresh_sorted.sql /tmp/migration_sorted.sql && echo "Schemas match" || (echo "Schema divergence detected" && exit 1)
 
+      # ── Index usage verification (issue #342) ───────────────────────────────
+      - name: Verify fraud_flags admin queries use index scans
+        env:
+          PGPASSWORD: bb
+        run: |
+          PLAN=$(psql -h localhost -p 5433 -U bb -d brandblitz_fresh -X -A -t -c \
+            "SET enable_seqscan = off; EXPLAIN ANALYZE SELECT * FROM fraud_flags WHERE user_id = '00000000-0000-0000-0000-000000000000';")
+          echo "$PLAN"
+          echo "$PLAN" | grep -q "idx_fraud_flags_user_id" \
+            || (echo "Expected index scan on idx_fraud_flags_user_id, got seq scan" && exit 1)
+          ORDER_PLAN=$(psql -h localhost -p 5433 -U bb -d brandblitz_fresh -X -A -t -c \
+            "SET enable_seqscan = off; EXPLAIN ANALYZE SELECT * FROM fraud_flags ORDER BY created_at DESC LIMIT 100;")
+          echo "$ORDER_PLAN"
+          echo "$ORDER_PLAN" | grep -q "idx_fraud_flags_created_at" \
+            || (echo "Expected index scan on idx_fraud_flags_created_at, got seq scan" && exit 1)
+
       - name: Install tbls
         run: |
           GOBIN=$HOME/go/bin go install github.com/k1LoW/tbls@latest

--- a/apps/api/src/db/queries/fraud-flags.test.ts
+++ b/apps/api/src/db/queries/fraud-flags.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const queryMock = vi.fn();
+
+vi.mock("../index", () => ({
+  query: (...args: unknown[]) => queryMock(...args),
+}));
+
+import { getFraudFlags } from "./fraud-flags";
+import { CursorQuerySchema } from "../pagination";
+
+function lastQueries(): string[] {
+  return queryMock.mock.calls.map((c) => String(c[0]));
+}
+
+describe("getFraudFlags index-aligned query (issue #342)", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    // rows query + count query both resolve
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] });
+  });
+
+  it("orders by the indexed created_at column, newest first", async () => {
+    await getFraudFlags({ pageSize: 20 });
+    const rowsSql = lastQueries().find((q) => q.includes("FROM fraud_flags ff"));
+    expect(rowsSql).toBeDefined();
+    expect(rowsSql).toMatch(/ORDER BY ff\.created_at DESC/);
+  });
+
+  it("bounds the result set with a LIMIT placeholder", async () => {
+    await getFraudFlags({ pageSize: 20 });
+    const rowsSql = lastQueries().find((q) => q.includes("FROM fraud_flags ff"));
+    expect(rowsSql).toMatch(/LIMIT \$\d+/);
+  });
+
+  it("passes the page size through as the LIMIT parameter", async () => {
+    await getFraudFlags({ pageSize: 50 });
+    const rowsCall = queryMock.mock.calls.find((c) =>
+      String(c[0]).includes("FROM fraud_flags ff"),
+    );
+    const params = rowsCall?.[1] as unknown[];
+    expect(params[params.length - 1]).toBe(50);
+  });
+});
+
+describe("CursorQuerySchema page-size cap (issue #342)", () => {
+  it("rejects a page size above the 100-row cap", () => {
+    expect(() => CursorQuerySchema.parse({ limit: 101 })).toThrow();
+  });
+
+  it("accepts the maximum page size of 100", () => {
+    expect(CursorQuerySchema.parse({ limit: 100 }).limit).toBe(100);
+  });
+
+  it("defaults to a bounded page size when omitted", () => {
+    const parsed = CursorQuerySchema.parse({});
+    expect(parsed.limit).toBeLessThanOrEqual(100);
+  });
+});

--- a/apps/api/src/lib/config-schema.ts
+++ b/apps/api/src/lib/config-schema.ts
@@ -12,6 +12,11 @@ export const configSchema = z.object({
   DB_SLOW_QUERY_MS: z.coerce.number().int().positive().default(250),
   WARMUP_COMPLETE_LOCK_TIMEOUT_MS: z.coerce.number().int().positive().default(2_000),
 
+  // Session-start brute-force lockout (issue #509). Tunable at runtime via the
+  // app_config key `session_start_lockout`; these are the fallback defaults.
+  SESSION_START_LOCKOUT_THRESHOLD: z.coerce.number().int().positive().default(10),
+  SESSION_START_LOCKOUT_WINDOW_SECONDS: z.coerce.number().int().positive().default(3_600),
+
   // Auth
   JWT_SECRET: z.string().min(32),
   /** Set during rotation: the secret being phased out. Both old + new are accepted

--- a/apps/api/src/middleware/anti-cheat.test.ts
+++ b/apps/api/src/middleware/anti-cheat.test.ts
@@ -6,6 +6,8 @@ import * as sessionQueries from "../db/queries/sessions";
 
 vi.mock("../db/queries/fraud-flags");
 vi.mock("../db/queries/sessions");
+vi.mock("../db/queries/config", () => ({ getConfig: vi.fn().mockResolvedValue(null) }));
+vi.mock("../db/index", () => ({ query: vi.fn().mockResolvedValue({ rows: [] }) }));
 vi.mock("../lib/redis", () => ({
   redis: {
     sadd: vi.fn().mockResolvedValue(1),
@@ -13,6 +15,8 @@ vi.mock("../lib/redis", () => ({
     scard: vi.fn().mockResolvedValue(1),
     get: vi.fn(),
     set: vi.fn(),
+    ttl: vi.fn().mockResolvedValue(-2),
+    incr: vi.fn().mockResolvedValue(1),
   },
 }));
 vi.mock("../lib/metrics", () => ({
@@ -24,6 +28,31 @@ vi.mock("../lib/fingerprint", () => ({
 
 import { redis } from "../lib/redis";
 import { computeFingerprint } from "../lib/fingerprint";
+import { requireSessionStartAllowed } from "./anti-cheat";
+import { getConfig } from "../db/queries/config";
+import { query } from "../db/index";
+
+// A minimal Express-like response that records headers and dispatches the
+// "finish" event the lockout middleware listens on.
+function makeRes() {
+  const listeners: Record<string, Array<() => void>> = {};
+  return {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    setHeader(key: string, value: string) {
+      this.headers[key] = value;
+    },
+    on(event: string, cb: () => void) {
+      (listeners[event] ??= []).push(cb);
+      return this;
+    },
+    emit(event: string) {
+      (listeners[event] ?? []).forEach((cb) => cb());
+    },
+  };
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
 
 describe("anti-cheat middleware", () => {
   let req: any;
@@ -241,6 +270,120 @@ describe("anti-cheat middleware", () => {
         code: "ROUND_SCORE_OUT_OF_RANGE",
       });
       expect(fraudQueries.createFraudFlag).toHaveBeenCalled();
+    });
+  });
+
+  describe("requireSessionStartAllowed", () => {
+    let lockReq: any;
+    let lockRes: ReturnType<typeof makeRes>;
+    let lockNext: any;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      lockReq = { user: { sub: "user-1" } };
+      lockRes = makeRes();
+      lockNext = vi.fn();
+      (getConfig as any).mockResolvedValue(null);
+      (redis.get as any).mockResolvedValue(null);
+      (redis.ttl as any).mockResolvedValue(-2);
+      (redis.incr as any).mockResolvedValue(1);
+      (redis.expire as any).mockResolvedValue(1);
+      (query as any).mockResolvedValue({ rows: [] });
+    });
+
+    it("allows the request when under the threshold", async () => {
+      await requireSessionStartAllowed(lockReq, lockRes as any, lockNext);
+      expect(lockNext).toHaveBeenCalledTimes(1);
+    });
+
+    it("increments the failure counter only when the start attempt fails", async () => {
+      await requireSessionStartAllowed(lockReq, lockRes as any, lockNext);
+
+      lockRes.statusCode = 400;
+      lockRes.emit("finish");
+      await flush();
+
+      expect(redis.incr).toHaveBeenCalledWith("lockout:session_start:user-1");
+    });
+
+    it("does NOT increment the counter on a successful start", async () => {
+      await requireSessionStartAllowed(lockReq, lockRes as any, lockNext);
+
+      lockRes.statusCode = 200;
+      lockRes.emit("finish");
+      await flush();
+
+      expect(redis.incr).not.toHaveBeenCalled();
+    });
+
+    it("sets a 1-hour expiry when recording the first failure", async () => {
+      (redis.incr as any).mockResolvedValue(1);
+      await requireSessionStartAllowed(lockReq, lockRes as any, lockNext);
+
+      lockRes.statusCode = 429;
+      lockRes.emit("finish");
+      await flush();
+
+      expect(redis.expire).toHaveBeenCalledWith("lockout:session_start:user-1", 3600);
+    });
+
+    it("blocks with 429 and Retry-After once the threshold is reached", async () => {
+      (redis.get as any).mockResolvedValue("10");
+      (redis.ttl as any).mockResolvedValue(1800);
+
+      await expect(
+        requireSessionStartAllowed(lockReq, lockRes as any, lockNext)
+      ).rejects.toMatchObject({ statusCode: 429, code: "SESSION_START_LOCKED" });
+
+      expect(lockRes.headers["Retry-After"]).toBe("1800");
+      expect(lockNext).not.toHaveBeenCalled();
+    });
+
+    it("writes a session_start_lockout audit event when the counter hits the threshold", async () => {
+      (redis.get as any).mockResolvedValue("9");
+      (redis.incr as any).mockResolvedValue(10);
+
+      await requireSessionStartAllowed(lockReq, lockRes as any, lockNext);
+      lockRes.statusCode = 400;
+      lockRes.emit("finish");
+      await flush();
+
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO audit_log"),
+        expect.arrayContaining(["user-1"])
+      );
+      const auditCall = (query as any).mock.calls.find((c: any[]) =>
+        String(c[0]).includes("session_start_lockout")
+      );
+      expect(auditCall).toBeDefined();
+    });
+
+    it("honours app_config overrides for threshold and window", async () => {
+      (getConfig as any).mockResolvedValue({ threshold: 2, window_seconds: 60 });
+      (redis.get as any).mockResolvedValue("2");
+      (redis.ttl as any).mockResolvedValue(60);
+
+      await expect(
+        requireSessionStartAllowed(lockReq, lockRes as any, lockNext)
+      ).rejects.toMatchObject({ statusCode: 429 });
+      expect(lockRes.headers["Retry-After"]).toBe("60");
+    });
+
+    it("fails open when Redis is unavailable", async () => {
+      (redis.get as any).mockRejectedValue(new Error("Redis down"));
+
+      await requireSessionStartAllowed(lockReq, lockRes as any, lockNext);
+
+      expect(lockNext).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips the check for unauthenticated requests", async () => {
+      lockReq.user = undefined;
+
+      await requireSessionStartAllowed(lockReq, lockRes as any, lockNext);
+
+      expect(lockNext).toHaveBeenCalledTimes(1);
+      expect(redis.get).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/middleware/anti-cheat.ts
+++ b/apps/api/src/middleware/anti-cheat.ts
@@ -9,6 +9,8 @@ import { computeFingerprint } from "../lib/fingerprint";
 import { createError } from "./error";
 import { normalizeClientIp } from "./rate-limit";
 import { MAX_ROUND_SCORE, MAX_TOTAL_SCORE } from "../services/scoring";
+import { config } from "../lib/config";
+import { query } from "../db/index";
 
 export const BOT_REACTION_THRESHOLD_MS = 80;
 // Fallback defaults — override at runtime via PATCH /admin/config/anti_cheat.thresholds
@@ -253,6 +255,135 @@ export async function validateRoundScore(
       "ROUND_SCORE_OUT_OF_RANGE"
     );
   }
+
+  next();
+}
+
+// ─── Session-start brute-force lockout (issue #509) ──────────────────────────
+
+const SESSION_START_LOCKOUT_CONFIG_KEY = "session_start_lockout";
+
+interface SessionStartLockoutConfig {
+  threshold: number;
+  windowSeconds: number;
+}
+
+function sessionStartLockoutKey(userId: string): string {
+  return `lockout:session_start:${userId}`;
+}
+
+/**
+ * Resolve the lockout threshold/window, preferring the runtime-tunable
+ * app_config key `session_start_lockout` and falling back to env-configured
+ * defaults so ops can adjust limits without a deploy.
+ */
+async function getSessionStartLockoutConfig(): Promise<SessionStartLockoutConfig> {
+  const fallback: SessionStartLockoutConfig = {
+    threshold: config.SESSION_START_LOCKOUT_THRESHOLD,
+    windowSeconds: config.SESSION_START_LOCKOUT_WINDOW_SECONDS,
+  };
+  try {
+    const cfg = await getConfig(SESSION_START_LOCKOUT_CONFIG_KEY);
+    const threshold = Number(cfg?.threshold);
+    const windowSeconds = Number(cfg?.window_seconds);
+    return {
+      threshold: Number.isFinite(threshold) && threshold > 0 ? threshold : fallback.threshold,
+      windowSeconds:
+        Number.isFinite(windowSeconds) && windowSeconds > 0
+          ? windowSeconds
+          : fallback.windowSeconds,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeSessionStartLockoutAudit(
+  userId: string,
+  cfg: SessionStartLockoutConfig
+): Promise<void> {
+  await query(
+    `INSERT INTO audit_log (actor_id, action, entity, entity_key, before, after)
+     VALUES ($1, 'session_start_lockout', 'user', $2, $3, $4)`,
+    [userId, userId, null, { threshold: cfg.threshold, windowSeconds: cfg.windowSeconds }]
+  );
+}
+
+/**
+ * Brute-force guard for POST /sessions/:challengeId/start.
+ *
+ * Maintains a rolling failure counter in Redis per user
+ * (`lockout:session_start:{userId}`). Once the configured threshold of failed
+ * start attempts is reached within the window, further start requests are
+ * rejected with HTTP 429 + Retry-After until the key's TTL expires. Successful
+ * starts never increment or consume the counter. Fails open if Redis is down.
+ */
+export async function requireSessionStartAllowed(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  const userId = req.user?.sub;
+  if (!userId) {
+    next();
+    return;
+  }
+
+  const key = sessionStartLockoutKey(userId);
+  const cfg = await getSessionStartLockoutConfig();
+
+  let count = 0;
+  let ttl = cfg.windowSeconds;
+  try {
+    const [raw, currentTtl] = await Promise.all([redis.get(key), redis.ttl(key)]);
+    count = raw ? parseInt(raw, 10) : 0;
+    if (typeof currentTtl === "number" && currentTtl > 0) ttl = currentTtl;
+  } catch (error) {
+    // Redis outage must never block legitimate logins — fail open.
+    logger.warn("Redis unavailable during session-start lockout check; failing open", {
+      userId,
+      error: (error as Error).message,
+    });
+    next();
+    return;
+  }
+
+  if (count >= cfg.threshold) {
+    res.setHeader("Retry-After", String(ttl));
+    metrics.inc("antiCheat.session_start_lockout_total", {});
+    throw createError(
+      "Too many failed session start attempts. Please try again later.",
+      429,
+      "SESSION_START_LOCKED"
+    );
+  }
+
+  // Increment the failure counter only when the start attempt actually fails.
+  // Registered before next() so the listener observes the final status code.
+  res.on("finish", () => {
+    if (res.statusCode < 400) return;
+    void (async () => {
+      try {
+        const updated = await redis.incr(key);
+        if (updated === 1) {
+          await redis.expire(key, cfg.windowSeconds);
+        }
+        if (updated === cfg.threshold) {
+          await writeSessionStartLockoutAudit(userId, cfg).catch((error) => {
+            logger.warn("Failed to write session_start_lockout audit event", {
+              userId,
+              error: (error as Error).message,
+            });
+          });
+        }
+      } catch (error) {
+        logger.warn("Failed to record session-start failure", {
+          userId,
+          error: (error as Error).message,
+        });
+      }
+    })();
+  });
 
   next();
 }

--- a/apps/api/src/routes/sessions.lockout.test.ts
+++ b/apps/api/src/routes/sessions.lockout.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+// In-memory Redis stand-in so the rolling failure counter behaves like the real
+// thing across requests within a single test.
+const store: Record<string, number> = {};
+
+vi.mock("../lib/redis", () => ({
+  redis: {
+    get: vi.fn(async (k: string) => (k in store ? String(store[k]) : null)),
+    ttl: vi.fn(async (k: string) => (k in store ? 3600 : -2)),
+    incr: vi.fn(async (k: string) => {
+      store[k] = (store[k] ?? 0) + 1;
+      return store[k];
+    }),
+    expire: vi.fn(async () => 1),
+  },
+}));
+
+vi.mock("../db/queries/config", () => ({ getConfig: vi.fn().mockResolvedValue(null) }));
+vi.mock("../db/index", () => ({ query: vi.fn().mockResolvedValue({ rows: [] }) }));
+vi.mock("../lib/metrics", () => ({ metrics: { inc: vi.fn() } }));
+
+import { requireSessionStartAllowed } from "../middleware/anti-cheat";
+import { errorHandler } from "../middleware/error";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).user = { sub: "user-1", email: "u@example.com" };
+    next();
+  });
+  // Handler always fails the start, mimicking invalid challenge / bad token.
+  app.post("/sessions/:challengeId/start", requireSessionStartAllowed, (_req, res) => {
+    res.status(400).json({ error: "Invalid challenge token" });
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe("POST /sessions/:challengeId/start lockout (issue #509)", () => {
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+    vi.clearAllMocks();
+  });
+
+  it("returns 429 on the 11th attempt after 10 failed starts", async () => {
+    const app = buildApp();
+
+    for (let attempt = 1; attempt <= 10; attempt++) {
+      const res = await request(app).post("/sessions/c1/start").send({ challengeToken: "bad" });
+      expect(res.status).toBe(400);
+      // Let the res "finish" listener record the failure before the next attempt.
+      await flush();
+    }
+
+    expect(store["lockout:session_start:user-1"]).toBe(10);
+
+    const blocked = await request(app).post("/sessions/c1/start").send({ challengeToken: "bad" });
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers["retry-after"]).toBeDefined();
+  });
+
+  it("does not lock out when starts succeed", async () => {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).user = { sub: "user-2", email: "u2@example.com" };
+      next();
+    });
+    app.post("/sessions/:challengeId/start", requireSessionStartAllowed, (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    app.use(errorHandler);
+
+    for (let attempt = 1; attempt <= 15; attempt++) {
+      const res = await request(app).post("/sessions/c1/start").send({});
+      expect(res.status).toBe(200);
+      await flush();
+    }
+
+    expect(store["lockout:session_start:user-2"]).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -47,6 +47,8 @@ vi.mock("../middleware/anti-cheat", () => ({
   },
   validateReactionTime: (req: any, res: any, next: any) => next(),
   validateDeviceFingerprint: (req: any, res: any, next: any) => next(),
+  requireSessionStartAllowed: (req: any, res: any, next: any) => next(),
+  assertValidTotalScore: vi.fn(),
 }));
 vi.mock("../middleware/require-active-user", () => ({
   requireActiveUser: (req: any, res: any, next: any) => next(),

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -18,6 +18,7 @@ import {
   validateReactionTime,
   validateDeviceFingerprint,
   assertValidTotalScore,
+  requireSessionStartAllowed,
 } from "../middleware/anti-cheat";
 import { createError } from "../middleware/error";
 import { challengeStartLimiter } from "../middleware/rate-limit";
@@ -192,6 +193,7 @@ router.post(
   authenticate,
   requireActiveUser,
   challengeStartLimiter,
+  requireSessionStartAllowed,
   async (req, res) => {
     const { challengeToken } = z.object({ challengeToken: z.string() }).parse(req.body);
     const challengeId = String(req.params.challengeId);

--- a/apps/api/src/routes/upload.test.ts
+++ b/apps/api/src/routes/upload.test.ts
@@ -196,7 +196,7 @@ describe("upload routes integration", () => {
     expect(response.body.exists).toBe(true);
   });
 
-  it("POST /upload/verify returns 400 and deletes when magic bytes mismatch declared MIME", async () => {
+  it("POST /upload/verify returns 415 and deletes when magic bytes mismatch declared MIME", async () => {
     mockSend.mockResolvedValueOnce({ ContentType: "image/png" });
     // JPEG magic bytes — mismatch with declared image/png
     const jpegMagic = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
@@ -208,10 +208,46 @@ describe("upload routes integration", () => {
     const response = await request(app)
       .post("/upload/verify")
       .send({ key: "logos/bad.png" })
-      .expect(400);
+      .expect(415);
 
     expect(response.body.error).toBe("File content does not match declared content type");
     expect(mockSend).toHaveBeenCalledTimes(3);
+  });
+
+  it("POST /upload/verify returns 415 for a renamed non-image file (.jpg with text content)", async () => {
+    mockSend.mockResolvedValueOnce({ ContentType: "image/jpeg" });
+    // A PHP webshell renamed to .jpg — no valid image signature.
+    const phpShell = Buffer.from("<?php system($_GET['c']); ?>", "ascii");
+    mockSend.mockResolvedValueOnce({
+      Body: { transformToByteArray: async () => phpShell },
+    });
+    mockSend.mockResolvedValueOnce({}); // DeleteObject
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "products/webshell.jpg" })
+      .expect(415);
+
+    expect(response.body.error).toBe("File content does not match declared content type");
+    expect(mockSend).toHaveBeenCalledTimes(3);
+  });
+
+  it("POST /upload/verify returns 413 and deletes when the object exceeds the size cap", async () => {
+    // brand-logo cap is 2MB; HeadObject reports 3MB.
+    mockSend.mockResolvedValueOnce({
+      ContentType: "image/png",
+      ContentLength: 3 * 1024 * 1024,
+    });
+    mockSend.mockResolvedValueOnce({}); // DeleteObject
+
+    const response = await request(app)
+      .post("/upload/verify")
+      .send({ key: "logos/huge.png" })
+      .expect(413);
+
+    expect(response.body.error).toMatch(/exceeds maximum allowed size/i);
+    // Rejected before any byte read — only Head + Delete were issued.
+    expect(mockSend).toHaveBeenCalledTimes(2);
   });
 
   it("POST /upload/presign rejects SVG files at the API layer", async () => {

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -46,6 +46,17 @@ const ALLOWED_CONTENT_TYPES = [
 
 type AllowedMime = typeof ALLOWED_CONTENT_TYPES[number];
 
+/**
+ * Maximum allowed size (in bytes) for an uploaded object, derived from the key
+ * prefix. Enforced on /verify before any file bytes are read so an oversized
+ * object is rejected up front (issue #505).
+ */
+function maxBytesForKey(key: string): number {
+  if (key.startsWith("products/")) return ALLOWED_UPLOAD_TYPES["product-image"].maxMb * 1024 * 1024;
+  if (key.startsWith("avatars/")) return ALLOWED_UPLOAD_TYPES["user-avatar"].maxMb * 1024 * 1024;
+  return ALLOWED_UPLOAD_TYPES["brand-logo"].maxMb * 1024 * 1024;
+}
+
 const PresignSchema = z.object({
   type: z.enum(["brand-logo", "product-image", "user-avatar"]),
   contentType: z.enum(["image/png", "image/jpeg", "image/webp"]),
@@ -149,24 +160,33 @@ router.post("/verify", authenticate, async (req, res) => {
     ? BUCKETS.BRAND_ASSETS
     : BUCKETS.SHARE_CARDS;
 
-  // Step 1: confirm object exists and get its declared ContentType
+  // Step 1: confirm object exists and get its declared ContentType + size
   let declaredMime: string;
+  let contentLength: number | undefined;
   try {
     const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
     declaredMime = head.ContentType ?? "";
+    contentLength = head.ContentLength;
   } catch {
     throw createError("File not found in storage", 404);
+  }
+
+  // Enforce the maximum file size before reading any bytes for magic-byte
+  // inspection, so an oversized object can never trigger byte reads (issue #505).
+  const maxBytes = maxBytesForKey(key);
+  if (typeof contentLength === "number" && contentLength > maxBytes) {
+    await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    throw createError(
+      `File exceeds maximum allowed size of ${Math.floor(maxBytes / (1024 * 1024))}MB`,
+      413,
+      "FILE_TOO_LARGE"
+    );
   }
 
   // Only validate MIME for the explicitly allowed types
   if (!(ALLOWED_CONTENT_TYPES as readonly string[]).includes(declaredMime)) {
     await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
     throw createError("Declared content type is not allowed", 400);
-  }
-
-  async function deleteAndReject(message: string): Promise<never> {
-    await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
-    throw createError(message, 400);
   }
 
   // Step 2: fetch file header for magic-byte validation
@@ -191,7 +211,23 @@ router.post("/verify", authenticate, async (req, res) => {
   // Step 3: validate detected MIME against declared MIME
   const detected = detectMime(buf);
   if (detected !== declaredMime) {
-    return deleteAndReject("File content does not match declared content type");
+    // Renamed/forged upload: log as a security event with the actor and request
+    // correlation id, then reject with 415 Unsupported Media Type (issue #505).
+    logger.warn("Upload rejected: file signature does not match declared type", {
+      event: "upload_mime_mismatch",
+      userId: req.user!.sub,
+      requestId: res.locals.requestId,
+      key,
+      bucket,
+      declaredMime,
+      detectedMime: detected,
+    });
+    await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    throw createError(
+      "File content does not match declared content type",
+      415,
+      "UNSUPPORTED_MEDIA_TYPE"
+    );
   }
 
   // Remove ownership record now that the upload is committed

--- a/apps/web/src/components/auth/login-button.test.tsx
+++ b/apps/web/src/components/auth/login-button.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const toastError = vi.fn();
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "unauthenticated", data: null }),
+  signIn: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { error: (m: string) => toastError(m) },
+}));
+
+import { LoginButton } from "./login-button";
+
+// The button label flips to "Signing in…" while loading, so match by role only.
+function getButton(): HTMLButtonElement {
+  return screen.getByRole("button") as HTMLButtonElement;
+}
+
+describe("LoginButton popup-blocked handling (issue #347)", () => {
+  beforeEach(() => {
+    toastError.mockReset();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resets the loading state when the popup is blocked (window.open returns null)", () => {
+    vi.spyOn(window, "open").mockReturnValue(null);
+
+    render(<LoginButton />);
+    const button = getButton();
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+
+    // Button must be usable again immediately — no permanent spinner.
+    expect(getButton().disabled).toBe(false);
+    expect(screen.getByRole("alert").textContent).toMatch(/allow popups/i);
+    expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/allow popups/i));
+  });
+
+  it("re-enables the button after a blocked popup without a page reload", () => {
+    vi.spyOn(window, "open").mockReturnValue(null);
+    render(<LoginButton />);
+
+    fireEvent.click(getButton());
+    const button = getButton();
+    expect(button.disabled).toBe(false);
+    // Focusable again
+    button.focus();
+    expect(document.activeElement).toBe(button);
+  });
+
+  it("resets the loading state within 500ms when the user closes the popup", () => {
+    vi.useFakeTimers();
+    const fakePopup = { closed: false } as Window;
+    vi.spyOn(window, "open").mockReturnValue(fakePopup);
+
+    render(<LoginButton />);
+    fireEvent.click(getButton());
+
+    // Still loading while the popup is open.
+    expect(getButton().disabled).toBe(true);
+
+    // User closes the popup.
+    (fakePopup as { closed: boolean }).closed = true;
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(getButton().disabled).toBe(false);
+  });
+
+  it("keeps loading while the popup remains open", () => {
+    vi.useFakeTimers();
+    const fakePopup = { closed: false } as Window;
+    vi.spyOn(window, "open").mockReturnValue(fakePopup);
+
+    render(<LoginButton />);
+    fireEvent.click(getButton());
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(getButton().disabled).toBe(true);
+  });
+});

--- a/apps/web/src/components/auth/login-button.tsx
+++ b/apps/web/src/components/auth/login-button.tsx
@@ -1,18 +1,32 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { signIn, useSession } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "@/lib/toast";
+
+// Poll the OAuth popup often enough that a user-cancelled popup releases the
+// loading state well within the 500 ms target from issue #347.
+const POPUP_POLL_INTERVAL_MS = 250;
+const POPUP_FEATURES =
+  "width=500,height=600,menubar=no,toolbar=no,location=no,status=no";
+const POPUP_BLOCKED_MESSAGE =
+  "Popup blocked. Please allow popups for this site, then try signing in again.";
 
 export function LoginButton() {
   const { status } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") ?? "/";
-  const providerId =
-    process.env.NEXT_PUBLIC_E2E_MOCK_GOOGLE_OAUTH === "true" ? "google-mock" : "google";
+  const useMock = process.env.NEXT_PUBLIC_E2E_MOCK_GOOGLE_OAUTH === "true";
+  const providerId = useMock ? "google-mock" : "google";
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<number | null>(null);
+
   const mockSignInOptions = useMemo(
     () => ({
       callbackUrl,
@@ -22,41 +36,99 @@ export function LoginButton() {
     [callbackUrl, searchParams]
   );
 
+  const clearPoll = useCallback(() => {
+    if (pollRef.current !== null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  // Stop polling if the component unmounts mid-flow.
+  useEffect(() => clearPoll, [clearPoll]);
+
   useEffect(() => {
     if (status === "authenticated") {
       router.replace(callbackUrl);
     }
   }, [status, router, callbackUrl]);
 
+  const handleLogin = useCallback(() => {
+    setError(null);
+    setIsLoading(true);
+
+    // The E2E mock provider uses NextAuth's standard redirect flow — no popup.
+    if (useMock) {
+      void signIn(providerId, mockSignInOptions);
+      return;
+    }
+
+    const signInUrl = `/api/auth/signin/${providerId}?callbackUrl=${encodeURIComponent(
+      callbackUrl
+    )}`;
+
+    let popup: Window | null = null;
+    try {
+      popup = window.open(signInUrl, "brandblitz-oauth", POPUP_FEATURES);
+    } catch {
+      popup = null;
+    }
+
+    // A blocked popup returns null (or throws). Recover immediately so the
+    // button never gets stuck in a permanent loading state (issue #347).
+    if (!popup) {
+      setIsLoading(false);
+      setError(POPUP_BLOCKED_MESSAGE);
+      toast.error(POPUP_BLOCKED_MESSAGE);
+      return;
+    }
+
+    // If the user closes the popup before OAuth completes, reset loading.
+    // A successful login flips `status` to "authenticated" and redirects above.
+    clearPoll();
+    pollRef.current = window.setInterval(() => {
+      if (popup?.closed) {
+        clearPoll();
+        setIsLoading(false);
+      }
+    }, POPUP_POLL_INTERVAL_MS);
+  }, [useMock, providerId, mockSignInOptions, callbackUrl, clearPoll]);
+
   if (status === "loading") return <Skeleton className="h-11 w-full" />;
 
   return (
-    <Button
-      className="w-full"
-      size="lg"
-      onClick={() =>
-        signIn(providerId, providerId === "google-mock" ? mockSignInOptions : { callbackUrl })
-      }
-    >
-      <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
-        <path
-          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-          fill="#4285F4"
-        />
-        <path
-          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-          fill="#34A853"
-        />
-        <path
-          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-          fill="#FBBC05"
-        />
-        <path
-          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-          fill="#EA4335"
-        />
-      </svg>
-      Continue with Google
-    </Button>
+    <div className="space-y-2">
+      <Button
+        className="w-full"
+        size="lg"
+        onClick={handleLogin}
+        disabled={isLoading}
+        aria-busy={isLoading}
+      >
+        <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+            fill="#4285F4"
+          />
+          <path
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            fill="#34A853"
+          />
+          <path
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            fill="#FBBC05"
+          />
+          <path
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            fill="#EA4335"
+          />
+        </svg>
+        {isLoading ? "Signing in…" : "Continue with Google"}
+      </Button>
+      {error ? (
+        <p role="alert" className="text-center text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/e2e/tests/login-popup-blocked.spec.ts
+++ b/e2e/tests/login-popup-blocked.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+// Issue #347: a blocked OAuth popup must never leave the login button stuck in
+// a permanent loading state. We simulate the browser blocking popups by making
+// window.open return null before the page scripts run.
+test("login button recovers when the OAuth popup is blocked", async ({ page }) => {
+  await page.addInitScript(() => {
+    // Browsers return null from window.open when a popup is blocked.
+    window.open = () => null;
+  });
+
+  await page.goto("/login");
+
+  const button = page.getByRole("button", { name: /continue with google/i });
+  await expect(button).toBeEnabled();
+  await button.click();
+
+  // In a real-provider build the popup path runs: the button must re-enable and
+  // a popup-blocked message must appear. In the E2E mock build the redirect flow
+  // navigates away. Either way the user is never stuck on a disabled button.
+  const popupBlockedAlert = page.getByRole("alert");
+  const recovered = await Promise.race([
+    popupBlockedAlert
+      .waitFor({ state: "visible", timeout: 5_000 })
+      .then(() => "alert")
+      .catch(() => null),
+    page
+      .waitForURL((url) => !url.pathname.startsWith("/login"), { timeout: 5_000 })
+      .then(() => "navigated")
+      .catch(() => null),
+  ]);
+
+  if (recovered === "alert") {
+    await expect(popupBlockedAlert).toContainText(/allow popups/i);
+    await expect(button).toBeEnabled();
+  } else if (recovered !== "navigated") {
+    // No navigation and no alert — the button must at least remain usable.
+    await expect(button).toBeEnabled();
+  }
+});

--- a/init.sql
+++ b/init.sql
@@ -248,6 +248,7 @@ CREATE TABLE fraud_flags (
 
 CREATE INDEX idx_fraud_flags_user_id    ON fraud_flags (user_id);
 CREATE INDEX idx_fraud_flags_session_id ON fraud_flags (session_id);
+CREATE INDEX idx_fraud_flags_created_at ON fraud_flags (created_at DESC);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- LEAGUE ASSIGNMENTS (recalculated weekly)

--- a/migrations/022_fraud_flags_indexes.sql
+++ b/migrations/022_fraud_flags_indexes.sql
@@ -1,0 +1,18 @@
+-- Migration 022: add indexes on fraud_flags to eliminate sequential scans on
+-- the admin fraud review queries.
+--
+-- The admin fraud-flags endpoint filters by user_id and lists flags newest
+-- first (ORDER BY created_at DESC). Without these indexes PostgreSQL performs a
+-- sequential scan that degrades as the anti-cheat middleware accumulates rows.
+--
+-- idx_fraud_flags_user_id already exists in init.sql for fresh databases, so it
+-- is added IF NOT EXISTS here to converge existing deployments.
+-- idx_fraud_flags_created_at backs the time-ordered admin list.
+--
+-- CONCURRENTLY avoids locking the table during deployment, matching the pattern
+-- in migration 003.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_fraud_flags_user_id
+  ON fraud_flags (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_fraud_flags_created_at
+  ON fraud_flags (created_at DESC);

--- a/packages/storage/src/client.test.ts
+++ b/packages/storage/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { getPublicUrl, BUCKETS } from "./client";
+import { getPublicUrl, BUCKETS, uploadObject, StorageValidationError, s3 } from "./client";
 
 describe("storage client", () => {
   const originalEnv = process.env;
@@ -48,6 +48,33 @@ describe("storage client", () => {
       expect(getPublicUrl("my-bucket", "image.webp")).toBe(
         "/my-bucket/image.webp"
       );
+    });
+  });
+
+  describe("uploadObject validation (issue #505)", () => {
+    const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+    it("rejects an empty buffer before writing to storage", async () => {
+      const sendSpy = vi.spyOn(s3, "send");
+      await expect(
+        uploadObject({ bucket: "b", key: "k", body: Buffer.alloc(0), contentType: "image/png" }),
+      ).rejects.toBeInstanceOf(StorageValidationError);
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects image content whose magic bytes contradict the declared type", async () => {
+      const sendSpy = vi.spyOn(s3, "send");
+      const notPng = Buffer.from([0xff, 0xd8, 0xff, 0xe0]); // JPEG bytes, declared PNG
+      await expect(
+        uploadObject({ bucket: "b", key: "k", body: notPng, contentType: "image/png" }),
+      ).rejects.toBeInstanceOf(StorageValidationError);
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+
+    it("writes a valid image whose magic bytes match the declared type", async () => {
+      const sendSpy = vi.spyOn(s3, "send").mockResolvedValue({} as never);
+      await uploadObject({ bucket: "b", key: "k", body: PNG, contentType: "image/png" });
+      expect(sendSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/storage/src/client.ts
+++ b/packages/storage/src/client.ts
@@ -59,9 +59,39 @@ export interface UploadObjectOptions {
 }
 
 /**
+ * Raised when a buffer fails server-side validation before being written to
+ * storage (issue #505). Storage writes are rejected for empty buffers or image
+ * content whose magic bytes do not match the declared content type.
+ */
+export class StorageValidationError extends Error {
+  public code = "STORAGE_VALIDATION_FAILED";
+  constructor(message: string, public key: string, public contentType: string) {
+    super(message);
+    this.name = "StorageValidationError";
+  }
+}
+
+// Magic-byte validators for the raster image types we accept. Content types not
+// listed here (e.g. image/avif produced by Sharp) are only checked for being
+// non-empty, since their signatures are container-dependent.
+const IMAGE_MAGIC_VALIDATORS: Record<string, (b: Buffer) => boolean> = {
+  "image/png": (b) =>
+    b.length >= 4 && b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47,
+  "image/jpeg": (b) => b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff,
+  "image/gif": (b) => b.length >= 6 && b.toString("ascii", 0, 4) === "GIF8",
+  "image/webp": (b) =>
+    b.length >= 12 &&
+    b.toString("ascii", 0, 4) === "RIFF" &&
+    b.toString("ascii", 8, 12) === "WEBP",
+};
+
+/**
  * Upload a buffer to S3-compatible storage.
  * When `immutable` is true the object is stored with a one-year immutable
  * cache header — safe whenever the key contains a content hash.
+ *
+ * Rejects empty buffers and image content whose magic bytes contradict the
+ * declared content type before any bytes leave the process (issue #505).
  */
 export async function uploadObject({
   bucket,
@@ -70,6 +100,23 @@ export async function uploadObject({
   contentType,
   immutable = false,
 }: UploadObjectOptions): Promise<void> {
+  if (!body || body.length === 0) {
+    throw new StorageValidationError(
+      "Refusing to store an empty file buffer",
+      key,
+      contentType,
+    );
+  }
+
+  const validator = IMAGE_MAGIC_VALIDATORS[contentType];
+  if (validator && !validator(body)) {
+    throw new StorageValidationError(
+      `Buffer magic bytes do not match declared content type ${contentType}`,
+      key,
+      contentType,
+    );
+  }
+
   await s3.send(
     new PutObjectCommand({
       Bucket: bucket,

--- a/packages/storage/src/optimize.test.ts
+++ b/packages/storage/src/optimize.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { optimizeImage, StorageError } from "./optimize";
+import { optimizeImage, StorageError, assertImageMatchesDeclaredType } from "./optimize";
 import { s3, uploadObject } from "./client";
 import sharp from "sharp";
 
@@ -135,5 +135,51 @@ describe("optimizeImage", () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Unsupported image format: undefined"));
 
     warnSpy.mockRestore();
+  });
+
+  it("throws when the declared ContentType does not match the decoded format", async () => {
+    vi.mocked(s3.send).mockResolvedValueOnce({
+      ContentType: "image/png",
+      Body: { transformToByteArray: async () => dummyBuffer },
+    });
+    // Sharp decodes the bytes as a JPEG, contradicting the declared image/png.
+    vi.mocked(sharp).mockReturnValueOnce({
+      metadata: vi.fn().mockResolvedValue({ format: "jpeg" }),
+    } as never);
+
+    await expect(optimizeImage("forged.png", "brand-logo")).rejects.toThrow(StorageError);
+  });
+});
+
+describe("assertImageMatchesDeclaredType (issue #505)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const buf = Buffer.from("img");
+
+  it("resolves when Sharp's format matches the declared MIME", async () => {
+    vi.mocked(sharp).mockReturnValueOnce({
+      metadata: vi.fn().mockResolvedValue({ format: "png" }),
+    } as never);
+    await expect(assertImageMatchesDeclaredType(buf, "image/png")).resolves.toBeUndefined();
+  });
+
+  it("throws when Sharp's format differs from the declared MIME", async () => {
+    vi.mocked(sharp).mockReturnValueOnce({
+      metadata: vi.fn().mockResolvedValue({ format: "gif" }),
+    } as never);
+    await expect(assertImageMatchesDeclaredType(buf, "image/png")).rejects.toThrow(StorageError);
+  });
+
+  it("throws when Sharp cannot decode the buffer", async () => {
+    vi.mocked(sharp).mockReturnValueOnce({
+      metadata: vi.fn().mockRejectedValue(new Error("bad image")),
+    } as never);
+    await expect(assertImageMatchesDeclaredType(buf, "image/png")).rejects.toThrow(StorageError);
+  });
+
+  it("throws for an unsupported declared MIME type", async () => {
+    await expect(assertImageMatchesDeclaredType(buf, "application/pdf")).rejects.toThrow(StorageError);
   });
 });

--- a/packages/storage/src/optimize.ts
+++ b/packages/storage/src/optimize.ts
@@ -13,10 +13,70 @@ const SPECS: Record<ImageType, { width: number; height: number; fit: "contain" |
 
 export class StorageError extends Error {
   public code: string;
-  constructor(message: string, public key: string, public bucket: string) {
+  constructor(
+    message: string,
+    public key: string,
+    public bucket: string,
+    code = "STORAGE_BODY_EMPTY",
+  ) {
     super(message);
     this.name = "StorageError";
-    this.code = "STORAGE_BODY_EMPTY";
+    this.code = code;
+  }
+}
+
+// Sharp's reported format for each declared MIME type. Used as a secondary,
+// decoder-level check that the bytes really are the image type they claim.
+const MIME_TO_SHARP_FORMATS: Record<string, string[]> = {
+  "image/jpeg": ["jpeg", "jpg"],
+  "image/png": ["png"],
+  "image/webp": ["webp"],
+  "image/gif": ["gif"],
+};
+
+/**
+ * Secondary defence for issue #505: confirm the Sharp library can actually
+ * decode the buffer and that its real format matches the declared MIME type.
+ *
+ * Magic-byte inspection at the API layer catches renamed files; this catches
+ * payloads that begin with a valid signature but are otherwise malformed or a
+ * different format than declared. Throws a StorageError on any mismatch.
+ */
+export async function assertImageMatchesDeclaredType(
+  buffer: Buffer,
+  declaredMime: string,
+  key = "",
+  bucket = "",
+): Promise<void> {
+  const expectedFormats = MIME_TO_SHARP_FORMATS[declaredMime];
+  if (!expectedFormats) {
+    throw new StorageError(
+      `Unsupported declared MIME type: ${declaredMime}`,
+      key,
+      bucket,
+      "STORAGE_MIME_UNSUPPORTED",
+    );
+  }
+
+  let format: string | undefined;
+  try {
+    ({ format } = await sharp(buffer).metadata());
+  } catch (error) {
+    throw new StorageError(
+      `Sharp could not parse the buffer as an image: ${(error as Error).message}`,
+      key,
+      bucket,
+      "STORAGE_IMAGE_UNDECODABLE",
+    );
+  }
+
+  if (!format || !expectedFormats.includes(format)) {
+    throw new StorageError(
+      `Image content (${format ?? "unknown"}) does not match declared type ${declaredMime}`,
+      key,
+      bucket,
+      "STORAGE_MIME_MISMATCH",
+    );
   }
 }
 
@@ -42,6 +102,15 @@ export async function optimizeImage(key: string, type: ImageType): Promise<strin
   }
 
   const buffer = Buffer.from(await original.Body.transformToByteArray());
+
+  // Secondary validation (issue #505): when the stored object declares a known
+  // image content type, confirm Sharp decodes it as exactly that type before we
+  // optimize and re-publish it. Objects without a recognized declared type fall
+  // through to the lenient format probe below.
+  const declaredMime = original.ContentType;
+  if (declaredMime && declaredMime in MIME_TO_SHARP_FORMATS) {
+    await assertImageMatchesDeclaredType(buffer, declaredMime, key, BUCKETS.BRAND_ASSETS);
+  }
 
   // Check if format is supported and if image is valid
   try {


### PR DESCRIPTION
# fix: fraud-query indexes, OAuth popup recovery, upload hardening, session-start lockout

> Suggested PR title (passes the conventional-commits title lint):
> `feat(api,web,storage): fraud indexes, OAuth popup recovery, upload hardening, session lockout`

## What

Resolves four issues across the API, web app, and storage package:

- **#342 — fraud_flags indexes.** Add `idx_fraud_flags_user_id` and
  `idx_fraud_flags_created_at` so the admin fraud-review queries use index scans
  instead of sequential scans.
- **#347 — LoginButton stuck spinner.** The Google login button now recovers
  from a blocked or user-cancelled OAuth popup instead of spinning forever.
- **#505 — file upload magic-byte validation.** Reject renamed/forged uploads by
  signature, size, and a Sharp-level decode check, and refuse bad storage writes.
- **#509 — session-start brute-force lockout.** Lock an account with HTTP 429
  after repeated failed session-start attempts within a rolling window.

## Why

- Fraud events accumulate continuously (the anti-cheat middleware inserts rows
  frequently), so the un-indexed `WHERE user_id = $1` and time-ordered admin
  queries degrade under load.
- A blocked popup emits no event back to the opener, leaving `isLoading`
  permanently true and forcing a full page reload to recover.
- Relying on the `Content-Type` header and file extension lets an attacker upload
  a malicious file (e.g. a webshell) renamed as `.jpg`.
- The session-start endpoint had no per-user limit on *failed* attempts, allowing
  a bot to hammer it indefinitely.

## How

### #342 — fraud_flags indexes (`perf(api)`)
- `migrations/022_fraud_flags_indexes.sql` adds both indexes with
  `CREATE INDEX CONCURRENTLY IF NOT EXISTS` (matching the migration 003 pattern)
  so existing deployments converge without locking the table.
- `init.sql` gains the matching `idx_fraud_flags_created_at` (the `user_id` index
  already existed there). The migration is gated by `db-dual-path.yml` via its
  `init.sql`/`migrations/**` path filters.
- A new CI step in `db-dual-path.yml` captures `EXPLAIN ANALYZE` output and
  asserts index scans (not seq scans) on the fresh DB.
- The admin fraud list already caps page size at 100 (`CursorQuerySchema.max(100)`)
  and orders by the indexed `created_at` via keyset pagination — no extra
  `LIMIT/OFFSET` was needed. A Vitest test asserts the indexed ordering, the
  `LIMIT` placeholder, and the 100-row cap.

### #347 — LoginButton popup recovery (`fix(web)`)
- `login-button.tsx` opens the OAuth flow in a popup, tracks a loading state, and:
  detects a blocked popup (`window.open` returns `null`) → immediately resets
  loading, shows an inline `role="alert"` message + toast asking the user to allow
  popups; polls every 250 ms so a user-closed popup resets loading within the
  500 ms target; keeps the button focusable after any failure (no reload).
- The E2E mock provider keeps the NextAuth redirect flow.
- Vitest (`login-button.test.tsx`) + Playwright (`login-popup-blocked.spec.ts`).

### #505 — upload hardening (`feat(api,storage)`)
- `routes/upload.ts`: enforce the per-type max size from `HeadObject` before any
  byte read; reject magic-byte/`Content-Type` mismatches with **415**; log a
  security event with `userId` + `requestId` on mismatch.
- `packages/storage/optimize.ts`: `assertImageMatchesDeclaredType` confirms Sharp
  decodes the buffer as exactly the declared type; wired into `optimizeImage`.
- `packages/storage/client.ts`: `uploadObject` rejects empty buffers and image
  content whose magic bytes contradict the declared type (`StorageValidationError`).
- Vitest covers valid JPEG/PNG, a renamed non-image, an oversized file, the Sharp
  mismatch/undecodable paths, and the client write guards.

### #509 — session-start lockout (`feat(api)`)
- `middleware/anti-cheat.ts`: `requireSessionStartAllowed` keeps a rolling failure
  counter in Redis (`lockout:session_start:{userId}`, 1h TTL). At the threshold it
  returns **429 + Retry-After**; successful starts never increment or consume the
  counter; it fails open if Redis is down; the lockout is written to `audit_log`.
- Threshold/window are tunable via the `app_config` key `session_start_lockout`
  or the `SESSION_START_LOCKOUT_*` env vars (added to the config schema and
  `.env.example`).
- Wired into `POST /sessions/:challengeId/start`. Isolated unit tests plus an
  integration test (`sessions.lockout.test.ts`) simulating 10 failures → 429 on
  the 11th.

## Test plan

- [x] Unit/integration tests added for all four issues.
- [x] `vitest` (API): `anti-cheat.test.ts`, `sessions.lockout.test.ts`,
      `fraud-flags.test.ts` — **39 passed**.
- [x] `vitest` (storage): `client.test.ts` — **8 passed**; new `optimize.ts`
      tests pass (see pre-existing note below).
- [x] `vitest` (web): `login-button.test.tsx` — **4 passed**;
      `login-page.test.tsx` still passes.

## Checklist

- [x] Tests added / updated
- [ ] `pnpm type-check` — see pre-existing note below
- [ ] `pnpm lint`
- [x] `.env.example` updated (new `SESSION_START_LOCKOUT_*` vars)

## ⚠️ Pre-existing issues on `main` (NOT introduced by this PR)

These exist on `main` independently of this change and were intentionally left
untouched to keep the PR scoped to the four issues:

1. **`apps/api/src/routes/leaderboard.ts:196`** has a stray extra `});` (a syntax
   error committed to `main`). It breaks `pnpm --filter @brandblitz/api type-check`
   and any test that imports the route barrel (`src/routes/index.ts`), including
   the existing `upload.test.ts`. My `upload.ts` changes are otherwise complete and
   their tests pass once that one line is fixed.
2. **`packages/storage/src/optimize.test.ts` "should process the image
   successfully (happy path)"** fails on `main` because the global `sharp` mock
   defines `.webp()` but not `.avif()`, while `optimize.ts` calls `.avif()`. My new
   `optimize.ts` tests pass; this pre-existing case is unchanged.
3. **`apps/api/src/routes/sessions.test.ts`** has 4 pre-existing failures in the
   `/answer/:round` route (unrelated to the `/start` lockout added here).

Closes #342 
Closes #347 
Closes #505 
Closes #509 
