### PR TITLE
perf(api,db): add performance indexes and strengthen suspension check

### DIFF
--- a/apps/api/src/middleware/require-active-user.test.ts
+++ b/apps/api/src/middleware/require-active-user.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+
+vi.mock("../db/queries/users", () => ({ findUserById: vi.fn() }));
+vi.mock("./error", () => ({
+  createError: (message: string, statusCode: number, code?: string) =>
+    Object.assign(new Error(message), { statusCode, code }),
+}));
+
+import { requireActiveUser } from "./require-active-user";
+import { findUserById } from "../db/queries/users";
+
+const mockFindUserById = vi.mocked(findUserById);
+const res = {} as Response;
+const next = vi.fn() as unknown as NextFunction;
+
+function makeReq(sub?: string): Partial<Request> {
+  return { user: sub ? { sub } : undefined } as any;
+}
+
+describe("requireActiveUser", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws 401 when req.user is absent", async () => {
+    await expect(requireActiveUser(makeReq() as Request, res, next)).rejects.toMatchObject({
+      statusCode: 401,
+    });
+  });
+
+  it("throws 404 when user is not found in DB", async () => {
+    mockFindUserById.mockResolvedValue(null);
+    await expect(requireActiveUser(makeReq("uid") as Request, res, next)).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("calls next() for an active user with suspended_at = null", async () => {
+    mockFindUserById.mockResolvedValue({ status: "active", suspended_at: null } as any);
+    await requireActiveUser(makeReq("uid") as Request, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("throws 403 ACCOUNT_SUSPENDED when suspended_at is non-null", async () => {
+    mockFindUserById.mockResolvedValue({
+      status: "suspended",
+      suspended_at: "2025-01-01T00:00:00Z",
+    } as any);
+    await expect(requireActiveUser(makeReq("uid") as Request, res, next)).rejects.toMatchObject({
+      statusCode: 403,
+      code: "ACCOUNT_SUSPENDED",
+    });
+  });
+
+  it("throws 403 ACCOUNT_SUSPENDED when status=suspended even if suspended_at=null", async () => {
+    mockFindUserById.mockResolvedValue({ status: "suspended", suspended_at: null } as any);
+    await expect(requireActiveUser(makeReq("uid") as Request, res, next)).rejects.toMatchObject({
+      statusCode: 403,
+      code: "ACCOUNT_SUSPENDED",
+    });
+  });
+});

--- a/apps/api/src/middleware/require-active-user.ts
+++ b/apps/api/src/middleware/require-active-user.ts
@@ -26,7 +26,7 @@ export async function requireActiveUser(
     throw createError("User not found", 404, "USER_NOT_FOUND");
   }
 
-  if ((user as any).status === "suspended") {
+  if (user.status === "suspended" || user.suspended_at !== null) {
     throw createError(
       "Your account has been suspended. Please contact support for assistance.",
       403,

--- a/init.sql
+++ b/init.sql
@@ -34,6 +34,10 @@ CREATE TABLE users (
   streak_repairs_this_month INTEGER NOT NULL DEFAULT 0,
   streak_repair_available BOOLEAN NOT NULL DEFAULT FALSE,
   role              TEXT NOT NULL DEFAULT 'player' CHECK (role IN ('player', 'brand', 'admin')),
+  status            TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'suspended')),
+  suspension_reason TEXT,
+  suspended_at      TIMESTAMPTZ,
+  suspended_by      UUID REFERENCES users(id) ON DELETE SET NULL,
   created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -43,6 +47,7 @@ CREATE INDEX idx_users_google_id    ON users (google_id);
 CREATE INDEX idx_users_phone_hash   ON users (phone_hash);
 CREATE INDEX idx_users_total_score  ON users (total_score DESC);
 CREATE INDEX idx_users_league       ON users (league);
+CREATE INDEX idx_users_status       ON users (status);
 -- ─────────────────────────────────────────────────────────────────────────────
 -- BRANDS
 -- ─────────────────────────────────────────────────────────────────────────────
@@ -92,11 +97,12 @@ CREATE TABLE challenges (
   )
 );
 
-CREATE INDEX idx_challenges_brand_id      ON challenges (brand_id);
-CREATE INDEX idx_challenges_status        ON challenges (status);
-CREATE INDEX idx_challenges_ends_at       ON challenges (ends_at);
-CREATE INDEX idx_challenges_challenge_id  ON challenges (challenge_id);
-CREATE INDEX idx_challenges_deposit_memo  ON challenges (deposit_memo);
+CREATE INDEX idx_challenges_brand_id        ON challenges (brand_id);
+CREATE INDEX idx_challenges_status          ON challenges (status);
+CREATE INDEX idx_challenges_active_status   ON challenges (status) WHERE status = 'active';
+CREATE INDEX idx_challenges_ends_at         ON challenges (ends_at);
+CREATE INDEX idx_challenges_challenge_id    ON challenges (challenge_id);
+CREATE INDEX idx_challenges_deposit_memo    ON challenges (deposit_memo);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- CHALLENGE QUESTIONS (3 per challenge, server-side only)
@@ -268,7 +274,8 @@ CREATE TABLE league_assignments (
   UNIQUE (user_id, week_start)
 );
 
-CREATE INDEX idx_league_assignments_week ON league_assignments (week_start, league, group_id, weekly_points DESC);
+CREATE INDEX idx_league_assignments_week        ON league_assignments (week_start, league, group_id, weekly_points DESC);
+CREATE INDEX idx_league_assignments_week_league ON league_assignments (week_start, league);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- USER BADGES

--- a/migrations/023_idx_challenges_active_status.sql
+++ b/migrations/023_idx_challenges_active_status.sql
@@ -1,0 +1,16 @@
+-- Migration 023: partial index on challenges(status) WHERE status = 'active'
+--
+-- The active-challenge listing query in db/queries/challenges.ts filters
+-- exclusively on status = 'active'. A partial index is smaller than a full
+-- index on status and the planner will prefer it for this highly selective
+-- predicate. The vast majority of challenges are in terminal states, so
+-- maintenance cost of the partial index is minimal.
+--
+-- Using CONCURRENTLY so this can run without locking the table in production.
+--
+-- Down migration:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_challenges_active_status;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_challenges_active_status
+  ON challenges (status)
+  WHERE status = 'active';

--- a/migrations/024_idx_payouts_user_id.sql
+++ b/migrations/024_idx_payouts_user_id.sql
@@ -1,0 +1,17 @@
+-- Migration 024: ensure index on payouts(user_id) for earnings history queries
+--
+-- services/payout.ts and routes/users.ts query the payouts table filtered by
+-- user_id to compute earnings history and display payout records. Without this
+-- index, lookups degrade linearly as the payouts table grows with Stellar
+-- settlement records.
+--
+-- The index already exists on fresh databases (declared in init.sql), so this
+-- migration is idempotent via IF NOT EXISTS and converges the migration path.
+--
+-- Using CONCURRENTLY so this can run without locking the table in production.
+--
+-- Down migration:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_payouts_user_id;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_payouts_user_id
+  ON payouts (user_id);

--- a/migrations/025_idx_league_assignments_week_league.sql
+++ b/migrations/025_idx_league_assignments_week_league.sql
@@ -1,0 +1,15 @@
+-- Migration 025: dedicated two-column index on league_assignments(week_start, league)
+--
+-- The weekly recalculation job in queues/processors/league.processor.ts queries
+-- league_assignments filtered by week_start and grouped by league. The existing
+-- 4-column index idx_league_assignments_week(week_start, league, group_id,
+-- weekly_points DESC) optimises leaderboard ordering, not simple 2-column
+-- equality filters. This dedicated index improves the recalculation query plan.
+--
+-- Using CONCURRENTLY so this can run without locking the table in production.
+--
+-- Down migration:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_league_assignments_week_league;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_league_assignments_week_league
+  ON league_assignments (week_start, league);


### PR DESCRIPTION
  ## Summary

  - **#474** — Partial index `idx_challenges_active_status` on `challenges(status) WHERE status = 'active'`
  reduces active-challenge listing query cost.
  - **#476** — Idempotent migration ensuring `idx_payouts_user_id` on `payouts(user_id)` exists on all database
  paths for constant-time earnings history lookups.
  - **#478** — Composite index `idx_league_assignments_week_league` on `league_assignments(week_start, league)`
  for the weekly recalculation job's equality filter.
  - **#480** — `require-active-user` middleware strengthened to treat `suspended_at IS NOT NULL` as a suspension
  signal alongside `status = 'suspended'`; `init.sql` synced so the fresh-DB CI path matches the migration
  path; unit tests added for all suspension scenarios.

  ## Changes

  ### Migrations (root `migrations/`, applied via `psql -f` in autocommit mode — `CONCURRENTLY` is safe here)
  - `023_idx_challenges_active_status.sql` — partial index for active challenges
  - `024_idx_payouts_user_id.sql` — idempotent index on payouts user_id
  - `025_idx_league_assignments_week_league.sql` — two-column index for league recalculation

  ### Middleware
  - `apps/api/src/middleware/require-active-user.ts` — checks both `status === "suspended"` and `suspended_at
  !== null`

  ### Bootstrap schema
  - `init.sql` — adds suspension columns and new indexes so fresh-DB and migration-DB CI paths converge

  ### Tests
  - `apps/api/src/middleware/require-active-user.test.ts` — 5 unit tests: unauthenticated, user not found,
  active pass-through, suspended by timestamp, suspended by status

  ## Test plan
  - [ ] `pnpm --filter @brandblitz/api exec vitest run src/middleware/require-active-user.test.ts` — all 5 pass
  - [ ] `EXPLAIN ANALYZE SELECT * FROM challenges WHERE status = 'active'` uses `idx_challenges_active_status`
  - [ ] `EXPLAIN ANALYZE SELECT * FROM payouts WHERE user_id = $1` uses `idx_payouts_user_id`
  - [ ] `EXPLAIN ANALYZE SELECT * FROM league_assignments WHERE week_start = $1 AND league = $2` uses
  `idx_league_assignments_week_league`
  - [ ] User with non-null `suspended_at` hitting a protected route → 403 `ACCOUNT_SUSPENDED`

  Closes #474
  Closes #476
  Closes #478
  Closes #480