### PR TITLE
fix(api): persist Stellar deposit memos

### DIFF
--- a/apps/api/src/db/queries/challenges.ts
+++ b/apps/api/src/db/queries/challenges.ts
@@ -15,6 +15,7 @@ export interface Challenge {
   id: string;
   brand_id: string;
   challenge_id: string;
+  deposit_memo: string | null;
   pool_amount_stroops: string;
   pool_amount_usdc: string;
   participant_count?: number;
@@ -52,18 +53,21 @@ export interface ChallengeQuestion {
 export async function createChallenge(data: {
   brandId: string;
   challengeId: string;
+  depositMemo?: string;
   poolAmountUsdc: string;
   maxPlayers?: number;
   endsAt?: string;
 }): Promise<Challenge> {
   const result = await query<Challenge>(
     `INSERT INTO challenges
-       (brand_id, challenge_id, pool_amount_stroops, max_players, ends_at)
-     VALUES ($1,$2,$3,$4,$5)
+       (brand_id, challenge_id, deposit_memo, pool_amount_stroops,
+        max_players, ends_at)
+     VALUES ($1,$2,$3,$4,$5,$6)
      RETURNING *, (pool_amount_stroops::numeric / 10000000)::numeric(20,7)::text AS pool_amount_usdc`,
     [
       data.brandId,
       data.challengeId,
+      data.depositMemo ?? data.challengeId,
       usdcToStroops(data.poolAmountUsdc),
       data.maxPlayers ?? null,
       data.endsAt ?? null,
@@ -101,7 +105,9 @@ export async function getArchivedChallengeById(id: string): Promise<Challenge | 
   return result.rows[0] ?? null;
 }
 
-export async function getChallengeByIdAny(id: string): Promise<Challenge & { archived: boolean } | null> {
+export async function getChallengeByIdAny(
+  id: string
+): Promise<(Challenge & { archived: boolean }) | null> {
   const result = await query<Challenge & { archived: boolean }>(
     `SELECT *, false AS archived FROM challenges WHERE id = $1 AND deleted_at IS NULL
      UNION ALL
@@ -137,7 +143,7 @@ export async function getActiveChallengesCursor(
 
 export async function getActiveChallenges(
   limit = 20,
-  cursor?: string,
+  cursor?: string
 ): Promise<{ challenges: Challenge[]; nextCursor: string | null }> {
   const cursorValues = decodeCursorSafe(cursor, ["pool_amount_stroops", "id"]);
 
@@ -150,7 +156,7 @@ export async function getActiveChallenges(
       "DESC",
       cursorValues.pool_amount_stroops,
       cursorValues.id as string,
-      3,
+      3
     );
     whereExtra = clause;
     params.push(cursorValues.pool_amount_stroops, cursorValues.id);
@@ -166,7 +172,7 @@ export async function getActiveChallenges(
      ${whereExtra}
      ORDER BY c.pool_amount_stroops DESC, c.id DESC
      LIMIT $${params.length}`,
-    params,
+    params
   );
 
   const challenges = result.rows;
@@ -242,7 +248,7 @@ export async function getFilteredChallenges(opts: {
 export async function getChallengesByBrandId(
   brandId: string,
   limit = 20,
-  cursor?: string,
+  cursor?: string
 ): Promise<{ challenges: Challenge[]; nextCursor: string | null }> {
   const cursorValues = decodeCursorSafe(cursor, ["created_at", "id"]);
 
@@ -255,7 +261,7 @@ export async function getChallengesByBrandId(
       "DESC",
       cursorValues.created_at,
       cursorValues.id as string,
-      3,
+      3
     );
     whereExtra = clause;
     params.push(cursorValues.created_at, cursorValues.id);
@@ -272,7 +278,7 @@ export async function getChallengesByBrandId(
      ${whereExtra}
      ORDER BY c.created_at DESC, c.id DESC
      LIMIT $${params.length}`,
-    params,
+    params
   );
 
   const challenges = result.rows;
@@ -290,9 +296,10 @@ export async function getChallengesByBrandId(
  * Soft-delete a challenge.
  */
 export async function softDeleteChallenge(id: string): Promise<void> {
-  await query("UPDATE challenges SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1 AND deleted_at IS NULL", [
-    id,
-  ]);
+  await query(
+    "UPDATE challenges SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1 AND deleted_at IS NULL",
+    [id]
+  );
 }
 
 /**
@@ -308,15 +315,17 @@ export async function updateChallengeStatus(
   extras?: { depositTx?: string; payoutTxHashes?: string[] }
 ): Promise<void> {
   if (extras?.depositTx) {
-    await query(
-      "UPDATE challenges SET status = $1, deposit_tx_hash = $2 WHERE id = $3",
-      [status, extras.depositTx, id]
-    );
+    await query("UPDATE challenges SET status = $1, deposit_tx_hash = $2 WHERE id = $3", [
+      status,
+      extras.depositTx,
+      id,
+    ]);
   } else if (extras?.payoutTxHashes) {
-    await query(
-      "UPDATE challenges SET status = $1, payout_tx_hashes = $2 WHERE id = $3",
-      [status, extras.payoutTxHashes, id]
-    );
+    await query("UPDATE challenges SET status = $1, payout_tx_hashes = $2 WHERE id = $3", [
+      status,
+      extras.payoutTxHashes,
+      id,
+    ]);
   } else {
     await query("UPDATE challenges SET status = $1 WHERE id = $2", [status, id]);
   }
@@ -332,9 +341,17 @@ export async function insertChallengeQuestions(
           correct_answer, option_a, option_b, option_c, option_d, correct_option)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
       [
-        q.challenge_id, q.round, q.question_type, q.prompt_type,
-        q.question_text, q.correct_answer,
-        q.option_a, q.option_b, q.option_c, q.option_d, q.correct_option,
+        q.challenge_id,
+        q.round,
+        q.question_type,
+        q.prompt_type,
+        q.question_text,
+        q.correct_answer,
+        q.option_a,
+        q.option_b,
+        q.option_c,
+        q.option_d,
+        q.correct_option,
       ]
     );
   }
@@ -362,9 +379,17 @@ export async function insertChallengeQuestion(
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
      RETURNING *`,
     [
-      question.challenge_id, question.round, question.question_type, question.prompt_type,
-      question.question_text, question.correct_answer,
-      question.option_a, question.option_b, question.option_c, question.option_d, question.correct_option,
+      question.challenge_id,
+      question.round,
+      question.question_type,
+      question.prompt_type,
+      question.question_text,
+      question.correct_answer,
+      question.option_a,
+      question.option_b,
+      question.option_c,
+      question.option_d,
+      question.correct_option,
     ]
   );
   return result.rows[0];

--- a/apps/api/src/routes/brands.distractors.integration.test.ts
+++ b/apps/api/src/routes/brands.distractors.integration.test.ts
@@ -9,6 +9,13 @@ const mocks = vi.hoisted(() => ({
   createChallenge: vi.fn(),
   insertChallengeQuestions: vi.fn(),
   loggerWarn: vi.fn(),
+  authUser: {
+    sub: "owner-user-1",
+    email: "owner@example.com",
+    iat: 0,
+    exp: 0,
+  } as any,
+  tosAccepted: true,
 }));
 
 vi.mock("../db/queries/brands", () => ({
@@ -28,19 +35,24 @@ vi.mock("../db/queries/challenges", () => ({
 }));
 
 vi.mock("../middleware/authenticate", () => ({
-  authenticate: (req: any, _res: any, next: any) => {
-    req.user = {
-      sub: "owner-user-1",
-      email: "owner@example.com",
-      iat: 0,
-      exp: 0,
-    };
+  authenticate: (req: any, res: any, next: any) => {
+    if (!mocks.authUser) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    req.user = mocks.authUser;
     next();
   },
 }));
 
 vi.mock("../middleware/require-tos", () => ({
-  requireCurrentTosAccepted: (_req: any, _res: any, next: any) => next(),
+  requireCurrentTosAccepted: (_req: any, res: any, next: any) => {
+    if (!mocks.tosAccepted) {
+      res.status(403).json({ error: "Terms of Service acceptance required" });
+      return;
+    }
+    next();
+  },
 }));
 
 vi.mock("@brandblitz/storage", () => ({
@@ -59,6 +71,9 @@ vi.mock("../lib/logger", () => ({
 }));
 
 import router from "./brands";
+import { errorHandler } from "../middleware/error";
+
+const STELLAR_TEXT_MEMO_MAX_BYTES = 28;
 
 function buildBrand(params: {
   id: string;
@@ -78,7 +93,7 @@ function buildBrand(params: {
     tagline: params.tagline,
     brand_story: null,
     usp: params.usp,
-    product_image_keys: params.hasProductImage ?? true ? ["product.webp"] : [],
+    product_image_keys: (params.hasProductImage ?? true) ? ["product.webp"] : [],
     created_at: "2026-04-24T00:00:00.000Z",
   };
 }
@@ -88,15 +103,28 @@ function buildChallenge(brandId: string): Challenge {
     id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
     brand_id: brandId,
     challenge_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    deposit_memo: "bb-bbbbbbbbbbbbbbbbbbbbbbbbb",
     pool_amount_stroops: "500000000",
     pool_amount_usdc: "50.0000000",
     status: "pending_deposit",
-    stellar_deposit_tx: null,
+    deposit_tx_hash: null,
+    deposit_confirmations: 0,
     payout_tx_hashes: null,
     max_players: null,
     starts_at: "2026-04-24T00:00:00.000Z",
     ends_at: null,
+    reported_count: 0,
+    deleted_at: null,
     created_at: "2026-04-24T00:00:00.000Z",
+  };
+}
+
+function validChallengePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    brandId: "11111111-1111-4111-8111-111111111111",
+    poolAmountUsdc: "100.0000000",
+    endsAt: "2026-12-01T00:00:00.000Z",
+    ...overrides,
   };
 }
 
@@ -104,9 +132,7 @@ async function postChallenge(body: Record<string, unknown>) {
   const app = express();
   app.use(express.json());
   app.use("/brands", router);
-  app.use((err: any, _req: any, res: any, _next: any) => {
-    res.status(err?.statusCode ?? 500).json({ error: err?.message ?? "Unexpected error" });
-  });
+  app.use(errorHandler);
 
   const server = app.listen(0);
 
@@ -122,7 +148,16 @@ async function postChallenge(body: Record<string, unknown>) {
       body: JSON.stringify(body),
     });
 
-    const data = await response.json();
+    const responseText = await response.text();
+    const data = responseText
+      ? (() => {
+          try {
+            return JSON.parse(responseText);
+          } catch {
+            return { raw: responseText };
+          }
+        })()
+      : {};
     return { status: response.status, data };
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -138,6 +173,13 @@ describe("POST /brands/challenges distractor integration", () => {
     mocks.createChallenge.mockReset();
     mocks.insertChallengeQuestions.mockReset();
     mocks.loggerWarn.mockReset();
+    mocks.authUser = {
+      sub: "owner-user-1",
+      email: "owner@example.com",
+      iat: 0,
+      exp: 0,
+    };
+    mocks.tosAccepted = true;
 
     process.env.HOT_WALLET_PUBLIC_KEY = "GTESTHOTWALLETADDRESS";
 
@@ -151,6 +193,94 @@ describe("POST /brands/challenges distractor integration", () => {
     );
     mocks.createChallenge.mockResolvedValue(buildChallenge(brandId));
     mocks.insertChallengeQuestions.mockResolvedValue(undefined);
+    mocks.getActiveDistractorBrands.mockResolvedValue([]);
+  });
+
+  it("returns 401 before creating a challenge when the request is unauthenticated", async () => {
+    mocks.authUser = null;
+
+    const response = await postChallenge(validChallengePayload());
+
+    expect(response.status).toBe(401);
+    expect(response.data.error).toBe("Unauthorized");
+    expect(mocks.createChallenge).not.toHaveBeenCalled();
+    expect(mocks.insertChallengeQuestions).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 before creating a challenge when current terms are not accepted", async () => {
+    mocks.tosAccepted = false;
+
+    const response = await postChallenge(validChallengePayload());
+
+    expect(response.status).toBe(403);
+    expect(response.data.error).toBe("Terms of Service acceptance required");
+    expect(mocks.createChallenge).not.toHaveBeenCalled();
+    expect(mocks.insertChallengeQuestions).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing required challenge fields before touching the database", async () => {
+    const response = await postChallenge({});
+
+    expect(response.status).toBe(400);
+    expect(response.data.error).toBe("Validation Error");
+    expect(mocks.getBrandById).not.toHaveBeenCalled();
+    expect(mocks.createChallenge).not.toHaveBeenCalled();
+    expect(mocks.insertChallengeQuestions).not.toHaveBeenCalled();
+  });
+
+  it("returns deposit instructions with a Stellar-compatible text memo for a new pending-deposit challenge", async () => {
+    const response = await postChallenge(validChallengePayload());
+
+    expect(response.status).toBe(201);
+    expect(response.data.challenge).toMatchObject({
+      brand_id: brandId,
+      status: "pending_deposit",
+    });
+    expect(response.data.depositInstructions).toMatchObject({
+      hotWalletAddress: expect.stringMatching(/^G[A-Z0-9]+$/),
+      memo: expect.any(String),
+      amount: "100.0000000",
+      asset: "USDC",
+    });
+
+    const memo = response.data.depositInstructions.memo as string;
+    expect(Buffer.byteLength(memo, "utf8")).toBeLessThanOrEqual(STELLAR_TEXT_MEMO_MAX_BYTES);
+    expect(memo).toMatch(/^bb-[0-9a-f]{25}$/i);
+    expect(mocks.createChallenge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId,
+        challengeId: expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+        ),
+        depositMemo: memo,
+        poolAmountUsdc: "100.0000000",
+      })
+    );
+  });
+
+  it("generates unique Stellar memo values for sequential challenge creations", async () => {
+    mocks.createChallenge.mockImplementation(async ({ brandId: createdBrandId, depositMemo }) => ({
+      ...buildChallenge(createdBrandId),
+      deposit_memo: depositMemo,
+    }));
+
+    const first = await postChallenge(validChallengePayload());
+    const second = await postChallenge(validChallengePayload({ maxPlayers: 75 }));
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+
+    const firstMemo = first.data.depositInstructions.memo;
+    const secondMemo = second.data.depositInstructions.memo;
+    expect(firstMemo).not.toBe(secondMemo);
+    expect(mocks.createChallenge).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ depositMemo: firstMemo })
+    );
+    expect(mocks.createChallenge).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ depositMemo: secondMemo, maxPlayers: 75 })
+    );
   });
 
   it("uses real distractor brand names in generated question options", async () => {
@@ -181,7 +311,7 @@ describe("POST /brands/challenges distractor integration", () => {
 
     const response = await postChallenge({
       brandId,
-      poolAmountUsdc: "50.0000000",
+      poolAmountUsdc: "100.0000000",
       endsAt: "2026-12-01T00:00:00.000Z",
     });
 
@@ -217,7 +347,7 @@ describe("POST /brands/challenges distractor integration", () => {
 
     const response = await postChallenge({
       brandId,
-      poolAmountUsdc: "50.0000000",
+      poolAmountUsdc: "100.0000000",
       endsAt: "2026-12-01T00:00:00.000Z",
     });
 
@@ -248,7 +378,7 @@ describe("POST /brands/challenges distractor integration", () => {
   it("rejects challenge creation when endsAt is in the past", async () => {
     const response = await postChallenge({
       brandId,
-      poolAmountUsdc: "50.0000000",
+      poolAmountUsdc: "100.0000000",
       endsAt: "2020-01-01T00:00:00.000Z",
     });
 
@@ -260,7 +390,7 @@ describe("POST /brands/challenges distractor integration", () => {
   it("rejects challenge creation when duration is less than one hour", async () => {
     const response = await postChallenge({
       brandId,
-      poolAmountUsdc: "50.0000000",
+      poolAmountUsdc: "100.0000000",
       endsAt: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
     });
 

--- a/apps/api/src/routes/brands.ts
+++ b/apps/api/src/routes/brands.ts
@@ -47,8 +47,14 @@ const BrandKitSchema = z.object({
     .max(100)
     .refine((v) => !/<[^>]*>/.test(v), { message: "Brand name must not contain HTML tags" }),
   logoKey: z.string().optional(),
-  primaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
-  secondaryColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+  primaryColor: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/)
+    .optional(),
+  secondaryColor: z
+    .string()
+    .regex(/^#[0-9a-fA-F]{6}$/)
+    .optional(),
   tagline: z.string().max(100).optional(),
   brandStory: z.string().max(500).optional(),
   usp: z.string().max(200).optional(),
@@ -77,11 +83,14 @@ const ChallengeSchema = z.object({
 
 const MIN_CHALLENGE_DURATION_MS = 60 * 60 * 1000;
 const CHALLENGE_DURATION_GRACE_MS = 5_000;
+const STELLAR_TEXT_MEMO_MAX_BYTES = 28;
 
-const QuestionRoundTemplateSchema = z.object({
-  question_text: z.string().max(500).optional(),
-  prompt_type: z.enum(["logo", "tagline", "productImage1"]).optional(),
-}).strict();
+const QuestionRoundTemplateSchema = z
+  .object({
+    question_text: z.string().max(500).optional(),
+    prompt_type: z.enum(["logo", "tagline", "productImage1"]).optional(),
+  })
+  .strict();
 
 const QuestionTemplateSchema = z
   .object({
@@ -106,12 +115,14 @@ function validateChallengeEndsAt(endsAt: string): void {
   }
 
   if (endsAtMs < minEndsAtMs - CHALLENGE_DURATION_GRACE_MS) {
-    throw createError(
-      "Challenge duration must be at least 1 hour",
-      400,
-      "ENDS_AT_TOO_SOON"
-    );
+    throw createError("Challenge duration must be at least 1 hour", 400, "ENDS_AT_TOO_SOON");
   }
+}
+
+function generateDepositMemo(): string {
+  return `bb-${randomUUID()
+    .replace(/-/g, "")
+    .slice(0, STELLAR_TEXT_MEMO_MAX_BYTES - 3)}`;
 }
 
 /**
@@ -299,7 +310,10 @@ router.post("/:id/questions/:questionId/regenerate", authenticate, async (req, r
   const newDraft = regenerated.find((q) => q.round === existing.round) ?? regenerated[0];
 
   await deleteChallengeQuestion(questionId);
-  const inserted = await insertChallengeQuestion({ ...newDraft, challenge_id: existing.challenge_id });
+  const inserted = await insertChallengeQuestion({
+    ...newDraft,
+    challenge_id: existing.challenge_id,
+  });
 
   res.json({ question: inserted });
 });
@@ -360,8 +374,13 @@ router.post("/", authenticate, async (req, res) => {
     }
   } catch (error) {
     if (error instanceof StorageError || (error as any).name === "StorageError") {
-      console.error(`[api] Image optimization failed for body key. Reason: ${(error as Error).message}`);
-      throw createError("Image upload could not be processed. Please try again with a valid image.", 400);
+      console.error(
+        `[api] Image optimization failed for body key. Reason: ${(error as Error).message}`
+      );
+      throw createError(
+        "Image upload could not be processed. Please try again with a valid image.",
+        400
+      );
     }
     throw error;
   }
@@ -395,9 +414,11 @@ router.post("/challenges", authenticate, requireCurrentTosAccepted, async (req, 
   if (brand.owner_user_id !== req.user!.sub) throw createError("Forbidden", 403);
 
   const challengeId = randomUUID();
+  const depositMemo = generateDepositMemo();
   const challenge = await createChallenge({
     brandId: body.brandId,
     challengeId,
+    depositMemo,
     poolAmountUsdc: body.poolAmountUsdc,
     maxPlayers: body.maxPlayers,
     endsAt: body.endsAt,
@@ -419,10 +440,10 @@ router.post("/challenges", authenticate, requireCurrentTosAccepted, async (req, 
     challenge,
     depositInstructions: {
       hotWalletAddress: config.HOT_WALLET_PUBLIC_KEY,
-      memo: challengeId,
+      memo: depositMemo,
       amount: body.poolAmountUsdc,
       asset: "USDC",
-      note: `Send exactly ${body.poolAmountUsdc} USDC to the hot wallet with memo: ${challengeId}`,
+      note: `Send exactly ${body.poolAmountUsdc} USDC to the hot wallet with memo: ${depositMemo}`,
     },
   });
 });


### PR DESCRIPTION
## What
Fixes challenge creation so the deposit memo returned to clients is also persisted to the `challenges.deposit_memo` column, and keeps the memo within Stellar text memo limits.

## Why
Issue #372 calls out missing coverage around challenge creation deposit memos and initial pending-deposit state. While adding coverage, I found the create route returned a UUID as the memo and did not store it in `deposit_memo`, even though the deposit webhook resolves deposits through `getChallengeByMemo`.

## How
- Generate a short `bb-...` memo for `POST /brands/challenges` that stays within the 28-byte Stellar text memo limit.
- Pass that memo into `createChallenge` so it is persisted in `deposit_memo` and returned in `depositInstructions.memo`.
- Add route tests for unauthenticated requests, TOS enforcement, validation failure before DB access, pending-deposit creation, memo shape, and sequential memo uniqueness.

## Test plan
- [x] `./node_modules/.bin/vitest run apps/api/src/routes/brands.distractors.integration.test.ts`
- [x] `./node_modules/.bin/prettier --check apps/api/src/routes/brands.ts apps/api/src/db/queries/challenges.ts apps/api/src/routes/brands.distractors.integration.test.ts`
- [ ] `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` currently stops on an existing unrelated syntax error in `apps/api/src/routes/leaderboard.ts`.
- [ ] `./node_modules/.bin/vitest run apps/api/src/db/queries/challenges.test.ts` requires local PostgreSQL; my run failed with `ECONNREFUSED 127.0.0.1:5432` / `::1:5432` before executing assertions.

Closes #372