### PR TITLE
test(api): cover admin role gate

### DIFF
--- a/apps/api/src/middleware/__tests__/require-admin.test.ts
+++ b/apps/api/src/middleware/__tests__/require-admin.test.ts
@@ -1,0 +1,79 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { requireAdmin } from "../require-admin";
+
+function buildApp(user?: { role?: string }) {
+  const nextHandler = vi.fn((_req: express.Request, res: express.Response) => {
+    res.json({ ok: true });
+  });
+
+  const app = express();
+  app.use((req, _res, next) => {
+    if (user) {
+      req.user = {
+        sub: "test-user",
+        email: "test@example.com",
+        role: user.role as string,
+      };
+    }
+    next();
+  });
+  app.get("/admin-only", requireAdmin, nextHandler);
+  app.use(
+    (
+      err: { statusCode?: number; message?: string; code?: string },
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction
+    ) => {
+      res.status(err.statusCode ?? 500).json({ error: err.message, code: err.code });
+    }
+  );
+
+  return { app, nextHandler };
+}
+
+describe("requireAdmin", () => {
+  it("allows admin users through", async () => {
+    const { app, nextHandler } = buildApp({ role: "admin" });
+
+    const res = await request(app).get("/admin-only");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(nextHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows super_admin users through", async () => {
+    const { app, nextHandler } = buildApp({ role: "super_admin" });
+
+    const res = await request(app).get("/admin-only");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(nextHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["user", "brand"])("rejects %s users with a JSON 403", async (role) => {
+    const { app, nextHandler } = buildApp({ role });
+
+    const res = await request(app).get("/admin-only");
+
+    expect(res.status).toBe(403);
+    expect(res.type).toBe("application/json");
+    expect(res.body).toEqual({ error: "Forbidden", code: "FORBIDDEN" });
+    expect(nextHandler).not.toHaveBeenCalled();
+  });
+
+  it("rejects authenticated users with no role", async () => {
+    const { app, nextHandler } = buildApp({});
+
+    const res = await request(app).get("/admin-only");
+
+    expect(res.status).toBe(403);
+    expect(res.type).toBe("application/json");
+    expect(res.body.error).toBe("Forbidden");
+    expect(nextHandler).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/middleware/require-admin.ts
+++ b/apps/api/src/middleware/require-admin.ts
@@ -5,7 +5,7 @@ export function requireAdmin(req: Request, _res: Response, next: NextFunction): 
   if (!req.user) {
     throw createError("No token provided", 401);
   }
-  if (req.user.role !== "admin") {
+  if (req.user.role !== "admin" && req.user.role !== "super_admin") {
     throw createError("Forbidden", 403, "FORBIDDEN");
   }
   next();


### PR DESCRIPTION
## What
Adds focused coverage for the admin role gate and allows `super_admin` to satisfy `requireAdmin`.

## Why
Issue #405 asks for tests around the admin role hierarchy and 403 response shape. The current middleware only allowed `admin`, so a `super_admin` token was rejected even though the issue defines it as an admin superset.

## How
- Updates `requireAdmin` to allow both `admin` and `super_admin` roles.
- Adds isolated Express middleware tests for `admin`, `super_admin`, `user`, `brand`, and missing role cases.
- Asserts forbidden responses are JSON and that the protected handler is not called on 403.

## Test plan
- [x] `./node_modules/.bin/vitest run apps/api/src/middleware/__tests__/require-admin.test.ts apps/api/src/middleware/require-admin.test.ts`
- [x] `./node_modules/.bin/prettier --check apps/api/src/middleware/require-admin.ts apps/api/src/middleware/__tests__/require-admin.test.ts`
- [ ] `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` currently stops on an existing unrelated syntax error in `apps/api/src/routes/leaderboard.ts`.

Closes #405