### PR TITLE
fix(api): isolate redis rate limit stores

### DIFF
--- a/apps/api/src/middleware/__tests__/rate-limit.test.ts
+++ b/apps/api/src/middleware/__tests__/rate-limit.test.ts
@@ -1,0 +1,210 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MemoryRedis {
+  private readonly values = new Map<string, { hits: number; expiresAt: number }>();
+  private readonly incrementSha = "increment-sha";
+  private readonly getSha = "get-sha";
+  public readonly calls: string[][] = [];
+
+  async call(...args: string[]): Promise<unknown> {
+    const command = args[0]?.toUpperCase();
+    this.calls.push(args);
+
+    if (command === "SCRIPT" && args[1]?.toUpperCase() === "LOAD") {
+      return args[2]?.includes("INCR") ? this.incrementSha : this.getSha;
+    }
+
+    if (command === "EVALSHA") {
+      const [, sha, , key] = args;
+      if (sha === this.incrementSha) {
+        return this.increment(key, args[4] === "1", Number.parseInt(args[5] ?? "0", 10));
+      }
+      if (sha === this.getSha) {
+        return this.get(key);
+      }
+      throw new Error("NOSCRIPT");
+    }
+
+    if (command === "DECR") {
+      const entry = this.current(args[1]);
+      if (entry) entry.hits -= 1;
+      return entry?.hits ?? 0;
+    }
+
+    if (command === "DEL") {
+      return this.values.delete(args[1]) ? 1 : 0;
+    }
+
+    throw new Error(`Unsupported Redis command: ${args.join(" ")}`);
+  }
+
+  keys(): string[] {
+    this.pruneExpired();
+    return [...this.values.keys()];
+  }
+
+  pttl(key: string): number {
+    this.pruneExpired();
+    const entry = this.values.get(key);
+    return entry ? entry.expiresAt - Date.now() : -2;
+  }
+
+  private increment(key: string, resetOnChange: boolean, windowMs: number): [number, number] {
+    this.pruneExpired();
+    const existing = this.values.get(key);
+
+    if (!existing) {
+      this.values.set(key, { hits: 1, expiresAt: Date.now() + windowMs });
+      return [1, windowMs];
+    }
+
+    existing.hits += 1;
+    if (resetOnChange) existing.expiresAt = Date.now() + windowMs;
+    return [existing.hits, existing.expiresAt - Date.now()];
+  }
+
+  private get(key: string): [number | false, number] {
+    this.pruneExpired();
+    const entry = this.values.get(key);
+    return entry ? [entry.hits, entry.expiresAt - Date.now()] : [false, -2];
+  }
+
+  private current(key: string): { hits: number; expiresAt: number } | undefined {
+    this.pruneExpired();
+    return this.values.get(key);
+  }
+
+  private pruneExpired(): void {
+    for (const [key, entry] of this.values) {
+      if (entry.expiresAt <= Date.now()) this.values.delete(key);
+    }
+  }
+}
+
+async function loadRateLimitModule(redis: { call: (...args: string[]) => Promise<unknown> }) {
+  vi.resetModules();
+
+  vi.doMock("../../lib/config", () => ({
+    config: {
+      NODE_ENV: "production",
+    },
+  }));
+
+  vi.doMock("../../lib/redis", () => ({
+    redis,
+  }));
+
+  vi.doMock("../../lib/logger", () => ({
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    },
+  }));
+
+  return import("../rate-limit");
+}
+
+function appWith(limiter: express.RequestHandler, userSub?: string): express.Express {
+  const app = express();
+  app.set("trust proxy", true);
+
+  if (userSub) {
+    app.use((req, _res, next) => {
+      req.user = {
+        sub: userSub,
+        email: "user@example.com",
+        role: "player",
+        iss: "brandblitz-api",
+        aud: "brandblitz-client",
+        iat: 1,
+        exp: 9_999_999_999,
+      };
+      next();
+    });
+  }
+
+  app.use(limiter);
+  app.get("/", (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe("rate limit Redis-backed windows", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("sets a Redis TTL on the first hit and allows the bucket after the window expires", async () => {
+    const redis = new MemoryRedis();
+    const { challengeStartLimiter } = await loadRateLimitModule(redis);
+    const app = appWith(challengeStartLimiter, "user-ttl");
+
+    await request(app).get("/").set("X-Forwarded-For", "203.0.113.10").expect(200);
+
+    expect(redis.keys()).toEqual(["rl:user:user-ttl"]);
+    expect(redis.pttl("rl:user:user-ttl")).toBe(60 * 60 * 1000);
+
+    for (let i = 0; i < 4; i += 1) {
+      await request(app).get("/").set("X-Forwarded-For", "203.0.113.10").expect(200);
+    }
+    await request(app).get("/").set("X-Forwarded-For", "203.0.113.10").expect(429);
+
+    vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+    await request(app).get("/").set("X-Forwarded-For", "203.0.113.10").expect(200);
+  });
+
+  it("keys anonymous requests by X-Forwarded-For when trust proxy is enabled", async () => {
+    const redis = new MemoryRedis();
+    const { authLimiter } = await loadRateLimitModule(redis);
+    const app = appWith(authLimiter);
+
+    for (let i = 0; i < 10; i += 1) {
+      await request(app).get("/").set("X-Forwarded-For", "198.51.100.44").expect(200);
+    }
+
+    await request(app).get("/").set("X-Forwarded-For", "198.51.100.44").expect(429);
+    await request(app).get("/").set("X-Forwarded-For", "198.51.100.45").expect(200);
+
+    expect(redis.keys()).toContain("rl:ip:198.51.100.44");
+    expect(redis.keys()).toContain("rl:ip:198.51.100.45");
+  });
+
+  it("falls back to the socket remote address when no X-Forwarded-For header is present", async () => {
+    const redis = new MemoryRedis();
+    const { authLimiter } = await loadRateLimitModule(redis);
+    const app = appWith(authLimiter);
+
+    await request(app).get("/").expect(200);
+
+    expect(redis.keys()).toHaveLength(1);
+    expect(redis.keys()[0]).toMatch(/^rl:ip:/);
+    expect(redis.keys()[0]).not.toBe("rl:ip:undefined");
+  });
+
+  it("fails open when the Redis store throws", async () => {
+    const redis = {
+      call: vi.fn(async (...args: string[]) => {
+        if (args[0]?.toUpperCase() === "SCRIPT" && args[1]?.toUpperCase() === "LOAD") {
+          return args[2]?.includes("INCR") ? "increment-sha" : "get-sha";
+        }
+        throw new Error("redis unavailable");
+      }),
+    };
+    const { authLimiter } = await loadRateLimitModule(redis);
+    const app = appWith(authLimiter);
+
+    await request(app).get("/").set("X-Forwarded-For", "192.0.2.50").expect(200);
+
+    expect(redis.call).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -40,10 +40,7 @@ function parseIpv4Hextets(part: string): string[] | null {
   if (isIP(part) !== 4) return null;
 
   const octets = part.split(".").map((octet) => Number.parseInt(octet, 10));
-  return [
-    ((octets[0] << 8) | octets[1]).toString(16),
-    ((octets[2] << 8) | octets[3]).toString(16),
-  ];
+  return [((octets[0] << 8) | octets[1]).toString(16), ((octets[2] << 8) | octets[3]).toString(16)];
 }
 
 function expandIpv6(address: string): string[] | null {
@@ -109,9 +106,10 @@ function ipKey(req: Request): string {
 function makeRedisStore() {
   return new RedisStore({
     sendCommand: async (...args: string[]) => {
-      const command = typeof (redis as any).call === "function"
-        ? (redis as any).call
-        : (redis as any).sendCommand;
+      const command =
+        typeof (redis as any).call === "function"
+          ? (redis as any).call
+          : (redis as any).sendCommand;
       if (!command) throw new TypeError("Redis client does not support call/sendCommand");
       try {
         return await command.apply(redis, args);
@@ -125,7 +123,7 @@ function makeRedisStore() {
   });
 }
 
-const redisStore = config.NODE_ENV === "test" ? undefined : makeRedisStore();
+const rateLimitStore = () => (config.NODE_ENV === "test" ? undefined : makeRedisStore());
 
 // ── Limiters ──────────────────────────────────────────────────────────────────
 
@@ -142,7 +140,7 @@ export const apiLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: userAwareKey,
   passOnStoreError: true,
-  store: redisStore,
+  store: rateLimitStore(),
   handler: (req, res) => {
     record429("apiLimiter", userAwareKey(req));
     res.status(429).json({ error: "Too many requests, please try again later" });
@@ -160,7 +158,7 @@ export const authLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: ipKey,
   passOnStoreError: true,
-  store: redisStore,
+  store: rateLimitStore(),
   handler: (req, res) => {
     record429("authLimiter", normalizeClientIp(req.ip));
     res.status(429).json({ error: "Too many login attempts, please try again later" });
@@ -178,7 +176,7 @@ export const challengeStartLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: userAwareKey,
   passOnStoreError: true,
-  store: redisStore,
+  store: rateLimitStore(),
   handler: (req, res) => {
     record429("challengeStartLimiter", userAwareKey(req));
     res.status(429).json({ error: "Too many challenge attempts" });
@@ -195,7 +193,7 @@ export const uploadLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: userAwareKey,
   passOnStoreError: true,
-  store: redisStore,
+  store: rateLimitStore(),
   handler: (req, res) => {
     record429("uploadLimiter", userAwareKey(req));
     res.status(429).json({ error: "Too many upload requests" });
@@ -212,7 +210,7 @@ export const webhookLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false,
   keyGenerator: ipKey,
-  store: redisStore,
+  store: rateLimitStore(),
 });
 
 /**
@@ -224,7 +222,7 @@ export const phoneRateLimit = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false,
   passOnStoreError: true,
-  store: redisStore,
+  store: rateLimitStore(),
   keyGenerator: (req) => {
     const raw = typeof req.body?.phone === "string" ? req.body.phone.replace(/\D/g, "") : "";
     return raw ? `phone:${raw}` : userAwareKey(req);
@@ -253,7 +251,7 @@ export const webhookRotationLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: userAwareKey,
   passOnStoreError: true,
-  store: redisStore,
+  store: rateLimitStore(),
   handler: (req, res) => {
     record429("webhookRotationLimiter", userAwareKey(req));
     res.status(429).json({ error: "Too many webhook rotation requests" });
@@ -271,7 +269,7 @@ export const waitlistLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: ipKey,
   passOnStoreError: true,
-  store: redisStore,
+  store: rateLimitStore(),
   handler: (req, res) => {
     record429("waitlistLimiter", normalizeClientIp(req.ip));
     res.status(429).json({ error: "Too many signup attempts, please try again later" });
@@ -287,9 +285,10 @@ export const reportLimiter = rateLimit({
   max: 5,
   standardHeaders: "draft-7",
   legacyHeaders: false,
-  keyGenerator: (req) => (req.user?.sub ? `user:${req.user.sub}` : `ip:${normalizeClientIp(req.ip)}`),
+  keyGenerator: (req) =>
+    req.user?.sub ? `user:${req.user.sub}` : `ip:${normalizeClientIp(req.ip)}`,
   passOnStoreError: true,
-  store: redisStore,
+  store: rateLimitStore(),
   handler: (req, res) => {
     const key = req.user?.sub ? `user:${req.user.sub}` : `ip:${normalizeClientIp(req.ip)}`;
     record429("reportLimiter", key);


### PR DESCRIPTION
## Summary
- Add Redis-backed rate-limit tests covering TTL creation, window expiry, X-Forwarded-For keying, remote-address fallback, and Redis fail-open behavior.
- Fix production limiter setup so each express-rate-limit middleware gets its own RedisStore instance.
- Prevent RedisStore reuse from sharing one windowMs value across all limiters, which can make a 1-hour limiter behave like a 15-minute limiter.

Closes #403.

## Verification
- `./node_modules/.bin/prettier --check apps/api/src/middleware/rate-limit.ts apps/api/src/middleware/__tests__/rate-limit.test.ts`
- `./node_modules/.bin/vitest run apps/api/src/middleware/__tests__/rate-limit.test.ts apps/api/src/middleware/rate-limit.test.ts`
- `git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml --verbose`

## Note
- `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` is currently blocked by an existing syntax error in `apps/api/src/routes/leaderboard.ts:196`, outside this change.
