### PR TITLE
test(api): cover google auth token failures

### DIFF
--- a/apps/api/src/services/google-auth.test.ts
+++ b/apps/api/src/services/google-auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   redisSet: vi.fn(),
@@ -18,11 +18,16 @@ import {
   createCodeChallenge,
   createGooglePkceAuthorizationUrl,
   exchangeGoogleAuthorizationCode,
+  verifyGoogleIdToken,
 } from "./google-auth";
 
 describe("google-auth PKCE", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("creates an S256 authorization URL and stores a short-lived verifier in Redis", async () => {
@@ -77,7 +82,166 @@ describe("google-auth PKCE", () => {
     expect(mocks.redisGet).toHaveBeenCalledWith("oauth:google:pkce:state-123");
     expect(mocks.redisDel).toHaveBeenCalledWith("oauth:google:pkce:state-123");
     expect(profile.googleId).toBe("google-123");
+  });
 
+  it("rejects an expired or missing PKCE state before calling Google", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    mocks.redisGet.mockResolvedValue(null);
+
+    await expect(
+      exchangeGoogleAuthorizationCode({
+        code: "auth-code",
+        state: "expired-state",
+      })
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      code: "INVALID_OAUTH_STATE",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.redisDel).not.toHaveBeenCalled();
+  });
+
+  it("deletes the PKCE state before exchanging the Google authorization code", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id_token: "google-id-token" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sub: "google-123",
+          email: "player@example.com",
+          aud: "test-google-client-id",
+          email_verified: "true",
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    mocks.redisGet.mockResolvedValue(JSON.stringify({ codeVerifier: "b".repeat(43) }));
+    mocks.redisDel.mockResolvedValue(1);
+
+    await exchangeGoogleAuthorizationCode({
+      code: "auth-code",
+      state: "state-123",
+    });
+
+    expect(mocks.redisDel.mock.invocationCallOrder[0]).toBeLessThan(
+      fetchMock.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("rejects a failed Google token exchange response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "invalid_grant" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    mocks.redisGet.mockResolvedValue(JSON.stringify({ codeVerifier: "c".repeat(43) }));
+    mocks.redisDel.mockResolvedValue(1);
+
+    await expect(
+      exchangeGoogleAuthorizationCode({
+        code: "bad-code",
+        state: "state-123",
+      })
+    ).rejects.toMatchObject({
+      statusCode: 401,
+      code: "INVALID_GOOGLE_CODE",
+    });
+  });
+});
+
+describe("verifyGoogleIdToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("returns a verified Google profile for a valid tokeninfo response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sub: "google-123",
+        email: "player@example.com",
+        aud: "test-google-client-id",
+        email_verified: "true",
+        name: "Player One",
+        picture: "https://example.com/avatar.png",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const profile = await verifyGoogleIdToken("valid-id-token");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/tokeninfo?id_token=valid-id-token"
+    );
+    expect(profile).toEqual({
+      googleId: "google-123",
+      email: "player@example.com",
+      name: "Player One",
+      avatarUrl: "https://example.com/avatar.png",
+    });
+  });
+
+  it("rejects a tokeninfo response with the wrong audience", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          sub: "google-123",
+          email: "player@example.com",
+          aud: "another-client-id",
+          email_verified: "true",
+        }),
+      })
+    );
+
+    await expect(verifyGoogleIdToken("wrong-audience-token")).rejects.toMatchObject({
+      statusCode: 401,
+      code: "INVALID_GOOGLE_TOKEN",
+    });
+  });
+
+  it("rejects a tokeninfo response with an unverified email", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          sub: "google-123",
+          email: "player@example.com",
+          aud: "test-google-client-id",
+          email_verified: "false",
+        }),
+      })
+    );
+
+    await expect(verifyGoogleIdToken("unverified-email-token")).rejects.toMatchObject({
+      statusCode: 401,
+      code: "UNVERIFIED_GOOGLE_EMAIL",
+    });
+  });
+
+  it("rejects a non-OK tokeninfo response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: "invalid_token" }),
+      })
+    );
+
+    await expect(verifyGoogleIdToken("bad-id-token")).rejects.toMatchObject({
+      statusCode: 401,
+      code: "INVALID_GOOGLE_TOKEN",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add focused service-level coverage for Google tokeninfo success and failure paths.
- Cover wrong audience, unverified email, non-OK tokeninfo responses, expired/missing PKCE state, token exchange failures, and PKCE state deletion before code exchange.
- Keep the tests aligned with the current implementation, which validates tokeninfo through `fetch` and leaves user persistence to the auth route/database layer.

Closes #401.

## Verification
- `./node_modules/.bin/prettier --check apps/api/src/services/google-auth.test.ts`
- `./node_modules/.bin/vitest run apps/api/src/services/google-auth.test.ts`
- `git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml --verbose`

## Note
- `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` is currently blocked by an existing syntax error in `apps/api/src/routes/leaderboard.ts:196`, outside this change.
