### PR TITLE
test(api): cover refund service failure modes

### DIFF
--- a/apps/api/src/services/refund.test.ts
+++ b/apps/api/src/services/refund.test.ts
@@ -74,6 +74,7 @@ vi.mock("@stellar/stellar-sdk", () => {
 });
 
 import { refundChallenge } from "./refund";
+import { Memo, Operation } from "@stellar/stellar-sdk";
 
 describe("refundChallenge", () => {
   beforeEach(() => {
@@ -118,7 +119,60 @@ describe("refundChallenge", () => {
       "00000000-0000-0000-0000-000000000001",
       "refunded"
     );
-    expect(mocks.query).toHaveBeenCalled();
+    expect(Memo.text).toHaveBeenCalledWith("REFUND:00000000-0000-0000-00");
+    expect(Operation.payment).toHaveBeenCalledWith({
+      destination: "GBRAND",
+      asset: { code: "USDC", issuer: "GISSUER" },
+      amount: "0.2500000",
+    });
+    expect(mocks.query).toHaveBeenCalledWith(expect.stringContaining("challenge_refund"), [
+      "admin-1",
+      "00000000-0000-0000-0000-000000000001",
+      JSON.stringify({
+        refundId: "refund-1",
+        txHash: "refund-tx",
+        amount: "0.2500000",
+        destination: "GBRAND",
+        reason: "brand requested cancellation",
+      }),
+    ]);
+  });
+
+  it("returns an existing refund without submitting a duplicate payment", async () => {
+    const existingRefund = {
+      id: "refund-existing",
+      challenge_id: "00000000-0000-0000-0000-000000000001",
+      tx_hash: "existing-refund-tx",
+    };
+    mocks.findRefundByChallengeId.mockResolvedValue(existingRefund);
+
+    const refund = await refundChallenge({
+      challengeId: "00000000-0000-0000-0000-000000000001",
+      adminId: "admin-1",
+      reason: "duplicate request",
+    });
+
+    expect(refund).toBe(existingRefund);
+    expect(mocks.getChallengeById).not.toHaveBeenCalled();
+    expect(mocks.submitTransaction).not.toHaveBeenCalled();
+    expect(mocks.createRefund).not.toHaveBeenCalled();
+    expect(mocks.updateChallengeStatus).not.toHaveBeenCalled();
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the challenge does not exist", async () => {
+    mocks.getChallengeById.mockResolvedValue(null);
+
+    await expect(
+      refundChallenge({
+        challengeId: "00000000-0000-0000-0000-000000000001",
+        adminId: "admin-1",
+        reason: "test",
+      })
+    ).rejects.toThrow("Challenge not found");
+
+    expect(mocks.submitTransaction).not.toHaveBeenCalled();
+    expect(mocks.createRefund).not.toHaveBeenCalled();
   });
 
   it("rejects an already-settled challenge", async () => {
@@ -136,6 +190,9 @@ describe("refundChallenge", () => {
         reason: "test",
       })
     ).rejects.toThrow("Challenge already settled");
+
+    expect(mocks.submitTransaction).not.toHaveBeenCalled();
+    expect(mocks.createRefund).not.toHaveBeenCalled();
   });
 
   it("rejects when no deposit is found", async () => {
@@ -153,5 +210,83 @@ describe("refundChallenge", () => {
         reason: "test",
       })
     ).rejects.toThrow("No deposit found");
+
+    expect(mocks.forTransaction).not.toHaveBeenCalled();
+    expect(mocks.submitTransaction).not.toHaveBeenCalled();
+    expect(mocks.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the deposit transaction has no payment sender", async () => {
+    mocks.getChallengeById.mockResolvedValue({
+      id: "00000000-0000-0000-0000-000000000001",
+      status: "active",
+      deposit_tx_hash: "deposit-tx",
+      pool_amount_stroops: "2500000",
+    });
+    mocks.forTransaction.mockReturnValue({
+      call: vi.fn().mockResolvedValue({
+        records: [{ type: "change_trust", source_account: "GBRAND" }],
+      }),
+    });
+
+    await expect(
+      refundChallenge({
+        challengeId: "00000000-0000-0000-0000-000000000001",
+        adminId: "admin-1",
+        reason: "test",
+      })
+    ).rejects.toThrow("No deposit found");
+
+    expect(mocks.submitTransaction).not.toHaveBeenCalled();
+    expect(mocks.createRefund).not.toHaveBeenCalled();
+  });
+
+  it("falls back to source_account when the payment operation has no from field", async () => {
+    mocks.getChallengeById.mockResolvedValue({
+      id: "00000000-0000-0000-0000-000000000001",
+      status: "active",
+      deposit_tx_hash: "deposit-tx",
+      pool_amount_stroops: "2500000",
+    });
+    mocks.forTransaction.mockReturnValue({
+      call: vi.fn().mockResolvedValue({
+        records: [{ type: "payment", source_account: "GSOURCE" }],
+      }),
+    });
+
+    await refundChallenge({
+      challengeId: "00000000-0000-0000-0000-000000000001",
+      adminId: "admin-1",
+      reason: "brand requested cancellation",
+    });
+
+    expect(mocks.createRefund).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destination: "GSOURCE",
+        txHash: "refund-tx",
+      })
+    );
+  });
+
+  it("does not persist refund state when the Stellar refund submission fails", async () => {
+    mocks.getChallengeById.mockResolvedValue({
+      id: "00000000-0000-0000-0000-000000000001",
+      status: "active",
+      deposit_tx_hash: "deposit-tx",
+      pool_amount_stroops: "2500000",
+    });
+    mocks.submitTransaction.mockRejectedValue(new Error("horizon timeout"));
+
+    await expect(
+      refundChallenge({
+        challengeId: "00000000-0000-0000-0000-000000000001",
+        adminId: "admin-1",
+        reason: "test",
+      })
+    ).rejects.toThrow("horizon timeout");
+
+    expect(mocks.createRefund).not.toHaveBeenCalled();
+    expect(mocks.updateChallengeStatus).not.toHaveBeenCalled();
+    expect(mocks.query).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What
Adds focused unit coverage for the refund service failure paths and persistence side effects.

## Why
Refunds are money-moving admin actions, so the service should be covered beyond the happy path. These tests document the existing behavior for duplicate refund requests, missing challenges/deposits, missing Horizon payment sender data, Stellar submission failures, and audit-log payloads.

## How
- Asserts duplicate refund requests return the existing refund without sending another payment.
- Covers challenge-not-found, settled challenge, missing deposit, and missing deposit sender failures.
- Verifies source_account fallback when Horizon payment records omit from.
- Verifies the Stellar payment operation, refund memo, and audit-log payload on success.
- Ensures refund state is not persisted if Stellar submission fails.

## Test plan
- [x] `./node_modules/.bin/vitest run apps/api/src/services/refund.test.ts`
- [x] `./node_modules/.bin/prettier --check apps/api/src/services/refund.test.ts`
- [x] `git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml --verbose`
- [ ] `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` currently blocked by existing unrelated `apps/api/src/routes/leaderboard.ts(196,1): error TS1128`

Closes #399