### PR TITLE
test(api): cover referral bonus queue edges

### DIFF
--- a/apps/api/src/services/referrals.test.ts
+++ b/apps/api/src/services/referrals.test.ts
@@ -133,4 +133,151 @@ describe("queueReferralBonusForPayout", () => {
     expect(mocks.markReferralRewarded).toHaveBeenCalledWith("referral-1");
     expect(mocks.enqueueReferralBonus).toHaveBeenCalledWith("payout-1");
   });
+
+  it("does nothing when the referred user has no referral", async () => {
+    mocks.findReferralByReferredId.mockResolvedValue(null);
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 100_000_000n,
+    });
+
+    expect(mocks.getSession).not.toHaveBeenCalled();
+    expect(mocks.findUserById).not.toHaveBeenCalled();
+    expect(mocks.createReferralPayout).not.toHaveBeenCalled();
+    expect(mocks.markReferralRewarded).not.toHaveBeenCalled();
+    expect(mocks.enqueueReferralBonus).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the referral was already rewarded", async () => {
+    mocks.findReferralByReferredId.mockResolvedValue({
+      id: "referral-1",
+      referrer_id: "referrer-1",
+      referred_id: "referred-1",
+      rewarded: true,
+    });
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 100_000_000n,
+    });
+
+    expect(mocks.getSession).not.toHaveBeenCalled();
+    expect(mocks.findUserById).not.toHaveBeenCalled();
+    expect(mocks.createReferralPayout).not.toHaveBeenCalled();
+    expect(mocks.markReferralRewarded).not.toHaveBeenCalled();
+    expect(mocks.enqueueReferralBonus).not.toHaveBeenCalled();
+  });
+
+  it("uses embedded wallet addresses before Stellar addresses", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ exists: false }] });
+    mocks.findUserById.mockImplementation((userId: string) =>
+      Promise.resolve({
+        id: userId,
+        stellar_address: `${userId}-stellar`,
+        embedded_wallet_address: `${userId}-embedded`,
+      })
+    );
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 100_000_000n,
+    });
+
+    expect(mocks.createReferralPayout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        referrerStellarAddress: "referrer-1-embedded",
+        referredStellarAddress: "referred-1-embedded",
+      })
+    );
+  });
+
+  it("does not create a payout when either user lacks a payout address", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ exists: false }] });
+    mocks.findUserById.mockImplementation((userId: string) =>
+      Promise.resolve({
+        id: userId,
+        stellar_address: userId === "referrer-1" ? "" : `${userId}-stellar`,
+        embedded_wallet_address: null,
+      })
+    );
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 100_000_000n,
+    });
+
+    expect(mocks.createReferralPayout).not.toHaveBeenCalled();
+    expect(mocks.markReferralRewarded).not.toHaveBeenCalled();
+    expect(mocks.enqueueReferralBonus).not.toHaveBeenCalled();
+  });
+
+  it("caps the referrer bonus at five USDC", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ exists: false }] });
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 1_000_000_000n,
+    });
+
+    expect(mocks.createReferralPayout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        referrerAmountStroops: 50_000_000n,
+        referredAmountStroops: 10_000_000n,
+      })
+    );
+  });
+
+  it("skips payout creation when the referrer bonus rounds down to zero", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ exists: false }] });
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 9n,
+    });
+
+    expect(mocks.createReferralPayout).not.toHaveBeenCalled();
+    expect(mocks.markReferralRewarded).not.toHaveBeenCalled();
+    expect(mocks.enqueueReferralBonus).not.toHaveBeenCalled();
+  });
+
+  it("does not check fraud flags when no challenge id is provided", async () => {
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: null,
+      referralWinAmountStroops: 100_000_000n,
+    });
+
+    expect(mocks.getSession).not.toHaveBeenCalled();
+    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.createReferralPayout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        challengeId: null,
+      })
+    );
+    expect(mocks.enqueueReferralBonus).toHaveBeenCalledWith("payout-1");
+  });
+
+  it("does not enqueue when payout creation returns a non-pending payout", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [{ exists: false }] });
+    mocks.createReferralPayout.mockResolvedValue({
+      id: "payout-1",
+      status: "sent",
+    });
+
+    await queueReferralBonusForPayout({
+      referredUserId: "referred-1",
+      challengeId: "challenge-1",
+      referralWinAmountStroops: 100_000_000n,
+    });
+
+    expect(mocks.markReferralRewarded).not.toHaveBeenCalled();
+    expect(mocks.enqueueReferralBonus).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What
Adds focused unit coverage for referral bonus queue edge cases.

## Why
Referral payouts are money-moving side effects, so the queueing service should document when it must create/enqueue a payout and when it must safely do nothing.

## How
- Covers missing referrals and already-rewarded referrals.
- Verifies embedded wallet addresses are preferred over Stellar addresses.
- Verifies missing payout addresses skip payout creation.
- Covers the five USDC referrer cap and zero-rounded bonus skip.
- Covers no-challenge attribution path without fraud lookup.
- Verifies non-pending payout records are not marked rewarded or enqueued.

## Test plan
- [x] `./node_modules/.bin/vitest run apps/api/src/services/referrals.test.ts`
- [x] `./node_modules/.bin/prettier --check apps/api/src/services/referrals.test.ts`
- [x] `git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml --verbose`
- [ ] `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` currently blocked by existing unrelated `apps/api/src/routes/leaderboard.ts(196,1): error TS1128`

Closes #398