### PR TITLE
test(api): cover streak service edge cases

### DIFF
--- a/apps/api/src/services/streaks.test.ts
+++ b/apps/api/src/services/streaks.test.ts
@@ -5,6 +5,8 @@ const mocks = vi.hoisted(() => ({
   setUserStreak: vi.fn(),
   repairUserStreak: vi.fn(),
   metricsInc: vi.fn(),
+  query: vi.fn(),
+  loggerWarn: vi.fn(),
 }));
 
 vi.mock("../db/queries/users", () => ({
@@ -15,6 +17,14 @@ vi.mock("../db/queries/users", () => ({
 
 vi.mock("../lib/metrics", () => ({
   metrics: { inc: mocks.metricsInc },
+}));
+
+vi.mock("../db", () => ({
+  query: mocks.query,
+}));
+
+vi.mock("../lib/logger", () => ({
+  logger: { warn: mocks.loggerWarn },
 }));
 
 import { getStreak, repairStreak, updateStreak } from "./streaks";
@@ -76,6 +86,108 @@ describe("streaks service", () => {
     expect(mocks.setUserStreak).toHaveBeenCalledWith(expect.objectContaining({ streak: 1 }));
   });
 
+  it("does not update the streak twice on the same UTC day", async () => {
+    const current = {
+      id: "user-1",
+      streak: 4,
+      last_play_day: "2026-05-30T00:00:00.000Z",
+      streak_repairs_this_month: 0,
+      streak_repair_available: true,
+    };
+    mocks.getUserStreak.mockResolvedValue(current);
+
+    const result = await updateStreak("user-1", new Date("2026-05-30T23:59:59Z"));
+
+    expect(result).toBe(current);
+    expect(mocks.setUserStreak).not.toHaveBeenCalled();
+    expect(mocks.metricsInc).not.toHaveBeenCalled();
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("starts a new streak when the user has never played before", async () => {
+    mocks.getUserStreak.mockResolvedValue({
+      id: "user-1",
+      streak: 0,
+      last_play_day: null,
+      streak_repairs_this_month: 0,
+      streak_repair_available: false,
+    });
+    mocks.setUserStreak.mockResolvedValue({
+      id: "user-1",
+      streak: 1,
+      last_play_day: "2026-05-30",
+      streak_repairs_this_month: 0,
+      streak_repair_available: false,
+    });
+
+    const result = await updateStreak("user-1", new Date("2026-05-30T10:00:00Z"));
+
+    expect(result.streak).toBe(1);
+    expect(mocks.setUserStreak).toHaveBeenCalledWith({
+      userId: "user-1",
+      streak: 1,
+      lastPlayDay: "2026-05-30",
+      repairAvailable: false,
+    });
+  });
+
+  it("inserts a notification when a notification milestone is reached", async () => {
+    mocks.getUserStreak.mockResolvedValue({
+      id: "user-1",
+      streak: 6,
+      last_play_day: "2026-05-29",
+      streak_repairs_this_month: 0,
+      streak_repair_available: true,
+    });
+    mocks.setUserStreak.mockResolvedValue({
+      id: "user-1",
+      streak: 7,
+      last_play_day: "2026-05-30",
+      streak_repairs_this_month: 0,
+      streak_repair_available: true,
+    });
+    mocks.query.mockResolvedValue({ rows: [] });
+
+    await updateStreak("user-1", new Date("2026-05-30T10:00:00Z"));
+
+    expect(mocks.metricsInc).toHaveBeenCalledWith("streaks.milestones_reached_total", {
+      milestone: "7",
+    });
+    expect(mocks.query).toHaveBeenCalledWith(expect.stringContaining("streak_milestone"), [
+      "user-1",
+      JSON.stringify({ milestone: 7 }),
+    ]);
+  });
+
+  it("keeps the updated streak when notification insert fails", async () => {
+    mocks.getUserStreak.mockResolvedValue({
+      id: "user-1",
+      streak: 6,
+      last_play_day: "2026-05-29",
+      streak_repairs_this_month: 0,
+      streak_repair_available: true,
+    });
+    mocks.setUserStreak.mockResolvedValue({
+      id: "user-1",
+      streak: 7,
+      last_play_day: "2026-05-30",
+      streak_repairs_this_month: 0,
+      streak_repair_available: true,
+    });
+    mocks.query.mockRejectedValue(new Error("notification insert failed"));
+
+    const result = await updateStreak("user-1", new Date("2026-05-30T10:00:00Z"));
+
+    expect(result.streak).toBe(7);
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "Failed to insert streak milestone notification",
+      expect.objectContaining({
+        userId: "user-1",
+        milestone: 7,
+      })
+    );
+  });
+
   it("repairs a streak when the monthly repair is available", async () => {
     mocks.repairUserStreak.mockResolvedValue({
       id: "user-1",
@@ -116,5 +228,35 @@ describe("streaks service", () => {
       nextMilestone: 7,
       milestoneJustHit: false,
     });
+  });
+
+  it("marks a milestone as just hit only on the same UTC day", async () => {
+    mocks.getUserStreak.mockResolvedValue({
+      id: "user-1",
+      streak: 7,
+      last_play_day: "2026-05-30T00:00:00.000Z",
+      streak_repairs_this_month: 0,
+      streak_repair_available: true,
+    });
+
+    await expect(getStreak("user-1", new Date("2026-05-30T10:00:00Z"))).resolves.toMatchObject({
+      milestoneJustHit: true,
+      progress: 0.5,
+      nextMilestone: 14,
+    });
+    await expect(getStreak("user-1", new Date("2026-05-31T10:00:00Z"))).resolves.toMatchObject({
+      milestoneJustHit: false,
+    });
+  });
+
+  it("throws when the user streak row does not exist", async () => {
+    mocks.getUserStreak.mockResolvedValue(null);
+
+    await expect(updateStreak("missing-user", new Date("2026-05-30T10:00:00Z"))).rejects.toThrow(
+      "User not found"
+    );
+    await expect(getStreak("missing-user", new Date("2026-05-30T10:00:00Z"))).rejects.toThrow(
+      "User not found"
+    );
   });
 });


### PR DESCRIPTION
## What
Adds focused unit coverage for streak service edge cases.

## Why
Streaks affect user retention and notification side effects. The existing tests covered the core increment/reset/repair paths, but not same-day idempotency, notification milestones, notification insert failures, missing users, or milestone formatting boundaries.

## How
- Verifies same-day updates return the current streak without writing again.
- Covers first-play streak initialization.
- Covers 7-day notification milestone insertion and logger fallback when notification insert fails.
- Covers milestoneJustHit behavior across UTC days.
- Covers missing user errors for update/get paths.

## Test plan
- [x] `./node_modules/.bin/vitest run apps/api/src/services/streaks.test.ts`
- [x] `./node_modules/.bin/prettier --check apps/api/src/services/streaks.test.ts`
- [x] `git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml --verbose`
- [ ] `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` currently blocked by existing unrelated `apps/api/src/routes/leaderboard.ts(196,1): error TS1128`

Closes #397