### PR TITLE
fix(api): expose flat public config

### DIFF
--- a/apps/api/src/db/queries/config.test.ts
+++ b/apps/api/src/db/queries/config.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../index", () => ({
+  query: mocks.query,
+}));
+
+import { getPublicConfig, PUBLIC_CONFIG_KEYS } from "./config";
+
+describe("config queries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads only whitelisted public config keys", async () => {
+    mocks.query.mockResolvedValue({
+      rows: [
+        { key: "game_round_duration_seconds", value: 30 },
+        { key: "max_rounds_per_session", value: 3 },
+        { key: "maintenance_mode", value: true },
+      ],
+    });
+
+    const config = await getPublicConfig();
+
+    expect(mocks.query).toHaveBeenCalledWith(
+      "SELECT key, value FROM app_config WHERE key = ANY($1::text[])",
+      [PUBLIC_CONFIG_KEYS]
+    );
+    expect(config).toEqual({
+      game_round_duration_seconds: 30,
+      max_rounds_per_session: 3,
+      maintenance_mode: true,
+    });
+    expect(config).not.toHaveProperty("webhook_secret_current");
+  });
+
+  it("returns an empty object when no public keys are configured", async () => {
+    mocks.query.mockResolvedValue({ rows: [] });
+
+    await expect(getPublicConfig()).resolves.toEqual({});
+  });
+});

--- a/apps/api/src/db/queries/config.ts
+++ b/apps/api/src/db/queries/config.ts
@@ -7,12 +7,33 @@ export interface AppConfigRow {
   updated_by: string | null;
 }
 
+export const PUBLIC_CONFIG_KEYS = [
+  "game_round_duration_seconds",
+  "max_rounds_per_session",
+  "maintenance_mode",
+] as const;
+
+export type PublicConfigKey = (typeof PUBLIC_CONFIG_KEYS)[number];
+export type PublicConfig = Partial<Record<PublicConfigKey, unknown>>;
+
 export async function getConfig(key: string): Promise<Record<string, unknown> | null> {
   const result = await query<{ value: Record<string, unknown> }>(
     "SELECT value FROM app_config WHERE key = $1",
     [key]
   );
   return result.rows[0]?.value ?? null;
+}
+
+export async function getPublicConfig(): Promise<PublicConfig> {
+  const result = await query<{ key: PublicConfigKey; value: unknown }>(
+    "SELECT key, value FROM app_config WHERE key = ANY($1::text[])",
+    [PUBLIC_CONFIG_KEYS]
+  );
+
+  return result.rows.reduce<PublicConfig>((config, row) => {
+    config[row.key] = row.value;
+    return config;
+  }, {});
 }
 
 export async function getConfigRow(key: string): Promise<AppConfigRow | null> {

--- a/apps/api/src/routes/config.test.ts
+++ b/apps/api/src/routes/config.test.ts
@@ -34,10 +34,7 @@ vi.mock("../middleware/authenticate", () => ({
   },
 }));
 
-import configRouter, {
-  PUBLIC_CONFIG_CACHE_KEY,
-  PUBLIC_CONFIG_CACHE_TTL_SECONDS,
-} from "./config";
+import configRouter, { PUBLIC_CONFIG_CACHE_KEY, PUBLIC_CONFIG_CACHE_TTL_SECONDS } from "./config";
 import adminCacheRouter from "./admin/cache";
 
 function createApp() {
@@ -57,11 +54,12 @@ describe("public config cache", () => {
   });
 
   it("queries Postgres once and serves the following request from Redis", async () => {
-    const payload = { anti_cheat: { minReactionTimeMs: 150 } };
+    const payload = {
+      game_round_duration_seconds: 30,
+      maintenance_mode: false,
+    };
     mocks.getPublicConfig.mockResolvedValue(payload);
-    mocks.redisGet
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(JSON.stringify({ config: payload }));
+    mocks.redisGet.mockResolvedValueOnce(null).mockResolvedValueOnce(JSON.stringify(payload));
 
     const app = createApp();
     const first = await request(app).get("/config").expect(200);
@@ -69,13 +67,32 @@ describe("public config cache", () => {
 
     expect(first.headers["x-cache"]).toBe("MISS");
     expect(second.headers["x-cache"]).toBe("HIT");
+    expect(first.headers["cache-control"]).toBe("public, max-age=60");
+    expect(first.body).toEqual(payload);
     expect(first.body).toEqual(second.body);
     expect(mocks.getPublicConfig).toHaveBeenCalledTimes(1);
     expect(mocks.redisSet).toHaveBeenCalledWith(
       PUBLIC_CONFIG_CACHE_KEY,
-      JSON.stringify({ config: payload }),
+      JSON.stringify(payload),
       "EX",
-      PUBLIC_CONFIG_CACHE_TTL_SECONDS,
+      PUBLIC_CONFIG_CACHE_TTL_SECONDS
+    );
+  });
+
+  it("returns an empty flat object when no public config keys exist", async () => {
+    mocks.getPublicConfig.mockResolvedValue({});
+    mocks.redisGet.mockResolvedValueOnce(null);
+
+    const app = createApp();
+    const response = await request(app).get("/config").expect(200);
+
+    expect(response.body).toEqual({});
+    expect(response.headers["cache-control"]).toBe("public, max-age=60");
+    expect(mocks.redisSet).toHaveBeenCalledWith(
+      PUBLIC_CONFIG_CACHE_KEY,
+      JSON.stringify({}),
+      "EX",
+      PUBLIC_CONFIG_CACHE_TTL_SECONDS
     );
   });
 

--- a/apps/api/src/routes/config.ts
+++ b/apps/api/src/routes/config.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getPublicConfig, type PublicConfig } from "../db/queries/config";
+import { getPublicConfig } from "../db/queries/config";
 import { redis } from "../lib/redis";
 
 export const PUBLIC_CONFIG_CACHE_KEY = "config:public";
@@ -10,11 +10,13 @@ const router = Router();
 /**
  * GET /config
  *
- * Public, read-through runtime configuration. The exact JSON envelope is
+ * Public, read-through runtime configuration. The exact JSON payload is
  * constructed before it reaches Redis so cached and uncached responses are
  * byte-for-byte the same shape.
  */
 router.get("/", async (_req, res) => {
+  res.set("Cache-Control", "public, max-age=60");
+
   const cached = await redis.get(PUBLIC_CONFIG_CACHE_KEY);
   if (cached !== null) {
     res.set("X-Cache", "HIT");
@@ -23,16 +25,15 @@ router.get("/", async (_req, res) => {
   }
 
   const config = await getPublicConfig();
-  const payload: { config: PublicConfig } = { config };
   await redis.set(
     PUBLIC_CONFIG_CACHE_KEY,
-    JSON.stringify(payload),
+    JSON.stringify(config),
     "EX",
-    PUBLIC_CONFIG_CACHE_TTL_SECONDS,
+    PUBLIC_CONFIG_CACHE_TTL_SECONDS
   );
 
   res.set("X-Cache", "MISS");
-  res.json(payload);
+  res.json(config);
 });
 
 export default router;


### PR DESCRIPTION
## What
Fixes the public config endpoint so it returns a flat whitelisted config object and adds the missing getPublicConfig query implementation.

## Why
The existing /config route imported getPublicConfig, but the DB query module did not actually export it outside of tests. It also returned a wrapped { config } envelope, while the public API issue calls for a flat JSON object with only safe keys.

## How
- Adds a typed PUBLIC_CONFIG_KEYS whitelist for safe public runtime config keys.
- Implements getPublicConfig() against app_config using the whitelist.
- Returns the flat config object from GET /config for both cache hits and misses.
- Adds Cache-Control: public, max-age=60.
- Adds route and query tests for cache behavior, empty config, whitelist filtering, and sensitive-key exclusion.

## Test plan
- [x] `./node_modules/.bin/vitest run apps/api/src/routes/config.test.ts apps/api/src/db/queries/config.test.ts`
- [x] `./node_modules/.bin/prettier --check apps/api/src/routes/config.ts apps/api/src/routes/config.test.ts apps/api/src/db/queries/config.ts apps/api/src/db/queries/config.test.ts`
- [x] `git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml --verbose`
- [ ] `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` currently blocked by existing unrelated `apps/api/src/routes/leaderboard.ts(196,1): error TS1128`

Addresses the API portion of #469