### PR TITLE
feat(api): add authenticated user search

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -18,6 +18,8 @@ var mockRedisSet = vi.fn();
 var mockRedisDel = vi.fn();
 var mockGetStreak = vi.fn();
 var mockRepairStreak = vi.fn();
+var mockQuery = vi.fn();
+var mockVerifyOtpWithBruteForceProtection = vi.fn();
 
 vi.mock("../db/queries/users", () => ({
   findUserById: mockFindUserById,
@@ -30,6 +32,8 @@ vi.mock("../db/queries/users", () => ({
 vi.mock("../services/phone", () => ({
   sendVerificationCode: mockSendVerificationCode,
   checkVerificationCode: mockCheckVerificationCode,
+  verifyOtpWithBruteForceProtection: (...args: any[]) =>
+    mockVerifyOtpWithBruteForceProtection(...args),
   normalizePhoneNumber: (value: string) => value,
   hashPhoneNumber: (value: string) => crypto.createHash("sha256").update(value).digest("hex"),
 }));
@@ -44,6 +48,14 @@ vi.mock("../lib/redis", () => ({
   },
 }));
 
+vi.mock("../db", () => ({
+  query: (...args: any[]) => mockQuery(...args),
+}));
+
+vi.mock("../db/index", () => ({
+  query: (...args: any[]) => mockQuery(...args),
+}));
+
 vi.mock("../services/streaks", () => ({
   getStreak: mockGetStreak,
   repairStreak: mockRepairStreak,
@@ -53,6 +65,7 @@ vi.mock("../middleware/rate-limit", () => ({
   apiLimiter: (_req: any, _res: any, next: any) => next(),
   authLimiter: (_req: any, _res: any, next: any) => next(),
   challengeStartLimiter: (_req: any, _res: any, next: any) => next(),
+  reportLimiter: (_req: any, _res: any, next: any) => next(),
   uploadLimiter: (_req: any, _res: any, next: any) => next(),
   webhookLimiter: (_req: any, _res: any, next: any) => next(),
   phoneRateLimit: async (req: any, res: any, next: any) => {
@@ -69,8 +82,13 @@ vi.mock("../middleware/rate-limit", () => ({
 
 vi.mock("@brandblitz/stellar", () => ({
   WARMUP_MIN_SECONDS: 20,
+  MIN_POOL_STROOPS: 1_000_000_000n,
   validateMuxedAccount: vi.fn(),
   createMuxedAccount: vi.fn(),
+  feeBumpTransaction: vi.fn(),
+  getHorizonServer: vi.fn(() => ({})),
+  getAccountUsdcBalance: vi.fn(),
+  EscrowClient: vi.fn(),
 }));
 
 import { errorHandler } from "../middleware/error";
@@ -80,9 +98,19 @@ const userId = "user-123";
 const phone = "+15550000000";
 const phoneHash = crypto.createHash("sha256").update(phone).digest("hex");
 const authToken = () =>
-  jwt.sign({ sub: userId, email: "me@example.com" }, process.env.JWT_SECRET as string, {
-    expiresIn: "1h",
-  });
+  jwt.sign(
+    {
+      sub: userId,
+      email: "me@example.com",
+      role: "user",
+      iss: "brandblitz-api",
+      aud: "brandblitz-client",
+    },
+    process.env.JWT_SECRET as string,
+    {
+      expiresIn: "1h",
+    }
+  );
 
 const userRecord = {
   id: userId,
@@ -106,15 +134,12 @@ const userRecord = {
   username: "testuser",
 };
 
-let registerRoutes: (app: express.Express) => void;
-
 beforeAll(async () => {
   process.env.JWT_SECRET = process.env.JWT_SECRET ?? "test-secret";
   app = express();
   app.use(express.json());
-  const routes = await import("../routes");
-  registerRoutes = routes.registerRoutes;
-  registerRoutes(app);
+  const usersRoutes = await import("./users");
+  app.use("/users", usersRoutes.default);
   app.use(errorHandler);
 });
 
@@ -133,6 +158,8 @@ beforeEach(() => {
   mockRedisDel.mockReset();
   mockGetStreak.mockReset();
   mockRepairStreak.mockReset();
+  mockQuery.mockReset();
+  mockVerifyOtpWithBruteForceProtection.mockReset();
 });
 
 afterAll(() => {
@@ -239,6 +266,80 @@ describe("users routes integration", () => {
     expect(mockUpdateUserWallet).toHaveBeenCalledWith(userId, address);
   });
 
+  it("GET /users/search rejects missing and too-short search queries", async () => {
+    await request(app)
+      .get("/users/search")
+      .set("Authorization", `Bearer ${authToken()}`)
+      .expect(400);
+
+    await request(app)
+      .get("/users/search?q=a")
+      .set("Authorization", `Bearer ${authToken()}`)
+      .expect(400);
+
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("GET /users/search requires authentication", async () => {
+    await request(app).get("/users/search?q=al").expect(401);
+
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("GET /users/search returns an empty array when no usernames match", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const response = await request(app)
+      .get("/users/search?q=zz")
+      .set("Authorization", `Bearer ${authToken()}`)
+      .expect(200);
+
+    expect(response.body).toEqual([]);
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining("username ILIKE $1"), [
+      "zz%",
+      20,
+      0,
+    ]);
+  });
+
+  it("GET /users/search paginates username prefix matches and excludes sensitive fields", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          id: "user-alice",
+          username: "alice",
+          avatar_url: "https://example.com/alice.png",
+          total_earnings: "12.5000000",
+          email: "alice@example.com",
+          phone_hash: "secret",
+          role: "admin",
+        },
+      ],
+    });
+
+    const response = await request(app)
+      .get("/users/search?q=Al&page=2")
+      .set("Authorization", `Bearer ${authToken()}`)
+      .expect(200);
+
+    expect(response.body).toEqual([
+      {
+        id: "user-alice",
+        username: "alice",
+        avatar_url: "https://example.com/alice.png",
+        total_earnings: "12.5000000",
+      },
+    ]);
+    expect(response.body[0].email).toBeUndefined();
+    expect(response.body[0].phone_hash).toBeUndefined();
+    expect(response.body[0].role).toBeUndefined();
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining("ORDER BY username ASC"), [
+      "Al%",
+      20,
+      20,
+    ]);
+  });
+
   it("POST /users/me/phone/send rate limits after 3 sends", async () => {
     mockRedisIncr
       .mockResolvedValueOnce(1)
@@ -276,7 +377,7 @@ describe("users routes integration", () => {
 
   it("POST /users/me/phone/verify approves correct code and marks phone verified", async () => {
     mockRedisGet.mockResolvedValue(null);
-    mockCheckVerificationCode.mockResolvedValue(true);
+    mockVerifyOtpWithBruteForceProtection.mockResolvedValue(undefined);
 
     const response = await request(app)
       .post("/users/me/phone/verify")
@@ -285,15 +386,16 @@ describe("users routes integration", () => {
       .expect(200);
 
     expect(response.body).toEqual({ success: true });
+    expect(mockVerifyOtpWithBruteForceProtection).toHaveBeenCalledWith(phone, "123456");
     expect(mockMarkPhoneVerified).toHaveBeenCalledWith(userId, phoneHash);
     expect(mockRedisSet).toHaveBeenCalledWith(`phone:hash:${phoneHash}`, userId, "EX", 86400 * 365);
-    expect(mockRedisDel).toHaveBeenCalledWith(`phone:verify:${phoneHash}`);
   });
 
   it("POST /users/me/phone/verify rejects invalid code and bumps attempt counter", async () => {
     mockRedisGet.mockResolvedValue(null);
-    mockCheckVerificationCode.mockResolvedValue(false);
-    mockRedisIncr.mockResolvedValue(1);
+    const invalidCode = new Error("Invalid verification code") as Error & { statusCode: number };
+    invalidCode.statusCode = 400;
+    mockVerifyOtpWithBruteForceProtection.mockRejectedValue(invalidCode);
 
     const response = await request(app)
       .post("/users/me/phone/verify")
@@ -302,7 +404,7 @@ describe("users routes integration", () => {
 
     expect(response.status).toBe(400);
     expect(response.body.error).toBe("Invalid verification code");
-    expect(mockRedisIncr).toHaveBeenCalledWith(`phone:verify:${phoneHash}`);
+    expect(mockVerifyOtpWithBruteForceProtection).toHaveBeenCalledWith(phone, "000000");
     expect(mockMarkPhoneVerified).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -150,6 +150,46 @@ router.get("/me/referrals", authenticate, async (req, res) => {
   });
 });
 
+/**
+ * GET /users/search
+ * Authenticated username prefix search for public profile fields.
+ */
+router.get("/search", authenticate, async (req, res) => {
+  const { q, page } = z
+    .object({
+      q: z.string().trim().min(2),
+      page: z.coerce.number().int().min(1).default(1),
+    })
+    .parse(req.query);
+
+  const pageSize = 20;
+  const offset = (page - 1) * pageSize;
+  const result = await query<{
+    id: string;
+    username: string;
+    avatar_url: string | null;
+    total_earnings: string;
+  }>(
+    `SELECT id, username, avatar_url, total_earned_usdc AS total_earnings
+     FROM users
+     WHERE username ILIKE $1
+       AND deleted_at IS NULL
+     ORDER BY username ASC
+     LIMIT $2
+     OFFSET $3`,
+    [`${q}%`, pageSize, offset]
+  );
+
+  res.json(
+    result.rows.map((user) => ({
+      id: user.id,
+      username: user.username,
+      avatar_url: user.avatar_url,
+      total_earnings: user.total_earnings,
+    }))
+  );
+});
+
 router.post("/streaks/repair", authenticate, async (req, res) => {
   const repaired = await repairStreak(req.user!.sub);
   if (!repaired) {
@@ -267,10 +307,7 @@ router.patch("/me/profile", authenticate, async (req, res) => {
   }
 
   // Trigger Next.js cache revalidation so profile pages reflect the new data
-  const revalidatePaths = [
-    `/profile/${oldUsername}`,
-    `/profile/${newUsername}`,
-  ];
+  const revalidatePaths = [`/profile/${oldUsername}`, `/profile/${newUsername}`];
 
   try {
     await fetch(`${config.WEB_URL}/api/revalidate`, {
@@ -387,10 +424,9 @@ router.patch("/me/notifications/:id/read", authenticate, async (req, res) => {
  * Marks all unread notifications as read.
  */
 router.patch("/me/notifications/read-all", authenticate, async (req, res) => {
-  await query(
-    `UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`,
-    [req.user!.sub]
-  );
+  await query(`UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`, [
+    req.user!.sub,
+  ]);
 
   res.json({ success: true });
 });


### PR DESCRIPTION
## What
Adds `GET /users/search` for authenticated username prefix search.

## Why
Issue #471 asks for a protected user-search endpoint so leaderboard/profile UI can find users without exposing private account fields.

## How
- Adds `/users/search?q=&page=` before dynamic user routes.
- Requires auth via `authenticate` to prevent anonymous enumeration.
- Validates `q` as at least 2 chars and `page` as a 1-based integer.
- Uses `username ILIKE 'prefix%'`, `LIMIT 20`, and offset pagination.
- Returns only whitelisted public fields: `id`, `username`, `avatar_url`, `total_earnings`.
- Keeps no-match responses as an empty array.
- Focuses the users route test harness on `/users` so unrelated route parse errors do not block this suite.

## Test plan
- [x] `./node_modules/.bin/vitest run apps/api/src/routes/users.test.ts`
- [x] `./node_modules/.bin/prettier --check apps/api/src/routes/users.ts apps/api/src/routes/users.test.ts`
- [x] `git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml --verbose`
- [ ] `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` currently blocked by existing unrelated `apps/api/src/routes/leaderboard.ts(196,1): error TS1128`

Closes #471