### PR TITLE
 feat(api): add public user profile endpoint

### DIFF
--- a/apps/api/src/routes/users.public.test.ts
+++ b/apps/api/src/routes/users.public.test.ts
@@ -1,0 +1,150 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/error";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  getUserPublicProfileByUsername: vi.fn(),
+  getUserActivity: vi.fn(),
+}));
+
+vi.mock("../db", () => ({
+  query: mocks.query,
+}));
+
+vi.mock("../db/queries/users", () => ({
+  findUserById: vi.fn(),
+  findUserByPhoneHash: vi.fn(),
+  markPhoneVerified: vi.fn(),
+  updateUserWallet: vi.fn(),
+  updateUserProfile: vi.fn(),
+  getUserPublicProfileByUsername: mocks.getUserPublicProfileByUsername,
+}));
+
+vi.mock("../services/referrals", () => ({
+  getReferralStats: vi.fn(),
+  ensureUserReferralCode: vi.fn(),
+}));
+
+vi.mock("../services/streaks", () => ({
+  getStreak: vi.fn(),
+  repairStreak: vi.fn(),
+  getUserActivity: mocks.getUserActivity,
+}));
+
+vi.mock("../services/phone", () => ({
+  sendVerificationCode: vi.fn(),
+  hashPhoneNumber: (value: string) => `hash:${value}`,
+  normalizePhoneNumber: (value: string) => value,
+  verifyOtpWithBruteForceProtection: vi.fn(),
+}));
+
+vi.mock("../middleware/authenticate", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.user = { sub: "user-1", role: "user" };
+    next();
+  },
+}));
+
+vi.mock("../middleware/rate-limit", () => ({
+  apiLimiter: (_req: any, _res: any, next: any) => next(),
+  phoneRateLimit: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../services/badges", () => ({
+  getBadgesForUser: vi.fn(),
+}));
+
+vi.mock("../lib/redis", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+vi.mock("../lib/config", () => ({
+  config: {
+    WEB_URL: "http://localhost:3000",
+    WEBHOOK_SECRET: "test-secret",
+  },
+}));
+
+import usersRouter from "./users";
+
+const app = express();
+app.use(express.json());
+app.use("/users", usersRouter);
+app.use(errorHandler);
+
+const publicProfileRow = {
+  id: "user-1",
+  username: "alice",
+  avatar_url: "https://example.com/avatar.png",
+  joined_at: "2026-01-01T00:00:00.000Z",
+  win_count: 3,
+  total_sessions_played: 10,
+  accuracy_pct: 88.5,
+  league_tier: "gold",
+  league_rank: 2,
+  league_season: "2026-06-22",
+  badges: Array.from({ length: 7 }, (_, index) => ({
+    badge_slug: `badge_${index}`,
+    awarded_at: `2026-06-${28 - index}T00:00:00.000Z`,
+  })),
+  email: "private@example.com",
+  phone: "+15550000000",
+  stellar_account_id: "GPRIVATE",
+  kyc_status: "approved",
+};
+
+describe("GET /users/:username/public", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a public profile without private account fields", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [publicProfileRow] });
+
+    const res = await request(app).get("/users/alice/public").expect(200);
+
+    expect(res.body).toEqual({
+      username: "alice",
+      avatar_url: "https://example.com/avatar.png",
+      joined_at: "2026-01-01T00:00:00.000Z",
+      win_count: 3,
+      total_sessions_played: 10,
+      accuracy_pct: 88.5,
+      league: {
+        tier: "gold",
+        rank: 2,
+        season: "2026-06-22",
+      },
+      badges: publicProfileRow.badges.slice(0, 6),
+    });
+    expect(res.body).not.toHaveProperty("email");
+    expect(res.body).not.toHaveProperty("phone");
+    expect(res.body).not.toHaveProperty("stellar_account_id");
+    expect(res.body).not.toHaveProperty("kyc_status");
+  });
+
+  it("queries only active, non-deleted users by username", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [publicProfileRow] });
+
+    await request(app).get("/users/alice/public").expect(200);
+
+    expect(mocks.query).toHaveBeenCalledWith(expect.stringContaining("AND deleted_at IS NULL"), [
+      "alice",
+    ]);
+    expect(mocks.query.mock.calls[0][0]).toContain("AND status = 'active'");
+  });
+
+  it("returns 404 for deactivated or missing accounts", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app).get("/users/deactivated/public").expect(404);
+
+    expect(res.body).toEqual({ error: "User not found" });
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -224,6 +224,112 @@ router.get("/:username/activity", apiLimiter, async (req, res) => {
 });
 
 /**
+ * GET /users/:username/public
+ * Public read-only profile. Omits private account, wallet, phone, and KYC fields.
+ */
+router.get("/:username/public", apiLimiter, async (req, res) => {
+  const { username } = z.object({ username: z.string().trim().min(1) }).parse(req.params);
+
+  const result = await query<{
+    id: string;
+    username: string;
+    avatar_url: string | null;
+    joined_at: string;
+    win_count: number;
+    total_sessions_played: number;
+    accuracy_pct: number;
+    league_tier: string | null;
+    league_rank: number | null;
+    league_season: string | null;
+    badges: Array<{
+      badge_slug: string;
+      awarded_at: string;
+    }> | null;
+  }>(
+    `WITH public_user AS (
+       SELECT id, username, avatar_url, created_at AS joined_at
+       FROM users
+       WHERE username = $1
+         AND deleted_at IS NULL
+         AND status = 'active'
+       LIMIT 1
+     ),
+     stats AS (
+       SELECT
+         COUNT(*) FILTER (WHERE status = 'completed')::int AS total_sessions_played,
+         COUNT(*) FILTER (WHERE status = 'completed' AND rank = 1)::int AS win_count,
+         COALESCE(
+           ROUND(
+             (
+               SUM(total_score) FILTER (WHERE status = 'completed')::numeric
+               / NULLIF(COUNT(*) FILTER (WHERE status = 'completed') * 450, 0)
+             ) * 100,
+             2
+           ),
+           0
+         )::float AS accuracy_pct
+       FROM game_sessions
+       WHERE user_id = (SELECT id FROM public_user)
+     ),
+     current_league AS (
+       SELECT league, rank_in_group, week_start
+       FROM league_assignments
+       WHERE user_id = (SELECT id FROM public_user)
+       ORDER BY week_start DESC
+       LIMIT 1
+     ),
+     recent_badges AS (
+       SELECT COALESCE(json_agg(b ORDER BY b.awarded_at DESC), '[]'::json) AS badges
+       FROM (
+         SELECT badge_slug, awarded_at
+         FROM user_badges
+         WHERE user_id = (SELECT id FROM public_user)
+         ORDER BY awarded_at DESC
+         LIMIT 6
+       ) b
+     )
+     SELECT
+       pu.id,
+       pu.username,
+       pu.avatar_url,
+       pu.joined_at,
+       COALESCE(s.win_count, 0) AS win_count,
+       COALESCE(s.total_sessions_played, 0) AS total_sessions_played,
+       COALESCE(s.accuracy_pct, 0) AS accuracy_pct,
+       cl.league AS league_tier,
+       cl.rank_in_group AS league_rank,
+       cl.week_start::text AS league_season,
+       rb.badges
+     FROM public_user pu
+     CROSS JOIN stats s
+     LEFT JOIN current_league cl ON TRUE
+     CROSS JOIN recent_badges rb`,
+    [username]
+  );
+
+  const profile = result.rows[0];
+  if (!profile) throw createError("User not found", 404);
+
+  res.json({
+    username: profile.username,
+    avatar_url: profile.avatar_url,
+    joined_at: profile.joined_at,
+    win_count: Number(profile.win_count),
+    total_sessions_played: Number(profile.total_sessions_played),
+    accuracy_pct: Number(profile.accuracy_pct),
+    league: {
+      tier: profile.league_tier,
+      rank: profile.league_rank,
+      season: profile.league_season,
+    },
+    badges: (profile.badges ?? []).slice(0, 6).map((badge) => ({
+      badge_slug: badge.badge_slug,
+      awarded_at: badge.awarded_at,
+    })),
+  });
+});
+
+/**
  * PATCH /users/me/wallet
  */
 router.patch("/me/wallet", authenticate, async (req, res) => {
@@ -267,10 +373,7 @@ router.patch("/me/profile", authenticate, async (req, res) => {
   }
 
   // Trigger Next.js cache revalidation so profile pages reflect the new data
-  const revalidatePaths = [
-    `/profile/${oldUsername}`,
-    `/profile/${newUsername}`,
-  ];
+  const revalidatePaths = [`/profile/${oldUsername}`, `/profile/${newUsername}`];
 
   try {
     await fetch(`${config.WEB_URL}/api/revalidate`, {
@@ -387,10 +490,9 @@ router.patch("/me/notifications/:id/read", authenticate, async (req, res) => {
  * Marks all unread notifications as read.
  */
 router.patch("/me/notifications/read-all", authenticate, async (req, res) => {
-  await query(
-    `UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`,
-    [req.user!.sub]
-  );
+  await query(`UPDATE notifications SET read_at = NOW() WHERE user_id = $1 AND read_at IS NULL`, [
+    req.user!.sub,
+  ]);
 
   res.json({ success: true });
 });


### PR DESCRIPTION
## What
Adds public `GET /users/:username/public` for #455.

## Why
Profile pages need a safe public endpoint that returns player stats, league data, and recent badges without exposing private account data.

## How
- Adds an unauthenticated public profile route under `users.ts`.
- Filters to active, non-deleted users and returns `404` for missing, deactivated, or GDPR-erased accounts.
- Returns `username`, `avatar_url`, `joined_at`, `win_count`, `total_sessions_played`, and `accuracy_pct`.
- Adds latest league data as `{ tier, rank, season }`.
- Adds the 6 most recent awarded badges.
- Manually maps the response to exclude private fields such as email, phone, wallet/KYC data.
- Adds focused Vitest coverage for PII exclusion, active/non-deleted query filters, and 404 behavior.

## Test plan
- [x] `./node_modules/.bin/vitest run apps/api/src/routes/users.public.test.ts`
- [x] `./node_modules/.bin/prettier --check apps/api/src/routes/users.ts apps/api/src/routes/users.public.test.ts`
- [x] `git diff --cached --no-color | node scripts/gitleaks.mjs detect --pipe --redact --config .gitleaks.toml --verbose`
- [ ] `./node_modules/.bin/vitest run apps/api/src/routes/users.test.ts` is currently blocked by existing unrelated full-route mock drift: `@brandblitz/stellar` mock lacks `MIN_POOL_STROOPS` while importing `routes/index.ts`.
- [ ] `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` currently blocked by existing unrelated `apps/api/src/routes/leaderboard.ts(196,1): error TS1128`.

Note: the local Husky hook invokes `pnpm gitleaks:pre-commit`, but pnpm exits first due ignored build-script approvals for `@fingerprintjs/fingerprintjs-pro-react` and `@sentry/cli`. I ran the underlying staged-diff gitleaks command directly and it passed.

Closes #455